### PR TITLE
修复自动发布 wiki

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -4,7 +4,7 @@ name: Publish Wiki
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ wiki ]
+    branches: [ main ]
     paths: [ 'docs/**' ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -19,8 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Upload Documentation to Wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@v1
-        with:
-          path: "docs"
+        run: ./.github/scripts/build.sh
+        shell: bash
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Upload Documentation to Wiki
-        run: ./.github/scripts/build.sh
+        run: ci/wiki.sh
         shell: bash
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -4,7 +4,7 @@ name: Publish Wiki
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ main ]
+    branches: [ wiki ]
     paths: [ 'docs/**' ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function debug() {
+    echo "::debug file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
+}
+
+function warning() {
+    echo "::warning file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
+}
+
+function error() {
+    echo "::error file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
+}
+
+function add_mask() {
+    echo "::add-mask::$1"
+}
+
+if [ -z "$GITHUB_ACTOR" ]; then
+    error "GITHUB_ACTOR environment variable is not set"
+    exit 1
+fi
+
+if [ -z "$GITHUB_REPOSITORY" ]; then
+    error "GITHUB_REPOSITORY environment variable is not set"
+    exit 1
+fi
+
+if [ -z "$GH_PERSONAL_ACCESS_TOKEN" ]; then
+    error "GH_PERSONAL_ACCESS_TOKEN environment variable is not set"
+    exit 1
+fi
+
+add_mask "${GH_PERSONAL_ACCESS_TOKEN}"
+
+if [ -z "${WIKI_COMMIT_MESSAGE:-}" ]; then
+    debug "WIKI_COMMIT_MESSAGE not set, using default"
+    WIKI_COMMIT_MESSAGE='Automatically publish wiki'
+fi
+
+GIT_REPOSITORY_URL="https://${GH_PERSONAL_ACCESS_TOKEN}@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY.wiki.git"
+
+debug "Checking out wiki repository"
+tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
+(
+    cd "$tmp_dir" || exit 1
+    git init
+    git config user.name "$GITHUB_ACTOR"
+    git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    git pull "$GIT_REPOSITORY_URL"
+) || exit 1
+
+debug "Enumerating contents of $1"
+for file in $(find $1 -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
+    debug "Copying $file"
+    cp "$1/$file" "$tmp_dir"
+done
+
+debug "Committing and pushing changes"
+(
+    cd "$tmp_dir" || exit 1
+    git add .
+    git commit -m "$WIKI_COMMIT_MESSAGE"
+    git push --set-upstream "$GIT_REPOSITORY_URL" master
+) || exit 1
+
+rm -rf "$tmp_dir"
+exit 0

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -52,8 +52,7 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
     git pull "$GIT_REPOSITORY_URL"
 ) || exit 1
 
-debug "Enumerating contents of $1"
-for file in $(find $1 -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
+for file in $(find docs -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
     debug "Copying $file"
     cp "$1/$file" "$tmp_dir"
 done

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -57,6 +57,11 @@ for file in $(find docs -maxdepth 1 -type f -name '*.md' -execdir basename '{}' 
     cp "docs/$file" "$tmp_dir"
 done
 
+for file in docs/*.md; do
+    cp "$file" "$tmp_dir"
+done
+
+
 debug "Committing and pushing changes"
 (
     cd "$tmp_dir" || exit 1

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -52,17 +52,10 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
     git pull "$GIT_REPOSITORY_URL"
 ) || exit 1
 
-for file in $(find docs -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
-    debug "Copying $file"
-    cp "docs/$file" "$tmp_dir"
-done
-
 for file in docs/*.md; do
     cp "$file" "$tmp_dir"
 done
 
-
-debug "Committing and pushing changes"
 (
     cd "$tmp_dir" || exit 1
     git add .

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -1,7 +1,3 @@
-#!/bin/bash
-
-set -euo pipefail
-
 function debug() {
     echo "::debug file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
 }

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -54,7 +54,7 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 
 for file in $(find docs -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
     debug "Copying $file"
-    cp "$1/$file" "$tmp_dir"
+    cp "docs/$file" "$tmp_dir"
 done
 
 debug "Committing and pushing changes"

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -24,7 +24,7 @@ done
 (
     cd "$tmp_dir" || exit 1
     git add .
-    git commit -m "Automatically publish wiki"
+    git commit -m "Published by CI"
     git push --set-upstream "$GIT_REPOSITORY_URL" master
 ) || exit 1
 

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
 function debug() {
     echo "::debug file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
 }

--- a/ci/wiki.sh
+++ b/ci/wiki.sh
@@ -2,47 +2,12 @@
 
 set -euo pipefail
 
-function debug() {
-    echo "::debug file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
-}
-
-function warning() {
-    echo "::warning file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
-}
-
-function error() {
-    echo "::error file=${BASH_SOURCE[0]},line=${BASH_LINENO[0]}::$1"
-}
-
-function add_mask() {
-    echo "::add-mask::$1"
-}
-
-if [ -z "$GITHUB_ACTOR" ]; then
-    error "GITHUB_ACTOR environment variable is not set"
-    exit 1
-fi
-
-if [ -z "$GITHUB_REPOSITORY" ]; then
-    error "GITHUB_REPOSITORY environment variable is not set"
-    exit 1
-fi
-
 if [ -z "$GH_PERSONAL_ACCESS_TOKEN" ]; then
-    error "GH_PERSONAL_ACCESS_TOKEN environment variable is not set"
     exit 1
-fi
-
-add_mask "${GH_PERSONAL_ACCESS_TOKEN}"
-
-if [ -z "${WIKI_COMMIT_MESSAGE:-}" ]; then
-    debug "WIKI_COMMIT_MESSAGE not set, using default"
-    WIKI_COMMIT_MESSAGE='Automatically publish wiki'
 fi
 
 GIT_REPOSITORY_URL="https://${GH_PERSONAL_ACCESS_TOKEN}@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY.wiki.git"
 
-debug "Checking out wiki repository"
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 (
     cd "$tmp_dir" || exit 1
@@ -59,7 +24,7 @@ done
 (
     cd "$tmp_dir" || exit 1
     git add .
-    git commit -m "$WIKI_COMMIT_MESSAGE"
+    git commit -m "Automatically publish wiki"
     git push --set-upstream "$GIT_REPOSITORY_URL" master
 ) || exit 1
 

--- a/docs/Built-in effects.md
+++ b/docs/Built-in effects.md
@@ -1,6 +1,6 @@
 Magpie ships with a handful of effect that an be used in combinations. Most of the effects have parameters that can be customized. All effects are stored in the `effects` folder. You can easily add effects if you are familiar with HLSL. Check the [MagpieFX](https://github.com/Blinue/Magpie/wiki/MagpieFX%20(EN)) page.
 
-## Introduction to shipped effects1
+## Introduction to shipped effects
 
 * ACNet: Port of [ACNetGLSL](https://github.com/TianZerL/ACNetGLSL). Suitable for anime-style images. Strong denoise effects.
   * Output size: twice that of the input

--- a/docs/Built-in effects.md
+++ b/docs/Built-in effects.md
@@ -1,6 +1,6 @@
 Magpie ships with a handful of effect that an be used in combinations. Most of the effects have parameters that can be customized. All effects are stored in the `effects` folder. You can easily add effects if you are familiar with HLSL. Check the [MagpieFX](https://github.com/Blinue/Magpie/wiki/MagpieFX%20(EN)) page.
 
-## Introduction to shipped effects
+## Introduction to shipped effects1
 
 * ACNet: Port of [ACNetGLSL](https://github.com/TianZerL/ACNetGLSL). Suitable for anime-style images. Strong denoise effects.
   * Output size: twice that of the input


### PR DESCRIPTION
SwiftDocOrg/github-wiki-publish-action 无法处理文件名中的空格，这个 pr 拷贝了它的代码并修复这个错误。