### PR TITLE
提高开发者选项的门槛

### DIFF
--- a/src/Magpie.App/AboutPage.cpp
+++ b/src/Magpie.App/AboutPage.cpp
@@ -10,6 +10,7 @@ namespace winrt::Magpie::App::implementation {
 void AboutPage::VersionTextBlock_DoubleTapped(IInspectable const&, Input::DoubleTappedRoutedEventArgs const&) {
 	if (!_viewModel.IsDeveloperMode() && (GetAsyncKeyState(VK_MENU) & 0x8000)) {
 		_viewModel.IsDeveloperMode(true);
+		DeveloperModeTeachingTip().IsOpen(true);
 	}
 }
 

--- a/src/Magpie.App/AboutPage.cpp
+++ b/src/Magpie.App/AboutPage.cpp
@@ -8,7 +8,9 @@
 namespace winrt::Magpie::App::implementation {
 
 void AboutPage::VersionTextBlock_DoubleTapped(IInspectable const&, Input::DoubleTappedRoutedEventArgs const&) {
-	OutputDebugString(L"test");
+	if (!_viewModel.IsDeveloperMode() && (GetAsyncKeyState(VK_MENU) & 0x8000)) {
+		_viewModel.IsDeveloperMode(true);
+	}
 }
 
 void AboutPage::BugReportButton_Click(IInspectable const&, RoutedEventArgs const&) {

--- a/src/Magpie.App/AboutPage.cpp
+++ b/src/Magpie.App/AboutPage.cpp
@@ -7,6 +7,10 @@
 
 namespace winrt::Magpie::App::implementation {
 
+void AboutPage::VersionTextBlock_DoubleTapped(IInspectable const&, Input::DoubleTappedRoutedEventArgs const&) {
+	OutputDebugString(L"test");
+}
+
 void AboutPage::BugReportButton_Click(IInspectable const&, RoutedEventArgs const&) {
 	Win32Utils::ShellOpen(L"https://github.com/Blinue/Magpie/issues/new?assignees=&labels=bug&template=01_bug.yaml");
 }

--- a/src/Magpie.App/AboutPage.h
+++ b/src/Magpie.App/AboutPage.h
@@ -8,6 +8,8 @@ struct AboutPage : AboutPageT<AboutPage> {
 		return _viewModel;
 	}
 
+	void VersionTextBlock_DoubleTapped(IInspectable const&, Input::DoubleTappedRoutedEventArgs const&);
+
 	void BugReportButton_Click(IInspectable const&, RoutedEventArgs const&);
 	void FeatureRequestButton_Click(IInspectable const&, RoutedEventArgs const&);
 	void DiscussionsButton_Click(IInspectable const&, RoutedEventArgs const&);

--- a/src/Magpie.App/AboutPage.xaml
+++ b/src/Magpie.App/AboutPage.xaml
@@ -23,7 +23,8 @@
 					            Spacing="4">
 						<TextBlock FontSize="24"
 						           Text="Magpie" />
-						<TextBlock FontSize="{StaticResource SecondaryTextFontSize}"
+						<TextBlock DoubleTapped="VersionTextBlock_DoubleTapped"
+						           FontSize="{StaticResource SecondaryTextFontSize}"
 						           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
 						           Text="{x:Bind ViewModel.Version, Mode=OneTime}" />
 					</StackPanel>

--- a/src/Magpie.App/AboutPage.xaml
+++ b/src/Magpie.App/AboutPage.xaml
@@ -27,6 +27,9 @@
 						           FontSize="{StaticResource SecondaryTextFontSize}"
 						           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
 						           Text="{x:Bind ViewModel.Version, Mode=OneTime}" />
+						<muxc:TeachingTip x:Name="DeveloperModeTeachingTip"
+						                  IsLightDismissEnabled="True"
+						                  Subtitle="开发者模式已启用" />
 					</StackPanel>
 				</StackPanel>
 				<StackPanel>

--- a/src/Magpie.App/AboutViewModel.cpp
+++ b/src/Magpie.App/AboutViewModel.cpp
@@ -81,6 +81,14 @@ hstring AboutViewModel::Version() const noexcept {
 	));
 }
 
+bool AboutViewModel::IsDeveloperMode() const noexcept {
+	return AppSettings::Get().IsDeveloperMode();
+}
+
+void AboutViewModel::IsDeveloperMode(bool value) {
+	AppSettings::Get().IsDeveloperMode(value);
+}
+
 fire_and_forget AboutViewModel::CheckForUpdates() {
 	return UpdateService::Get().CheckForUpdatesAsync(false);
 }

--- a/src/Magpie.App/AboutViewModel.h
+++ b/src/Magpie.App/AboutViewModel.h
@@ -21,6 +21,9 @@ struct AboutViewModel : AboutViewModelT<AboutViewModel> {
 
 	hstring Version() const noexcept;
 
+	bool IsDeveloperMode() const noexcept;
+	void IsDeveloperMode(bool value);
+
 	fire_and_forget CheckForUpdates();
 
 	bool IsCheckForPreviewUpdates() const noexcept;

--- a/src/Magpie.App/AboutViewModel.idl
+++ b/src/Magpie.App/AboutViewModel.idl
@@ -6,6 +6,8 @@ namespace Magpie.App {
 
 		String Version { get; };
 
+		Boolean IsDeveloperMode;
+
 		void CheckForUpdates();
 		Boolean IsCheckingForUpdates { get; };
 		Boolean IsCheckForUpdatesButtonEnabled { get; };

--- a/src/Magpie.App/AppSettings.cpp
+++ b/src/Magpie.App/AppSettings.cpp
@@ -397,6 +397,20 @@ void AppSettings::CountdownSeconds(uint32_t value) noexcept {
 	SaveAsync();
 }
 
+void AppSettings::IsDeveloperMode(bool value) noexcept {
+	_isDeveloperMode = value;
+	if (!value) {
+		// 关闭开发者模式则禁用所有开发者选项
+		_isDebugMode = false;
+		_isDisableEffectCache = false;
+		_isDisableFontCache = false;
+		_isSaveEffectSources = false;
+		_isWarningsAreErrors = false;
+	}
+
+	SaveAsync();
+}
+
 void AppSettings::IsAlwaysRunAsAdmin(bool value) noexcept {
 	if (_isAlwaysRunAsAdmin == value) {
 		return;

--- a/src/Magpie.App/AppSettings.cpp
+++ b/src/Magpie.App/AppSettings.cpp
@@ -494,6 +494,8 @@ bool AppSettings::_Save(const _AppSettingsData& data) noexcept {
 	writer.Bool(data._isAutoRestore);
 	writer.Key("countdownSeconds");
 	writer.Uint(data._countdownSeconds);
+	writer.Key("developerMode");
+	writer.Bool(data._isDeveloperMode);
 	writer.Key("debugMode");
 	writer.Bool(data._isDebugMode);
 	writer.Key("disableEffectCache");
@@ -640,6 +642,7 @@ void AppSettings::_LoadSettings(const rapidjson::GenericObject<true, rapidjson::
 	if (_countdownSeconds == 0 || _countdownSeconds > 5) {
 		_countdownSeconds = 3;
 	}
+	JsonHelper::ReadBool(root, "developerMode", _isDeveloperMode);
 	JsonHelper::ReadBool(root, "debugMode", _isDebugMode);
 	JsonHelper::ReadBool(root, "disableEffectCache", _isDisableEffectCache);
 	JsonHelper::ReadBool(root, "disableFontCache", _isDisableFontCache);

--- a/src/Magpie.App/AppSettings.h
+++ b/src/Magpie.App/AppSettings.h
@@ -190,10 +190,7 @@ public:
 		return _isDeveloperMode;
 	}
 
-	void IsDeveloperMode(bool value) noexcept {
-		_isDeveloperMode = value;
-		SaveAsync();
-	}
+	void IsDeveloperMode(bool value) noexcept;
 
 	bool IsDebugMode() const noexcept {
 		return _isDebugMode;

--- a/src/Magpie.App/AppSettings.h
+++ b/src/Magpie.App/AppSettings.h
@@ -48,6 +48,7 @@ struct _AppSettingsData {
 	
 	bool _isPortableMode = false;
 	bool _isAlwaysRunAsAdmin = false;
+	bool _isDeveloperMode = false;
 	bool _isDebugMode = false;
 	bool _isDisableEffectCache = false;
 	bool _isDisableFontCache = false;
@@ -183,6 +184,15 @@ public:
 
 	void CountdownSecondsChanged(event_token const& token) {
 		_countdownSecondsChangedEvent.remove(token);
+	}
+
+	bool IsDeveloperMode() const noexcept {
+		return _isDeveloperMode;
+	}
+
+	void IsDeveloperMode(bool value) noexcept {
+		_isDeveloperMode = value;
+		SaveAsync();
 	}
 
 	bool IsDebugMode() const noexcept {

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -141,43 +141,48 @@
 						              IsOn="{x:Bind ViewModel.IsInlineParams, Mode=TwoWay}" />
 					</local:SettingsCard.ActionContent>
 				</local:SettingsCard>
-				<muxc:Expander HorizontalAlignment="Stretch"
-				               HorizontalContentAlignment="Stretch"
-				               Style="{StaticResource SettingExpanderStyle}">
-					<muxc:Expander.Header>
-						<local:SettingsCard x:Uid="Settings_DeveloperOptions"
-						                    Style="{StaticResource ExpanderHeaderSettingStyle}">
-							<local:SettingsCard.Icon>
-								<FontIcon Glyph="&#xEC7A;" />
-							</local:SettingsCard.Icon>
-						</local:SettingsCard>
-					</muxc:Expander.Header>
-					<muxc:Expander.Content>
-						<StackPanel>
-							<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
-								<CheckBox x:Uid="Settings_DeveloperOptions_DebugMode"
-								          IsChecked="{x:Bind ViewModel.IsDebugMode, Mode=TwoWay}" />
-							</local:SettingsCard>
-							<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
-								<CheckBox x:Uid="Settings_DeveloperOptions_DisableEffectCache"
-								          IsChecked="{x:Bind ViewModel.IsDisableEffectCache, Mode=TwoWay}" />
-							</local:SettingsCard>
-							<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
-								<CheckBox x:Uid="Settings_DeveloperOptions_DisableFontCache"
-								          IsChecked="{x:Bind ViewModel.IsDisableFontCache, Mode=TwoWay}" />
-							</local:SettingsCard>
-							<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
-								<CheckBox x:Uid="Settings_DeveloperOptions_SaveEffectSources"
-								          IsChecked="{x:Bind ViewModel.IsSaveEffectSources, Mode=TwoWay}" />
-							</local:SettingsCard>
-							<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
-								<CheckBox x:Uid="Settings_DeveloperOptions_WarningsAreErrors"
-								          IsChecked="{x:Bind ViewModel.IsWarningsAreErrors, Mode=TwoWay}" />
-							</local:SettingsCard>
-						</StackPanel>
-					</muxc:Expander.Content>
-				</muxc:Expander>
 			</local:SettingsGroup>
+			<muxc:Expander Margin="0,0,0,2"
+			               HorizontalAlignment="Stretch"
+			               HorizontalContentAlignment="Stretch"
+			               Style="{StaticResource SettingExpanderStyle}"
+			               Visibility="{x:Bind ViewModel.IsDeveloperMode, Mode=OneWay}">
+				<muxc:Expander.Header>
+					<local:SettingsCard x:Uid="Settings_DeveloperOptions"
+					                    Style="{StaticResource ExpanderHeaderSettingStyle}">
+						<local:SettingsCard.Icon>
+							<FontIcon Glyph="&#xEC7A;" />
+						</local:SettingsCard.Icon>
+						<local:SettingsCard.ActionContent>
+							<ToggleSwitch IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay}" />
+						</local:SettingsCard.ActionContent>
+					</local:SettingsCard>
+				</muxc:Expander.Header>
+				<muxc:Expander.Content>
+					<StackPanel>
+						<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
+							<CheckBox x:Uid="Settings_DeveloperOptions_DebugMode"
+							          IsChecked="{x:Bind ViewModel.IsDebugMode, Mode=TwoWay}" />
+						</local:SettingsCard>
+						<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
+							<CheckBox x:Uid="Settings_DeveloperOptions_DisableEffectCache"
+							          IsChecked="{x:Bind ViewModel.IsDisableEffectCache, Mode=TwoWay}" />
+						</local:SettingsCard>
+						<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
+							<CheckBox x:Uid="Settings_DeveloperOptions_DisableFontCache"
+							          IsChecked="{x:Bind ViewModel.IsDisableFontCache, Mode=TwoWay}" />
+						</local:SettingsCard>
+						<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
+							<CheckBox x:Uid="Settings_DeveloperOptions_SaveEffectSources"
+							          IsChecked="{x:Bind ViewModel.IsSaveEffectSources, Mode=TwoWay}" />
+						</local:SettingsCard>
+						<local:SettingsCard Style="{StaticResource ExpanderContentSettingStyle}">
+							<CheckBox x:Uid="Settings_DeveloperOptions_WarningsAreErrors"
+							          IsChecked="{x:Bind ViewModel.IsWarningsAreErrors, Mode=TwoWay}" />
+						</local:SettingsCard>
+					</StackPanel>
+				</muxc:Expander.Content>
+			</muxc:Expander>
 		</StackPanel>
 	</local:PageFrame>
 </Page>

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -145,6 +145,7 @@
 			<muxc:Expander Margin="0,0,0,2"
 			               HorizontalAlignment="Stretch"
 			               HorizontalContentAlignment="Stretch"
+			               IsExpanded="{x:Bind ViewModel.IsDeveloperMode, Mode=OneTime}"
 			               Style="{StaticResource SettingExpanderStyle}"
 			               Visibility="{x:Bind ViewModel.IsDeveloperMode, Mode=OneWay}">
 				<muxc:Expander.Header>

--- a/src/Magpie.App/SettingsViewModel.cpp
+++ b/src/Magpie.App/SettingsViewModel.cpp
@@ -212,6 +212,21 @@ void SettingsViewModel::IsInlineParams(bool value) noexcept {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsInlineParams"));
 }
 
+bool SettingsViewModel::IsDeveloperMode() const noexcept {
+	return AppSettings::Get().IsDeveloperMode();
+}
+
+void SettingsViewModel::IsDeveloperMode(bool value) noexcept {
+	AppSettings& settings = AppSettings::Get();
+
+	if (settings.IsDeveloperMode() == value) {
+		return;
+	}
+
+	settings.IsDeveloperMode(value);
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDeveloperMode"));
+}
+
 bool SettingsViewModel::IsDebugMode() const noexcept {
 	return AppSettings::Get().IsDebugMode();
 }

--- a/src/Magpie.App/SettingsViewModel.h
+++ b/src/Magpie.App/SettingsViewModel.h
@@ -53,6 +53,9 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel> {
 	bool IsInlineParams() const noexcept;
 	void IsInlineParams(bool value) noexcept;
 
+	bool IsDeveloperMode() const noexcept;
+	void IsDeveloperMode(bool value) noexcept;
+
 	bool IsDebugMode() const noexcept;
 	void IsDebugMode(bool value) noexcept;
 

--- a/src/Magpie.App/SettingsViewModel.idl
+++ b/src/Magpie.App/SettingsViewModel.idl
@@ -21,6 +21,8 @@ namespace Magpie.App {
 		Boolean IsAllowScalingMaximized;
 		Boolean IsSimulateExclusiveFullscreen;
 		Boolean IsInlineParams;
+		
+		Boolean IsDeveloperMode;
 		Boolean IsDebugMode;
 		Boolean IsDisableEffectCache;
 		Boolean IsDisableFontCache;


### PR DESCRIPTION
开发者选项默认隐藏，开启方法为按住 Alt 键双击版本号。