### PR TITLE
修正贴靠布局弹窗位置

### DIFF
--- a/src/Magpie/MainWindow.h
+++ b/src/Magpie/MainWindow.h
@@ -24,6 +24,7 @@ private:
 	void _ResizeTitleBarWindow() noexcept;
 
 	HWND _hwndTitleBar = NULL;
+	HWND _hwndMaximizeButton = NULL;
 	bool _trackingMouse = false;
 };
 


### PR DESCRIPTION
fix #661 

修正前：
![image](https://github.com/Blinue/Magpie/assets/34770031/01030846-f45c-4756-bd65-419d1fe6d2da)
修正后：
![image](https://github.com/Blinue/Magpie/assets/34770031/691c7dbf-d0fe-45f0-9eb6-568af0a004eb)

这是大部分自定义标题栏的应用都有的问题，但似乎无人关心。经过了很长时间，我终于找到了解决方案。

在贴靠布局弹窗显示之前，窗口会收到 WM_GETOBJECT 消息，因此我猜测 OS 使用 UI Automation 来获取标题栏高度，如果不可用就假设和原生窗口相同。UI Automation 我并不了解，但我们可以变通一下：Win32 控件有默认的 UI Automation 机制，我们只需将一个原生按钮摆放在这里，OS 便会将它当作最大化/还原按钮，从而将贴靠布局弹窗显示在正确的位置。

因此我们有了一个不可见、禁用状态的原生按钮控件，它的高度和标题栏按钮相同，唯一的作用便是修正贴靠布局弹窗的位置。