### PR TITLE
fix: 根据显示语言选择字体

### DIFF
--- a/src/Magpie.App/ContentDialogHelper.cpp
+++ b/src/Magpie.App/ContentDialogHelper.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "ContentDialogHelper.h"
+#include "App.h"
 
 using namespace winrt;
 using namespace Windows::UI::Xaml::Controls;
@@ -10,6 +11,10 @@ static weak_ref<ContentDialog> activeDialog;
 
 IAsyncOperation<ContentDialogResult> ContentDialogHelper::ShowAsync(ContentDialog dialog) {
 	assert(activeDialog == nullptr);
+
+	// 设置 Language 属性帮助 XAML 选择合适的字体
+	MainPage mainPage = Application::Current().as<App>().MainPage();
+	dialog.Content().as<FrameworkElement>().Language(mainPage.Language());
 
 	activeDialog = dialog;
 	ContentDialogResult result = co_await dialog.ShowAsync();

--- a/src/Magpie.App/LocalizationService.cpp
+++ b/src/Magpie.App/LocalizationService.cpp
@@ -51,7 +51,7 @@ void LocalizationService::EarlyInitialize() {
 		}
 	}
 
-	ResourceContext::SetGlobalQualifierValue(L"Language", bestLanguage);
+	_Language(bestLanguage);
 }
 
 void LocalizationService::Initialize() {
@@ -59,12 +59,17 @@ void LocalizationService::Initialize() {
 
 	int language = settings.Language();
 	if (language >= 0) {
-		ResourceContext::SetGlobalQualifierValue(L"Language", SUPPORTED_LANGUAGES[language]);
+		_Language(SUPPORTED_LANGUAGES[language]);
 	}
 }
 
 std::span<const wchar_t*> LocalizationService::SupportedLanguages() noexcept {
 	return SUPPORTED_LANGUAGES;
+}
+
+void LocalizationService::_Language(const wchar_t* tag) {
+	_language = tag;
+	ResourceContext::SetGlobalQualifierValue(L"Language", tag);
 }
 
 }

--- a/src/Magpie.App/LocalizationService.h
+++ b/src/Magpie.App/LocalizationService.h
@@ -21,8 +21,16 @@ public:
 	// 支持的所有语言的标签，均为小写
 	static std::span<const wchar_t* > SupportedLanguages() noexcept;
 
+	const wchar_t* Language() const noexcept {
+		return _language;
+	}
+
 private:
 	LocalizationService() = default;
+
+	void _Language(const wchar_t* tag);
+
+	const wchar_t* _language = nullptr;
 };
 
 }

--- a/src/Magpie.App/MainPage.cpp
+++ b/src/Magpie.App/MainPage.cpp
@@ -15,6 +15,7 @@
 #include "ComboBoxHelper.h"
 #include "CommonSharedConstants.h"
 #include "ContentDialogHelper.h"
+#include "LocalizationService.h"
 
 using namespace winrt;
 using namespace Windows::Graphics::Display;
@@ -48,6 +49,9 @@ MainPage::MainPage() {
 		auto_revoke, { this, &MainPage::_ProfileService_ProfileRemoved });
 	_profileMovedRevoker = profileService.ProfileMoved(
 		auto_revoke, { this, &MainPage::_ProfileService_ProfileReordered });
