### PR TITLE
feat: 适配 Win11 23H2

### DIFF
--- a/src/Magpie/app.manifest
+++ b/src/Magpie/app.manifest
@@ -23,6 +23,7 @@
       <!-- 启用 Segoe UI Variable 和 Segoe Fluent Icons -->
       <maxversiontested Id="10.0.22000.0"/>
       <maxversiontested Id="10.0.22621.0"/>
+      <maxversiontested Id="10.0.22631.0"/>
     </application>
   </compatibility>
   


### PR DESCRIPTION
Windows 11 23H2 于 2023 年 10 月 31 日发布，版本号 22631。对于每一个新发布的正式版本，我们应更新 manifest 声明对它的支持，这可以让 OS 启用某些新功能。