### PR TITLE
移除 NotoSansSC-Regular.otf

### DIFF
--- a/src/Magpie.Core/Magpie.Core.vcxproj
+++ b/src/Magpie.Core/Magpie.Core.vcxproj
@@ -140,12 +140,6 @@
     <ClCompile Include="WindowHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="NotoSansSC-Regular.otf">
-      <FileType>Document</FileType>
-      <DestinationFolders>$(OutDir)assets</DestinationFolders>
-    </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="Magpie.Core.rc" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Magpie.Core/Magpie.Core.vcxproj.filters
+++ b/src/Magpie.Core/Magpie.Core.vcxproj.filters
@@ -138,11 +138,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="NotoSansSC-Regular.otf">
-      <Filter>资源文件</Filter>
-    </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="Magpie.Core.rc">
       <Filter>资源文件</Filter>
     </ResourceCompile>

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -532,7 +532,7 @@ void OverlayDrawer::_DrawTimelineItem(ImU32 color, float dpiScale, std::string_v
 	float textWidth = ImGui::CalcTextSize(text.c_str()).x;
 	float itemWidth = ImGui::GetItemRectSize().x;
 	float itemSpacing = ImGui::GetStyle().ItemSpacing.x;
-	if (itemWidth - (selected ? 0 : itemSpacing) > textWidth + 4) {
+	if (itemWidth - (selected ? 0 : itemSpacing) > textWidth + 4 * _dpiScale) {
 		ImGui::SameLine(0, 0);
 		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (itemWidth - textWidth - itemSpacing) / 2);
 		ImGui::TextUnformatted(text.c_str());
@@ -860,7 +860,7 @@ void OverlayDrawer::_DrawUI() noexcept {
 			MyPlotLines([](void* data, int idx) {
 				return (*(std::deque<float>*)data)[idx];
 			}, &_frameTimes, (int)_frameTimes.size(), 0,
-				fmt::format("avg: {:.3f} ms", totalTime / _validFrames).c_str(),
+				fmt::format("avg: {:.1f} ms", totalTime / _validFrames).c_str(),
 				0, maxTime2 * 1.7f, ImVec2(250 * _dpiScale, 80 * _dpiScale));
 		}
 

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -20,7 +20,7 @@
 
 namespace Magpie::Core {
 
-OverlayDrawer::OverlayDrawer() {
+OverlayDrawer::OverlayDrawer() noexcept {
 	HWND hwndSrc = MagApp::Get().GetHwndSrc();
 	_isSrcMainWnd = Win32Utils::GetWndClassName(hwndSrc) == CommonSharedConstants::MAIN_WINDOW_CLASS_NAME;
 }
@@ -183,7 +183,7 @@ static std::wstring GetSystemFontsFolder() noexcept {
 	return result;
 }
 
-bool OverlayDrawer::Initialize() {
+bool OverlayDrawer::Initialize() noexcept {
 	_imguiImpl.reset(new ImGuiImpl());
 	if (!_imguiImpl->Initialize()) {
 		Logger::Get().Error("初始化 ImGuiImpl 失败");
@@ -211,7 +211,7 @@ bool OverlayDrawer::Initialize() {
 	return true;
 }
 
-void OverlayDrawer::Draw() {
+void OverlayDrawer::Draw() noexcept {
 	bool isShowFPS = MagApp::Get().GetOptions().IsShowFPS();
 
 	if (!_isUIVisiable && !isShowFPS) {
@@ -234,7 +234,7 @@ void OverlayDrawer::Draw() {
 	_imguiImpl->EndFrame();
 }
 
-void OverlayDrawer::SetUIVisibility(bool value) {
+void OverlayDrawer::SetUIVisibility(bool value) noexcept {
 	if (_isUIVisiable == value) {
 		return;
 	}
@@ -541,7 +541,7 @@ void OverlayDrawer::_DrawTimelineItem(ImU32 color, float dpiScale, std::string_v
 	ImGui::PopFont();
 }
 
-void OverlayDrawer::_DrawFPS() {
+void OverlayDrawer::_DrawFPS() noexcept {
 	static float oldOpacity = 0.0f;
 	static float opacity = 0.0f;
 	static bool isLocked = false;
@@ -763,7 +763,7 @@ static void MyPlotLines(float(*values_getter)(void* data, int idx), void* data, 
 	ImGuiImpl::Tooltip(fmt::format("{:.1f}", v0).c_str());
 }
 
-void OverlayDrawer::_DrawUI() {
+void OverlayDrawer::_DrawUI() noexcept {
 	auto& settings = MagApp::Get().GetOptions();
 	auto& renderer = MagApp::Get().GetRenderer();
 	auto& gpuTimer = renderer.GetGPUTimer();
@@ -1112,7 +1112,7 @@ void OverlayDrawer::_DrawUI() {
 	ImGui::End();
 }
 
-void OverlayDrawer::_RetrieveHardwareInfo() {
+void OverlayDrawer::_RetrieveHardwareInfo() noexcept {
 	DXGI_ADAPTER_DESC desc{};
 	HRESULT hr = MagApp::Get().GetDeviceResources().GetGraphicsAdapter()->GetDesc(&desc);
 	_hardwareInfo.gpuName = SUCCEEDED(hr) ? StrUtils::UTF16ToUTF8(desc.Description) : "UNAVAILABLE";
@@ -1121,7 +1121,7 @@ void OverlayDrawer::_RetrieveHardwareInfo() {
 	_hardwareInfo.cpuName = !cpuName.empty() ? std::move(cpuName) : "UNAVAILABLE";
 }
 
-void OverlayDrawer::_EnableSrcWnd(bool enable) {
+void OverlayDrawer::_EnableSrcWnd(bool enable) noexcept {
 	HWND hwndSrc = MagApp::Get().GetHwndSrc();
 	if (!_isSrcMainWnd) {
 		// 如果源窗口是 Magpie 主窗口会卡死

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -507,8 +507,6 @@ int OverlayDrawer::_DrawEffectTimings(
 }
 
 void OverlayDrawer::_DrawTimelineItem(ImU32 color, float dpiScale, std::string_view name, float time, float effectsTotalTime, bool selected) {
-	ImGui::PushFont(_fontMonoNumbers);
-
 	ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, color);
 	ImGui::PushStyleColor(ImGuiCol_HeaderActive, color);
 	ImGui::PushStyleColor(ImGuiCol_HeaderHovered, color);
@@ -518,7 +516,9 @@ void OverlayDrawer::_DrawTimelineItem(ImU32 color, float dpiScale, std::string_v
 
 	if (ImGui::IsItemHovered() || ImGui::IsItemClicked()) {
 		std::string content = fmt::format("{}\n{:.3f} ms\n{}%", name, time, std::lroundf(time / effectsTotalTime * 100));
+		ImGui::PushFont(_fontMonoNumbers);
 		ImGuiImpl::Tooltip(content.c_str(), 500 * dpiScale);
+		ImGui::PopFont();
 	}
 
 	// 空间足够时显示文字
@@ -537,8 +537,6 @@ void OverlayDrawer::_DrawTimelineItem(ImU32 color, float dpiScale, std::string_v
 		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (itemWidth - textWidth - itemSpacing) / 2);
 		ImGui::TextUnformatted(text.c_str());
 	}
-
-	ImGui::PopFont();
 }
 
 void OverlayDrawer::_DrawFPS() noexcept {

--- a/src/Magpie.Core/OverlayDrawer.h
+++ b/src/Magpie.Core/OverlayDrawer.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <deque>
 #include "SmallVector.h"
-
-struct ImFont;
+#include <imgui.h>
 
 namespace Magpie::Core {
 
+struct EffectDesc;
 class ImGuiImpl;
 
 class OverlayDrawer {
@@ -29,6 +29,16 @@ public:
 private:
 	bool _BuildFonts() noexcept;
 
+	struct _EffectTimings {
+		const EffectDesc* desc = nullptr;
+		std::span<const float> passTimings;
+		float totalTime = 0.0f;
+	};
+
+	int _DrawEffectTimings(const _EffectTimings& et, bool showPasses, float maxWindowWidth, std::span<const ImColor> colors, bool singleEffect) noexcept;
+
+	void _DrawTimelineItem(ImU32 color, float dpiScale, std::string_view name, float time, float effectsTotalTime, bool selected = false);
+
 	void _DrawFPS();
 
 	void _DrawUI();
@@ -39,8 +49,9 @@ private:
 
 	float _dpiScale = 1.0f;
 
-	ImFont* _fontUI = nullptr;
-	ImFont* _fontFPS = nullptr;
+	ImFont* _fontUI = nullptr;	// 普通 UI 文字
+	ImFont* _fontMonoNumbers = nullptr;	// 普通 UI 文字，但数字部分是等宽的
+	ImFont* _fontFPS = nullptr;	// FPS
 
 	std::deque<float> _frameTimes;
 	UINT _validFrames = 0;

--- a/src/Magpie.Core/OverlayDrawer.h
+++ b/src/Magpie.Core/OverlayDrawer.h
@@ -10,21 +10,21 @@ class ImGuiImpl;
 
 class OverlayDrawer {
 public:
-	OverlayDrawer();
+	OverlayDrawer() noexcept;
 	OverlayDrawer(const OverlayDrawer&) = delete;
 	OverlayDrawer(OverlayDrawer&&) = delete;
 
 	~OverlayDrawer();
 
-	bool Initialize();
+	bool Initialize() noexcept;
 
-	void Draw();
+	void Draw() noexcept;
 
 	bool IsUIVisiable() const noexcept {
 		return _isUIVisiable;
 	}
 
-	void SetUIVisibility(bool value);
+	void SetUIVisibility(bool value) noexcept;
 
 private:
 	bool _BuildFonts() noexcept;
@@ -39,18 +39,18 @@ private:
 
 	void _DrawTimelineItem(ImU32 color, float dpiScale, std::string_view name, float time, float effectsTotalTime, bool selected = false);
 
-	void _DrawFPS();
+	void _DrawFPS() noexcept;
 
-	void _DrawUI();
+	void _DrawUI() noexcept;
 
-	void _RetrieveHardwareInfo();
+	void _RetrieveHardwareInfo() noexcept;
 
-	void _EnableSrcWnd(bool enable);
+	void _EnableSrcWnd(bool enable) noexcept;
 
 	float _dpiScale = 1.0f;
 
 	ImFont* _fontUI = nullptr;	// 普通 UI 文字
-	ImFont* _fontMonoNumbers = nullptr;	// 普通 UI 文字，但数字部分是等宽的
+	ImFont* _fontMonoNumbers = nullptr;	// 普通 UI 文字，但数字部分是等宽的，只支持 ASCII
 	ImFont* _fontFPS = nullptr;	// FPS
 
 	std::deque<float> _frameTimes;

--- a/src/Magpie.Core/OverlayDrawer.h
+++ b/src/Magpie.Core/OverlayDrawer.h
@@ -27,6 +27,8 @@ public:
 	void SetUIVisibility(bool value);
 
 private:
+	bool _BuildFonts() noexcept;
+
 	void _DrawFPS();
 
 	void _DrawUI();

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -36,8 +36,8 @@ bool Renderer::Initialize() {
 	if (MagApp::Get().GetOptions().IsShowFPS()) {
 		_overlayDrawer.reset(new OverlayDrawer());
 		if (!_overlayDrawer->Initialize()) {
+			_overlayDrawer.reset();
 			Logger::Get().Error("初始化 OverlayDrawer 失败");
-			return false;
 		}
 	}
 
@@ -167,6 +167,7 @@ void Renderer::SetUIVisibility(bool value) {
 	if (!_overlayDrawer) {
 		_overlayDrawer.reset(new OverlayDrawer());
 		if (!_overlayDrawer->Initialize()) {
+			_overlayDrawer.reset();
 			Logger::Get().Error("初始化 OverlayDrawer 失败");
 			return;
 		}


### PR DESCRIPTION
移除这个字体文件可使软件体积减小 20%，改为使用 Segoe UI 族（Win10 为 Segoe UI，Win11 为 Segoe UI Variable）。Segoe UI 的数字字符不是等宽的，为了提升观感，构造字体时应对数字特殊处理。

效果：
<img width="280" alt="屏幕截图(47)" src="https://github.com/Blinue/Magpie/assets/34770031/e9612690-4e1b-416c-afbe-d1cf5dd8c9e2">

现在需要三种字体：
1. 用于绘制 UI 的 Segoe UI，对于简/繁中文和日语需要加载额外的字体（这将在下一个 PR 中和本地化一起实现）
2. 用于绘制 UI 中数字的字体，以 Segoe UI 为蓝本，数字字符是等宽的
3. 用于绘制 FPS 的字体，它的数字也应是等宽的