### PR TITLE
允许缩放最大化或全屏的窗口

### DIFF
--- a/src/Magpie.App/AppSettings.cpp
+++ b/src/Magpie.App/AppSettings.cpp
@@ -502,6 +502,8 @@ bool AppSettings::_Save(const _AppSettingsData& data) noexcept {
 	writer.Bool(data._isSaveEffectSources);
 	writer.Key("warningsAreErrors");
 	writer.Bool(data._isWarningsAreErrors);
+	writer.Key("allowScalingMaximized");
+	writer.Bool(data._isAllowScalingMaximized);
 	writer.Key("simulateExclusiveFullscreen");
 	writer.Bool(data._isSimulateExclusiveFullscreen);
 	writer.Key("alwaysRunAsAdmin");
@@ -641,6 +643,7 @@ void AppSettings::_LoadSettings(const rapidjson::GenericObject<true, rapidjson::
 	JsonHelper::ReadBool(root, "disableFontCache", _isDisableFontCache);
 	JsonHelper::ReadBool(root, "saveEffectSources", _isSaveEffectSources);
 	JsonHelper::ReadBool(root, "warningsAreErrors", _isWarningsAreErrors);
+	JsonHelper::ReadBool(root, "allowScalingMaximized", _isAllowScalingMaximized);
 	JsonHelper::ReadBool(root, "simulateExclusiveFullscreen", _isSimulateExclusiveFullscreen);
 	if (!JsonHelper::ReadBool(root, "alwaysRunAsAdmin", _isAlwaysRunAsAdmin, true)) {
 		// v0.10.0-preview1 使用 alwaysRunAsElevated

--- a/src/Magpie.App/AppSettings.h
+++ b/src/Magpie.App/AppSettings.h
@@ -53,6 +53,7 @@ struct _AppSettingsData {
 	bool _isDisableFontCache = false;
 	bool _isSaveEffectSources = false;
 	bool _isWarningsAreErrors = false;
+	bool _isAllowScalingMaximized = false;
 	bool _isSimulateExclusiveFullscreen = false;
 	bool _isInlineParams = false;
 	bool _isShowTrayIcon = true;
@@ -226,6 +227,15 @@ public:
 
 	void IsWarningsAreErrors(bool value) noexcept {
 		_isWarningsAreErrors = value;
+		SaveAsync();
+	}
+
+	bool IsAllowScalingMaximized() const noexcept {
+		return _isAllowScalingMaximized;
+	}
+
+	void IsAllowScalingMaximized(bool value) noexcept {
+		_isAllowScalingMaximized = value;
 		SaveAsync();
 	}
 

--- a/src/Magpie.App/MagService.cpp
+++ b/src/Magpie.App/MagService.cpp
@@ -331,7 +331,16 @@ void MagService::_ScaleForegroundWindow() {
 }
 
 bool MagService::_CheckSrcWnd(HWND hWnd) noexcept {
-	return hWnd && IsWindow(hWnd) && Win32Utils::GetWindowShowCmd(hWnd) == SW_NORMAL;
+	if (!hWnd || !IsWindow(hWnd)) {
+		return false;
+	}
+
+	UINT showCmd = Win32Utils::GetWindowShowCmd(hWnd);
+	if (showCmd == SW_NORMAL) {
+		return true;
+	}
+
+	return showCmd == SW_MAXIMIZE && AppSettings::Get().IsAllowScalingMaximized();
 }
 
 }

--- a/src/Magpie.App/MagService.cpp
+++ b/src/Magpie.App/MagService.cpp
@@ -312,6 +312,7 @@ bool MagService::_StartScale(HWND hWnd, const Profile& profile) {
 	options.IsDisableFontCache(settings.IsDisableFontCache());
 	options.IsSaveEffectSources(settings.IsSaveEffectSources());
 	options.IsWarningsAreErrors(settings.IsWarningsAreErrors());
+	options.IsAllowScalingMaximized(settings.IsAllowScalingMaximized());
 	options.IsSimulateExclusiveFullscreen(settings.IsSimulateExclusiveFullscreen());
 
 	_isAutoScaling = profile.isAutoScale;

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -824,6 +824,6 @@
     <value>Disable font cache</value>
   </data>
   <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
-    <value>Allow scaling maximized or borderless full-screen windows</value>
+    <value>Allow scaling maximized or full-screen windows</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -823,4 +823,7 @@
   <data name="Settings_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
     <value>Disable font cache</value>
   </data>
+  <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
+    <value>Allow scaling maximized or borderless full-screen windows</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -824,6 +824,6 @@
     <value>禁用字体缓存</value>
   </data>
   <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
-    <value>允许缩放最大化或无边框全屏的窗口</value>
+    <value>允许缩放最大化或全屏的窗口</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -823,4 +823,7 @@
   <data name="Settings_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
     <value>禁用字体缓存</value>
   </data>
+  <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
+    <value>允许缩放最大化或无边框全屏的窗口</value>
+  </data>
 </root>

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -116,7 +116,7 @@
 			<local:SettingsGroup x:Uid="Settings_Advanced">
 				<local:SettingsCard x:Uid="Settings_Advanced_AllowScalingMaximized">
 					<local:SettingsCard.Icon>
-						<FontIcon Glyph="&#xF5A2;" />
+						<FontIcon Glyph="&#xE740;" />
 					</local:SettingsCard.Icon>
 					<local:SettingsCard.ActionContent>
 						<ToggleSwitch x:Uid="ToggleSwitch"

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -119,7 +119,8 @@
 						<FontIcon Glyph="&#xF5A2;" />
 					</local:SettingsCard.Icon>
 					<local:SettingsCard.ActionContent>
-						<ToggleSwitch x:Uid="ToggleSwitch" />
+						<ToggleSwitch x:Uid="ToggleSwitch"
+						              IsOn="{x:Bind ViewModel.IsAllowScalingMaximized, Mode=TwoWay}" />
 					</local:SettingsCard.ActionContent>
 				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Settings_Advanced_SimulateExclusiveFullscreen">

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -114,6 +114,14 @@
 				</local:SettingsCard>
 			</local:SettingsGroup>
 			<local:SettingsGroup x:Uid="Settings_Advanced">
+				<local:SettingsCard x:Uid="Settings_Advanced_AllowScalingMaximized">
+					<local:SettingsCard.Icon>
+						<FontIcon Glyph="&#xF5A2;" />
+					</local:SettingsCard.Icon>
+					<local:SettingsCard.ActionContent>
+						<ToggleSwitch x:Uid="ToggleSwitch" />
+					</local:SettingsCard.ActionContent>
+				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Settings_Advanced_SimulateExclusiveFullscreen">
 					<local:SettingsCard.Icon>
 						<FontIcon Glyph="&#xec46;" />

--- a/src/Magpie.App/SettingsViewModel.cpp
+++ b/src/Magpie.App/SettingsViewModel.cpp
@@ -169,6 +169,14 @@ void SettingsViewModel::IsAlwaysRunAsAdmin(bool value) noexcept {
 	AppSettings::Get().IsAlwaysRunAsAdmin(value);
 }
 
+bool SettingsViewModel::IsAllowScalingMaximized() const noexcept {
+	return AppSettings::Get().IsAllowScalingMaximized();
+}
+
+void SettingsViewModel::IsAllowScalingMaximized(bool value) noexcept {
+	AppSettings::Get().IsAllowScalingMaximized(value);
+}
+
 bool SettingsViewModel::IsSimulateExclusiveFullscreen() const noexcept {
 	return AppSettings::Get().IsSimulateExclusiveFullscreen();
 }

--- a/src/Magpie.App/SettingsViewModel.cpp
+++ b/src/Magpie.App/SettingsViewModel.cpp
@@ -8,6 +8,7 @@
 #include "Win32Utils.h"
 #include "CommonSharedConstants.h"
 #include "LocalizationService.h"
+#include "MagService.h"
 
 namespace winrt::Magpie::App::implementation {
 
@@ -175,6 +176,10 @@ bool SettingsViewModel::IsAllowScalingMaximized() const noexcept {
 
 void SettingsViewModel::IsAllowScalingMaximized(bool value) noexcept {
 	AppSettings::Get().IsAllowScalingMaximized(value);
+
+	if (value) {
+		MagService::Get().CheckForeground();
+	}
 }
 
 bool SettingsViewModel::IsSimulateExclusiveFullscreen() const noexcept {

--- a/src/Magpie.App/SettingsViewModel.h
+++ b/src/Magpie.App/SettingsViewModel.h
@@ -44,6 +44,9 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel> {
 	bool IsAlwaysRunAsAdmin() const noexcept;
 	void IsAlwaysRunAsAdmin(bool value) noexcept;
 
+	bool IsAllowScalingMaximized() const noexcept;
+	void IsAllowScalingMaximized(bool value) noexcept;
+
 	bool IsSimulateExclusiveFullscreen() const noexcept;
 	void IsSimulateExclusiveFullscreen(bool value) noexcept;
 

--- a/src/Magpie.App/SettingsViewModel.idl
+++ b/src/Magpie.App/SettingsViewModel.idl
@@ -18,6 +18,7 @@ namespace Magpie.App {
 		Boolean IsProcessElevated { get; };
 		Boolean IsAlwaysRunAsAdmin;
 
+		Boolean IsAllowScalingMaximized;
 		Boolean IsSimulateExclusiveFullscreen;
 		Boolean IsInlineParams;
 		Boolean IsDebugMode;

--- a/src/Magpie.Core/MagOptions.h
+++ b/src/Magpie.Core/MagOptions.h
@@ -44,6 +44,7 @@ struct MagFlags {
 	static constexpr const uint32_t DrawCursor = 0x1000;
 	static constexpr const uint32_t DisableDirectFlip = 0x2000;
 	static constexpr const uint32_t DisableFontCache = 0x4000;
+	static constexpr const uint32_t AllowScalingMaximized = 0x8000;
 };
 
 struct DownscalingEffect {
@@ -83,6 +84,7 @@ struct MagOptions {
 	DEFINE_FLAG_ACCESSOR(IsDisableFontCache, MagFlags::DisableFontCache, flags)
 	DEFINE_FLAG_ACCESSOR(IsSaveEffectSources, MagFlags::SaveEffectSources, flags)
 	DEFINE_FLAG_ACCESSOR(IsWarningsAreErrors, MagFlags::WarningsAreErrors, flags)
+	DEFINE_FLAG_ACCESSOR(IsAllowScalingMaximized, MagFlags::AllowScalingMaximized, flags)
 	DEFINE_FLAG_ACCESSOR(IsSimulateExclusiveFullscreen, MagFlags::SimulateExclusiveFullscreen, flags)
 	DEFINE_FLAG_ACCESSOR(Is3DGameMode, MagFlags::Is3DGameMode, flags)
 	DEFINE_FLAG_ACCESSOR(IsShowFPS, MagFlags::ShowFPS, flags)


### PR DESCRIPTION
v0.10 禁止缩放这种窗口，我们添加一个选项带回这个功能，下面是一些使用场景

* 作为滤镜使用
* 自定义裁剪
* 多屏幕

**实测支持独占全屏。**

Closes #559 