### PR TITLE
允许更改用于启动的可执行文件

### DIFF
--- a/src/Magpie.App/AppSettings.cpp
+++ b/src/Magpie.App/AppSettings.cpp
@@ -66,6 +66,8 @@ static void WriteProfile(rapidjson::PrettyWriter<rapidjson::StringBuffer>& write
 		writer.String(StrUtils::UTF16ToUTF8(profile.pathRule).c_str());
 		writer.Key("classNameRule");
 		writer.String(StrUtils::UTF16ToUTF8(profile.classNameRule).c_str());
+		writer.Key("launcherPath");
+		writer.String(StrUtils::UTF16ToUTF8(profile.launcherPath).c_str());
 		writer.Key("autoScale");
 		writer.Bool(profile.isAutoScale);
 		writer.Key("launchParameters");
@@ -751,6 +753,7 @@ bool AppSettings::_LoadProfile(
 			return false;
 		}
 
+		JsonHelper::ReadString(profileObj, "launcherPath", profile.launcherPath);
 		JsonHelper::ReadBool(profileObj, "autoScale", profile.isAutoScale);
 		JsonHelper::ReadString(profileObj, "launchParameters", profile.launchParameters);
 	}

--- a/src/Magpie.App/FileDialogHelper.cpp
+++ b/src/Magpie.App/FileDialogHelper.cpp
@@ -1,0 +1,37 @@
+#include "pch.h"
+#include "FileDialogHelper.h"
+#include "Logger.h"
+#include "App.h"
+
+namespace winrt::Magpie::App {
+
+std::optional<std::wstring> FileDialogHelper::OpenFileDialog(IFileDialog* fileDialog, FILEOPENDIALOGOPTIONS options) noexcept {
+	FILEOPENDIALOGOPTIONS options1{};
+	fileDialog->GetOptions(&options1);
+	fileDialog->SetOptions(options1 | options | FOS_FORCEFILESYSTEM);
+
+	if (fileDialog->Show((HWND)Application::Current().as<App>().HwndMain()) != S_OK) {
+		// 被用户取消
+		return std::wstring();
+	}
+
+	com_ptr<IShellItem> file;
+	HRESULT hr = fileDialog->GetResult(file.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("IFileSaveDialog::GetResult 失败", hr);
+		return std::nullopt;
+	}
+
+	wchar_t* fileName = nullptr;
+	hr = file->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, &fileName);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("IShellItem::GetDisplayName 失败", hr);
+		return std::nullopt;
+	}
+
+	std::wstring result(fileName);
+	CoTaskMemFree(fileName);
+	return std::move(result);
+}
+
+}