+
+	// 设置 Language 属性帮助 XAML 选择合适的字体，比如繁体中文使用 Microsoft JhengHei UI，日语使用 Yu Gothic UI
+	Language(LocalizationService::Get().Language());
 }
 
 MainPage::~MainPage() {

--- a/src/Magpie.App/ShortcutControl.cpp
+++ b/src/Magpie.App/ShortcutControl.cpp
@@ -70,24 +70,24 @@ fire_and_forget ShortcutControl::EditButton_Click(IInspectable const&, RoutedEve
 		co_return;
 	}
 
-	if (!_ShortcutDialog) {
+	if (!_shortcutDialog) {
 		// 惰性初始化
-		_ShortcutDialog = ContentDialog();
+		_shortcutDialog = ContentDialog();
 		_ShortcutDialogContent = ShortcutDialog();
 
-		_ShortcutDialog.Title(GetValue(TitleProperty));
-		_ShortcutDialog.Content(_ShortcutDialogContent);
+		_shortcutDialog.Title(GetValue(TitleProperty));
+		_shortcutDialog.Content(_ShortcutDialogContent);
 		ResourceLoader resourceLoader = ResourceLoader::GetForCurrentView();
-		_ShortcutDialog.PrimaryButtonText(resourceLoader.GetString(L"ShortcutDialog_Save"));
-		_ShortcutDialog.CloseButtonText(resourceLoader.GetString(L"ShortcutDialog_Cancel"));
-		_ShortcutDialog.DefaultButton(ContentDialogButton::Primary);
+		_shortcutDialog.PrimaryButtonText(resourceLoader.GetString(L"ShortcutDialog_Save"));
+		_shortcutDialog.CloseButtonText(resourceLoader.GetString(L"ShortcutDialog_Cancel"));
+		_shortcutDialog.DefaultButton(ContentDialogButton::Primary);
 		// 在 Closing 事件中设置热键而不是等待 ShowAsync 返回
 		// 这两个时间点有一定间隔，用户在这段时间内的按键不应处理
-		_ShortcutDialog.Closing({ this, &ShortcutControl::_ShortcutDialog_Closing });
+		_shortcutDialog.Closing({ this, &ShortcutControl::_ShortcutDialog_Closing });
 	}
 
-	_ShortcutDialog.XamlRoot(XamlRoot());
-	_ShortcutDialog.RequestedTheme(ActualTheme());
+	_shortcutDialog.XamlRoot(XamlRoot());
+	_shortcutDialog.RequestedTheme(ActualTheme());
 
 	_that = this;
 	// 防止钩子冲突
@@ -103,11 +103,11 @@ fire_and_forget ShortcutControl::EditButton_Click(IInspectable const&, RoutedEve
 	ShortcutError error = _isError ? ShortcutHelper::CheckShortcut(_previewShortcut) : ShortcutError::NoError;
 	_ShortcutDialogContent.Keys(ToKeys(_previewShortcut, error != ShortcutError::NoError));
 	_ShortcutDialogContent.Error(error);
-	_ShortcutDialog.IsPrimaryButtonEnabled(error == ShortcutError::NoError);
+	_shortcutDialog.IsPrimaryButtonEnabled(error == ShortcutError::NoError);
 	
 	_pressedKeys.Clear();
 
-	co_await ContentDialogHelper::ShowAsync(_ShortcutDialog);
+	co_await ContentDialogHelper::ShowAsync(_shortcutDialog);
 }
 
 void ShortcutControl::_ShortcutDialog_Closing(ContentDialog const&, ContentDialogClosingEventArgs const& args) {
@@ -219,7 +219,7 @@ LRESULT ShortcutControl::_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM 
 
 		_that->_ShortcutDialogContent.Keys(ToKeys(previewShortcut, error != ShortcutError::NoError));
 		_that->_ShortcutDialogContent.Error(error);
-		_that->_ShortcutDialog.IsPrimaryButtonEnabled(isPrimaryButtonEnabled);
+		_that->_shortcutDialog.IsPrimaryButtonEnabled(isPrimaryButtonEnabled);
 	}
 
 	return -1;
@@ -232,8 +232,8 @@ void ShortcutControl::_OnActionChanged(DependencyObject const& sender, Dependenc
 
 void ShortcutControl::_OnTitleChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args) {
 	ShortcutControl* that = get_self<ShortcutControl>(sender.as<default_interface<ShortcutControl>>());
-	if (that->_ShortcutDialog) {
-		that->_ShortcutDialog.Title(args.NewValue());
+	if (that->_shortcutDialog) {
+		that->_shortcutDialog.Title(args.NewValue());
 	}
 }
 

--- a/src/Magpie.App/ShortcutControl.h
+++ b/src/Magpie.App/ShortcutControl.h
@@ -50,7 +50,7 @@ private:
 	WinRTUtils::EventRevoker _shortcutChangedRevoker;
 
 	Shortcut _shortcut;
-	Controls::ContentDialog _ShortcutDialog{ nullptr };
+	Controls::ContentDialog _shortcutDialog{ nullptr };
 	Magpie::App::ShortcutDialog _ShortcutDialogContent{ nullptr };
 
 	HHOOK _keyboardHook = NULL;

--- a/src/Magpie.App/ShortcutControl.xaml
+++ b/src/Magpie.App/ShortcutControl.xaml
@@ -58,7 +58,7 @@
 						</DataTemplate>
 					</ItemsControl.ItemTemplate>
 				</ItemsControl>
-				<FontIcon FontSize="14"
+				<FontIcon FontSize="16"
 				          Glyph="&#xE70F;" />
 			</StackPanel>
 		</Button>


### PR DESCRIPTION
修复 https://github.com/Blinue/Magpie/pull/592#issuecomment-1539559818 发现的错误。

控件根据 Language 属性选择合适的字体，但我没找到这个机制的文档。这是摇摇欲坠的 XAML Islands 的又一个补丁。

对比：[日语](https://imgsli.com/MTc3NTI3) [繁体中文](https://imgsli.com/MTc3NTI4)