### PR TITLE
修复向下还原按钮的文字提示

### DIFF
--- a/src/Magpie/MainWindow.cpp
+++ b/src/Magpie/MainWindow.cpp
@@ -436,6 +436,11 @@ void MainWindow::_ResizeTitleBarWindow() noexcept {
 		(int)std::floorf(rect.Height * dpiScale + 1),	// 不知为何，直接向上取整有时无法遮盖 TitleBarControl
 		SWP_SHOWWINDOW
 	);
+
+	// 设置标题栏窗口的最大化样式，这样才能展示正确的文字提示
+	LONG_PTR style = GetWindowLongPtr(_hwndTitleBar, GWL_STYLE);
+	SetWindowLongPtr(_hwndTitleBar, GWL_STYLE,
+		_isMaximized ? style | WS_MAXIMIZE : style & ~WS_MAXIMIZE);
 }
 
 }


### PR DESCRIPTION
![image](https://github.com/Blinue/Magpie/assets/34770031/2204b6d7-6d4d-409f-b539-448834902017)

最大化时向下还原按钮的文字提示为“最大化”，Win11 中关闭贴靠布局也会看到这个错误。

文字提示是标题栏窗口弹出的，这个窗口不会改变状态。我们不能真的将它最大化了，但可以通过设置 WS_MAXIMIZE 样式欺骗 OS。