--- a/src/Magpie.App/FileDialogHelper.cpp
+++ b/src/Magpie.App/FileDialogHelper.cpp
@@ -5,6 +5,7 @@
 
 namespace winrt::Magpie::App {
 
+// 出错返回空，取消返回空字符串
 std::optional<std::wstring> FileDialogHelper::OpenFileDialog(IFileDialog* fileDialog, FILEOPENDIALOGOPTIONS options) noexcept {
 	FILEOPENDIALOGOPTIONS options1{};
 	fileDialog->GetOptions(&options1);

--- a/src/Magpie.App/FileDialogHelper.h
+++ b/src/Magpie.App/FileDialogHelper.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace winrt::Magpie::App {
+
+struct FileDialogHelper {
+	static std::optional<std::wstring> OpenFileDialog(
+		IFileDialog* fileDialog,
+		FILEOPENDIALOGOPTIONS options = 0
+	) noexcept;
+};
+
+}

--- a/src/Magpie.App/Magpie.App.vcxproj
+++ b/src/Magpie.App/Magpie.App.vcxproj
@@ -140,6 +140,7 @@
       <SubType>Code</SubType>
     </ClInclude>
     <ClInclude Include="EffectsService.h" />
+    <ClInclude Include="FileDialogHelper.h" />
     <ClInclude Include="HomeViewModel.h">
       <DependentUpon>HomeViewModel.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -293,6 +294,7 @@
       <SubType>Code</SubType>
     </ClCompile>
     <ClCompile Include="EffectsService.cpp" />
+    <ClCompile Include="FileDialogHelper.cpp" />
     <ClCompile Include="HomeViewModel.cpp">
       <DependentUpon>HomeViewModel.idl</DependentUpon>
       <SubType>Code</SubType>

--- a/src/Magpie.App/Magpie.App.vcxproj.filters
+++ b/src/Magpie.App/Magpie.App.vcxproj.filters
@@ -55,6 +55,9 @@
     <ClCompile Include="LocalizationService.cpp">
       <Filter>Services</Filter>
     </ClCompile>
+    <ClCompile Include="FileDialogHelper.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -113,6 +116,9 @@
     <ClInclude Include="app.base.h" />
     <ClInclude Include="LocalizationService.h">
       <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="FileDialogHelper.h">
+      <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Magpie.App/Profile.h
+++ b/src/Magpie.App/Profile.h
@@ -47,8 +47,7 @@ struct Profile {
 	std::wstring pathRule;
 	std::wstring classNameRule;
 
-	// 存储相对路径
-	// 若为空使用 pathRule
+	// 存储相对路径，若为空使用 pathRule
 	std::wstring exePath;
 
 	CursorScaling cursorScaling = CursorScaling::NoScaling;

--- a/src/Magpie.App/Profile.h
+++ b/src/Magpie.App/Profile.h
@@ -47,6 +47,10 @@ struct Profile {
 	std::wstring pathRule;
 	std::wstring classNameRule;
 
+	// 存储相对路径
+	// 若为空使用 pathRule
+	std::wstring exePath;
+
 	CursorScaling cursorScaling = CursorScaling::NoScaling;
 	float customCursorScaling = 1.0;
 

--- a/src/Magpie.App/Profile.h
+++ b/src/Magpie.App/Profile.h
@@ -47,8 +47,9 @@ struct Profile {
 	std::wstring pathRule;
 	std::wstring classNameRule;
 
-	// 存储相对路径，若为空使用 pathRule
-	std::wstring exePath;
+	// 如果在同一个驱动器上则存储相对路径，否则存储绝对路径
+	// 若为空使用 pathRule
+	std::wstring launcherPath;
 
 	CursorScaling cursorScaling = CursorScaling::NoScaling;
 	float customCursorScaling = 1.0;

--- a/src/Magpie.App/ProfilePage.xaml
+++ b/src/Magpie.App/ProfilePage.xaml
@@ -34,6 +34,11 @@
 									<FontIcon Glyph="&#xE8DA;" />
 								</MenuFlyoutItem.Icon>
 							</MenuFlyoutItem>
+							<MenuFlyoutItem x:Uid="Profile_MoreOptions_ChangeExecutableToLaunch">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE8E5;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
 							<MenuFlyoutSeparator />
 							<MenuFlyoutItem x:Uid="Profile_MoreOptions_Rename"
 							                Click="RenameMenuItem_Click">
@@ -478,7 +483,7 @@
 					                    Margin="0,0,0,2"
 					                    Visibility="{x:Bind ViewModel.IsNotDefaultProfile, Mode=OneTime}">
 						<local:SettingsCard.Icon>
-							<FontIcon Glyph="&#xF259;" />
+							<FontIcon Glyph="&#xE756;" />
 						</local:SettingsCard.Icon>
 						<local:SettingsCard.ActionContent>
 							<Grid MinHeight="36">

--- a/src/Magpie.App/ProfilePage.xaml
+++ b/src/Magpie.App/ProfilePage.xaml
@@ -34,7 +34,9 @@
 									<FontIcon Glyph="&#xE8DA;" />
 								</MenuFlyoutItem.Icon>
 							</MenuFlyoutItem>
-							<MenuFlyoutItem x:Uid="Profile_MoreOptions_ChangeExecutableToLaunch">
+							<MenuFlyoutItem x:Uid="Profile_MoreOptions_ChangeExecutableToLaunch"
+							                Click="{x:Bind ViewModel.ChangeExeToLaunch}"
+							                IsEnabled="{x:Bind ViewModel.IsProgramExist, Mode=OneTime}">
 								<MenuFlyoutItem.Icon>
 									<FontIcon Glyph="&#xE8E5;" />
 								</MenuFlyoutItem.Icon>

--- a/src/Magpie.App/ProfilePage.xaml
+++ b/src/Magpie.App/ProfilePage.xaml
@@ -36,7 +36,8 @@
 							</MenuFlyoutItem>
 							<MenuFlyoutItem x:Uid="Profile_MoreOptions_ChangeExecutableToLaunch"
 							                Click="{x:Bind ViewModel.ChangeExeToLaunch}"
-							                IsEnabled="{x:Bind ViewModel.IsProgramExist, Mode=OneTime}">
+							                IsEnabled="{x:Bind ViewModel.IsProgramExist, Mode=OneTime}"
+							                Visibility="{x:Bind ViewModel.IsNotPackaged, Mode=OneTime}">
 								<MenuFlyoutItem.Icon>
 									<FontIcon Glyph="&#xE8E5;" />
 								</MenuFlyoutItem.Icon>

--- a/src/Magpie.App/ProfilePage.xaml
+++ b/src/Magpie.App/ProfilePage.xaml
@@ -34,8 +34,8 @@
 									<FontIcon Glyph="&#xE8DA;" />
 								</MenuFlyoutItem.Icon>
 							</MenuFlyoutItem>
-							<MenuFlyoutItem x:Uid="Profile_MoreOptions_ChangeExecutableToLaunch"
-							                Click="{x:Bind ViewModel.ChangeExeToLaunch}"
+							<MenuFlyoutItem x:Uid="Profile_MoreOptions_ChangeExecutableForLaunching"
+							                Click="{x:Bind ViewModel.ChangeExeForLaunching}"
 							                IsEnabled="{x:Bind ViewModel.IsProgramExist, Mode=OneTime}"
 							                Visibility="{x:Bind ViewModel.IsNotPackaged, Mode=OneTime}">
 								<MenuFlyoutItem.Icon>

--- a/src/Magpie.App/ProfileViewModel.cpp
+++ b/src/Magpie.App/ProfileViewModel.cpp
@@ -158,8 +158,46 @@ fire_and_forget ProfileViewModel::OpenProgramLocation() const noexcept {
 	Win32Utils::OpenFolderAndSelectFile(programLocation.c_str());
 }
 
-void ProfileViewModel::ChangeExeToLaunch() const noexcept {
-	if (!_isProgramExist) {
+std::wstring GetStartFolderForSettingLauncher(const Profile& profile) noexcept {
+	if (profile.launcherPath.empty()) {
+		// 没有指定启动器
+		size_t delimPos = profile.pathRule.find_last_of(L'\\');
+		return delimPos == std::wstring::npos ? std::wstring() : profile.pathRule.substr(0, delimPos);
+	}
+
+	if (!PathIsRelative(profile.launcherPath.c_str())) {
+		// 位于不同的驱动器上
+		size_t delimPos = profile.launcherPath.find_last_of(L'\\');
+		return delimPos == std::wstring::npos ? std::wstring() : profile.pathRule.substr(0, delimPos);
+	}
+
+	size_t delimPos = profile.pathRule.find_last_of(L'\\');
+	if (delimPos == std::wstring::npos) {
+		return {};
+	}
+
+	// 相对路径转绝对路径
+	std::wstring combinedPath(MAX_PATH, 0);
+	if (!PathCombine(
+		combinedPath.data(),
+		profile.pathRule.substr(0, delimPos).c_str(),
+		profile.launcherPath.c_str()
+	)) {
+		return {};
+	}
+
+	combinedPath.resize(StrUtils::StrLen(combinedPath.c_str()));
+	delimPos = combinedPath.find_last_of(L'\\');
+	if (delimPos == std::wstring::npos) {
+		return {};
+	}
+
+	combinedPath.resize(delimPos);
+	return combinedPath;
+}
+
+void ProfileViewModel::ChangeExeForLaunching() const noexcept {
+	if (!_isProgramExist || _data->isPackaged) {
 		return;
 	}
 
@@ -169,18 +207,43 @@ void ProfileViewModel::ChangeExeToLaunch() const noexcept {
 		return;
 	}
 
-	fileDialog->SetTitle(L"选择可执行文件");
+	static std::wstring titleStr(ResourceLoader::GetForCurrentView().GetString(L"SelectLauncherDialog_Title"));
+	fileDialog->SetTitle(titleStr.c_str());
 
-	const COMDLG_FILTERSPEC fileType{ L"可执行文件", L"*.exe"};
+	static std::wstring exeFileStr(ResourceLoader::GetForCurrentView().GetString(L"FileDialog_ExeFile"));
+	const COMDLG_FILTERSPEC fileType{ exeFileStr.c_str(), L"*.exe"};
 	fileDialog->SetFileTypes(1, &fileType);
 	fileDialog->SetDefaultExtension(L"exe");
 
+	std::wstring startFolder = GetStartFolderForSettingLauncher(*_data);
+	if (!startFolder.empty() && Win32Utils::DirExists(startFolder.c_str())) {
+		com_ptr<IShellItem> shellItem;
+		SHCreateItemFromParsingName(startFolder.c_str(), nullptr, IID_PPV_ARGS(&shellItem));
+		fileDialog->SetFolder(shellItem.get());
+	}
+
 	std::optional<std::wstring> exePath = FileDialogHelper::OpenFileDialog(fileDialog.get(), FOS_STRICTFILETYPES);
-	if (!exePath || *exePath == _data->pathRule) {
+	if (!exePath || exePath->empty() || *exePath == _data->pathRule) {
 		return;
 	}
 
-	
+	if (!PathIsSameRoot(exePath->c_str(), _data->pathRule.c_str())) {
+		// 位于不同的驱动器上
+		_data->launcherPath = std::move(*exePath);
+		return;
+	}
+
+	// 绝对路径转相对路径
+	_data->launcherPath.clear();
+	_data->launcherPath.resize(MAX_PATH, 0);
+	PathRelativePathTo(
+		_data->launcherPath.data(),
+		_data->pathRule.c_str(),
+		FILE_ATTRIBUTE_NORMAL,
+		exePath->c_str(),
+		FILE_ATTRIBUTE_NORMAL
+	);
+	_data->launcherPath.resize(StrUtils::StrLen(_data->launcherPath.c_str()));
 }
 
 hstring ProfileViewModel::Name() const noexcept {
@@ -191,7 +254,7 @@ hstring ProfileViewModel::Name() const noexcept {
 	}
 }
 
-static void LaunchPackagedApp(const Profile& profile) {
+static void LaunchPackagedApp(const Profile& profile) noexcept {
 	// 关于启动打包应用的讨论：
 	// https://github.com/microsoft/WindowsAppSDK/issues/2856#issuecomment-1224409948
 	// 使用 CLSCTX_LOCAL_SERVER 以在独立的进程中启动应用
@@ -217,6 +280,38 @@ static void LaunchPackagedApp(const Profile& profile) {
 	}
 }
 
+static void LaunchWin32App(const Profile& profile) noexcept {
+	if (profile.launcherPath.empty()) {
+		Win32Utils::ShellOpen(profile.pathRule.c_str(), profile.launchParameters.c_str());
+		return;
+	}
+
+	if (!PathIsRelative(profile.launcherPath.c_str())) {
+		// 位于不同的驱动器上
+		if (Win32Utils::FileExists(profile.launcherPath.c_str())) {
+			Win32Utils::ShellOpen(profile.launcherPath.c_str(), profile.launchParameters.c_str());
+		} else {
+			Win32Utils::ShellOpen(profile.pathRule.c_str(), profile.launchParameters.c_str());
+		}
+		return;
+	}
+
+	size_t delimPos = profile.pathRule.find_last_of(L'\\');
+	if (delimPos == std::wstring::npos) {
+		return;
+	}
+
+	// 相对路径转绝对路径
+	wchar_t combinedPath[MAX_PATH];
+	if (!PathCombine(combinedPath, profile.pathRule.substr(0, delimPos).c_str(), profile.launcherPath.c_str())
+		|| !Win32Utils::FileExists(combinedPath)) {
+		Win32Utils::ShellOpen(profile.pathRule.c_str(), profile.launchParameters.c_str());
+		return;
+	}
+
+	Win32Utils::ShellOpen(combinedPath, profile.launchParameters.c_str());
+}
+
 void ProfileViewModel::Launch() const noexcept {
 	if (!_isProgramExist) {
 		return;
@@ -225,7 +320,7 @@ void ProfileViewModel::Launch() const noexcept {
 	if (_data->isPackaged) {
 		LaunchPackagedApp(*_data);
 	} else {
-		Win32Utils::ShellOpen(_data->pathRule.c_str(), _data->launchParameters.c_str());
+		LaunchWin32App(*_data);
 	}
 }
 

--- a/src/Magpie.App/ProfileViewModel.cpp
+++ b/src/Magpie.App/ProfileViewModel.cpp
@@ -129,6 +129,10 @@ bool ProfileViewModel::IsNotDefaultProfile() const noexcept {
 	return !_data->name.empty();
 }
 
+bool ProfileViewModel::IsNotPackaged() const noexcept {
+	return !_data->isPackaged;
+}
+
 fire_and_forget ProfileViewModel::OpenProgramLocation() const noexcept {
 	if (!_isProgramExist) {
 		co_return;
@@ -159,7 +163,24 @@ void ProfileViewModel::ChangeExeToLaunch() const noexcept {
 		return;
 	}
 
+	com_ptr<IFileOpenDialog> fileDialog = try_create_instance<IFileOpenDialog>(CLSID_FileOpenDialog);
+	if (!fileDialog) {
+		Logger::Get().Error("创建 FileSaveDialog 失败");
+		return;
+	}
 
+	fileDialog->SetTitle(L"选择可执行文件");
+
+	const COMDLG_FILTERSPEC fileType{ L"可执行文件", L"*.exe"};
+	fileDialog->SetFileTypes(1, &fileType);
+	fileDialog->SetDefaultExtension(L"exe");
+
+	std::optional<std::wstring> exePath = FileDialogHelper::OpenFileDialog(fileDialog.get(), FOS_STRICTFILETYPES);
+	if (!exePath || *exePath == _data->pathRule) {
+		return;
+	}
+
+	
 }
 
 hstring ProfileViewModel::Name() const noexcept {

--- a/src/Magpie.App/ProfileViewModel.cpp
+++ b/src/Magpie.App/ProfileViewModel.cpp
@@ -153,6 +153,14 @@ fire_and_forget ProfileViewModel::OpenProgramLocation() const noexcept {
 	Win32Utils::OpenFolderAndSelectFile(programLocation.c_str());
 }
 
+void ProfileViewModel::ChangeExeToLaunch() const noexcept {
+	if (!_isProgramExist) {
+		return;
+	}
+
+
+}
+
 hstring ProfileViewModel::Name() const noexcept {
 	if (_data->name.empty()) {
 		return ResourceLoader::GetForCurrentView().GetString(L"Main_Defaults/Content");

--- a/src/Magpie.App/ProfileViewModel.cpp
+++ b/src/Magpie.App/ProfileViewModel.cpp
@@ -15,6 +15,7 @@
 #include "ScalingMode.h"
 #include <dxgi.h>
 #include "MagService.h"
+#include "FileDialogHelper.h"
 
 using namespace winrt;
 using namespace Windows::Graphics::Display;

--- a/src/Magpie.App/ProfileViewModel.h
+++ b/src/Magpie.App/ProfileViewModel.h
@@ -34,7 +34,7 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel> {
 
 	fire_and_forget OpenProgramLocation() const noexcept;
 
-	void ChangeExeToLaunch() const noexcept;
+	void ChangeExeForLaunching() const noexcept;
 
 	hstring Name() const noexcept;
 

--- a/src/Magpie.App/ProfileViewModel.h
+++ b/src/Magpie.App/ProfileViewModel.h
@@ -32,6 +32,8 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel> {
 
 	fire_and_forget OpenProgramLocation() const noexcept;
 
+	void ChangeExeToLaunch() const noexcept;
+
 	hstring Name() const noexcept;
 
 	void Launch() const noexcept;

--- a/src/Magpie.App/ProfileViewModel.h
+++ b/src/Magpie.App/ProfileViewModel.h
@@ -30,6 +30,8 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel> {
 		return _isProgramExist;
 	}
 
+	bool IsNotPackaged() const noexcept;
+
 	fire_and_forget OpenProgramLocation() const noexcept;
 
 	void ChangeExeToLaunch() const noexcept;

--- a/src/Magpie.App/ProfileViewModel.idl
+++ b/src/Magpie.App/ProfileViewModel.idl
@@ -10,6 +10,7 @@ namespace Magpie.App {
 
 		Boolean IsProgramExist { get; };
 		void OpenProgramLocation();
+		void ChangeExeToLaunch();
 
 		String RenameText;
 		Boolean IsRenameConfirmButtonEnabled { get; };

--- a/src/Magpie.App/ProfileViewModel.idl
+++ b/src/Magpie.App/ProfileViewModel.idl
@@ -12,7 +12,7 @@ namespace Magpie.App {
 		Boolean IsNotPackaged { get; };
 
 		void OpenProgramLocation();
-		void ChangeExeToLaunch();
+		void ChangeExeForLaunching();
 
 		String RenameText;
 		Boolean IsRenameConfirmButtonEnabled { get; };

--- a/src/Magpie.App/ProfileViewModel.idl
+++ b/src/Magpie.App/ProfileViewModel.idl
@@ -9,6 +9,8 @@ namespace Magpie.App {
 		void Launch();
 
 		Boolean IsProgramExist { get; };
+		Boolean IsNotPackaged { get; };
+
 		void OpenProgramLocation();
 		void ChangeExeToLaunch();
 

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -824,6 +824,9 @@
     <value>Disable font cache</value>
   </data>
   <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
-    <value>Allow scaling maximized or full-screen windows</value>
+    <value>Allow scaling maximized or fullscreen windows</value>
+  </data>
+  <data name="Profile_MoreOptions_ChangeExecutableToLaunch.Text" xml:space="preserve">
+    <value>Change the executable file to launch</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -829,7 +829,13 @@
   <data name="FileDialog_JsonFile" xml:space="preserve">
     <value>JSON file</value>
   </data>
-  <data name="Profile_MoreOptions_ChangeExecutableToLaunch.Text" xml:space="preserve">
-    <value>Change the executable file to launch</value>
+  <data name="Profile_MoreOptions_ChangeExecutableForLaunching.Text" xml:space="preserve">
+    <value>Change the executable file for launching</value>
+  </data>
+  <data name="FileDialog_ExeFile" xml:space="preserve">
+    <value>Executable file</value>
+  </data>
+  <data name="SelectLauncherDialog_Title" xml:space="preserve">
+    <value>Choose the executable file to launch the program</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -826,6 +826,9 @@
   <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
     <value>Allow scaling maximized or fullscreen windows</value>
   </data>
+  <data name="FileDialog_JsonFile" xml:space="preserve">
+    <value>JSON file</value>
+  </data>
   <data name="Profile_MoreOptions_ChangeExecutableToLaunch.Text" xml:space="preserve">
     <value>Change the executable file to launch</value>
   </data>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -826,4 +826,7 @@
   <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
     <value>允许缩放最大化或全屏的窗口</value>
   </data>
+  <data name="Profile_MoreOptions_ChangeExecutableToLaunch.Text" xml:space="preserve">
+    <value>更改要启动的可执行文件</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -829,7 +829,13 @@
   <data name="FileDialog_JsonFile" xml:space="preserve">
     <value>JSON 文件</value>
   </data>
-  <data name="Profile_MoreOptions_ChangeExecutableToLaunch.Text" xml:space="preserve">
-    <value>更改要启动的可执行文件</value>
+  <data name="Profile_MoreOptions_ChangeExecutableForLaunching.Text" xml:space="preserve">
+    <value>更改用于启动程序的可执行文件</value>
+  </data>
+  <data name="FileDialog_ExeFile" xml:space="preserve">
+    <value>可执行文件</value>
+  </data>
+  <data name="SelectLauncherDialog_Title" xml:space="preserve">
+    <value>选择用于启动程序的可执行文件</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -826,6 +826,9 @@
   <data name="Settings_Advanced_AllowScalingMaximized.Title" xml:space="preserve">
     <value>允许缩放最大化或全屏的窗口</value>
   </data>
+  <data name="FileDialog_JsonFile" xml:space="preserve">
+    <value>JSON 文件</value>
+  </data>
   <data name="Profile_MoreOptions_ChangeExecutableToLaunch.Text" xml:space="preserve">
     <value>更改要启动的可执行文件</value>
   </data>

--- a/src/Magpie.App/ScalingConfigurationViewModel.cpp
+++ b/src/Magpie.App/ScalingConfigurationViewModel.cpp
@@ -109,7 +109,7 @@ void ScalingConfigurationViewModel::Export() const noexcept {
 	Win32Utils::WriteTextFile(fileName->c_str(), {json.GetString(), json.GetLength()});
 }
 
-static bool ImportImpl(bool legacy) {
+static bool ImportImpl(bool legacy) noexcept {
 	com_ptr<IFileOpenDialog> fileDialog = try_create_instance<IFileOpenDialog>(CLSID_FileOpenDialog);
 	if (!fileDialog) {
 		Logger::Get().Error("创建 FileOpenDialog 失败");

--- a/src/Magpie.App/ScalingConfigurationViewModel.cpp
+++ b/src/Magpie.App/ScalingConfigurationViewModel.cpp
@@ -75,7 +75,9 @@ ScalingConfigurationViewModel::ScalingConfigurationViewModel() {
 }
 
 static std::optional<std::wstring> OpenFileDialogForJson(IFileDialog* fileDialog) noexcept {
-	const COMDLG_FILTERSPEC fileType{ L"JSON 文件", L"*.json" };
+	static std::wstring jsonFileStr(ResourceLoader::GetForCurrentView().GetString(L"FileDialog_JsonFile"));
+
+	const COMDLG_FILTERSPEC fileType{ jsonFileStr.c_str(), L"*.json"};
 	fileDialog->SetFileTypes(1, &fileType);
 	fileDialog->SetDefaultExtension(L"json");
 
@@ -90,7 +92,7 @@ void ScalingConfigurationViewModel::Export() const noexcept {
 	}
 
 	fileDialog->SetFileName(L"ScalingModes");
-	hstring title = ResourceLoader::GetForCurrentView().GetString(L"ExportDialog_Title");
+	static std::wstring title(ResourceLoader::GetForCurrentView().GetString(L"ExportDialog_Title"));
 	fileDialog->SetTitle(title.c_str());
 
 	std::optional<std::wstring> fileName = OpenFileDialogForJson(fileDialog.get());


### PR DESCRIPTION
某些游戏需要通过“启动器”启动，因此用户需要自定义启动器的路径。

此选项不适用于打包应用。

Closes #609 