### PR TITLE
使用正式版 WinUI

### DIFF
--- a/Magpie.sln
+++ b/Magpie.sln
@@ -23,7 +23,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		src\Common.Pre.props = src\Common.Pre.props
 		src\Common.Post.props = src\Common.Post.props
+		src\extract_winui_runtime.py = src\extract_winui_runtime.py
+		src\fix_resfiles.py = src\fix_resfiles.py
 		HybridCRT.props = HybridCRT.props
+		src\WinUI.props = src\WinUI.props
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shared", "src\Shared\Shared.vcxitems", "{4EB33017-68C1-40FE-877A-BCFAB2832F18}"

--- a/publish.py
+++ b/publish.py
@@ -131,16 +131,9 @@ def remove_file(file):
         pass
 
 
-# 删除文件夹，忽略错误
-def remove_folder(folder):
-    try:
-        shutil.rmtree(folder)
-    except:
-        pass
-
-
-remove_file("Microsoft.Web.WebView2.Core.dll")
-
+for folder in ["Microsoft.UI.Xaml", "Magpie.App"]:
+    shutil.rmtree(folder, ignore_errors=True)
+    
 for pattern in ["*.pdb", "*.lib", "*.exp", "*.winmd", "*.xml", "*.xbf", "dummy.*"]:
     for file in glob.glob(pattern):
         remove_file(file)
@@ -149,8 +142,7 @@ for file in glob.glob("*.pri"):
     if file != "resources.pri":
         remove_file(file)
 
-for folder in ["Microsoft.UI.Xaml", "Magpie.App"]:
-    remove_folder(folder)
+remove_file("Microsoft.Web.WebView2.Core.dll")
 
 print("清理完毕", flush=True)
 
@@ -162,9 +154,7 @@ print("清理完毕", flush=True)
 #####################################################################
 
 # 取最新的 Windows SDK
-windowsSdkDir = sorted(
-    glob.glob(programFilesX86Path + "\\Windows Kits\\10\\bin\\10.*")
-)[-1]
+windowsSdkDir = max(glob.glob(programFilesX86Path + "\\Windows Kits\\10\\bin\\10.*"))
 makepriPath = windowsSdkDir + "\\x64\\makepri.exe"
 if not os.access(makepriPath, os.X_OK):
     raise Exception("未找到 makepri")
@@ -186,6 +176,7 @@ for resourceNode in xmlTree.getroot().findall(
         continue
 
     # 我们仅需 19h1 和 21h1 的资源，分别用于 Win10 和 Win11
+    # 小写 compact 仅存在于预发行版 WinUI 的资源中
     for key in ["compact", "Compact", "v1", "rs2", "rs3", "rs4", "rs5"]:
         if key in name:
             # 将文件内容替换为一个空格（Base64 为 "IA=="）

--- a/src/Common.Post.props
+++ b/src/Common.Post.props
@@ -5,7 +5,7 @@
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <CppWinRTVerbosity>low</CppWinRTVerbosity>
-    <IntDir>$(SolutionDir)\obj\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</IntDir>
+    <IntDir>$(SolutionDir)obj\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</IntDir>
     <GeneratedFilesDir>$(IntDir)Generated Files\</GeneratedFilesDir>
   </PropertyGroup>
   

--- a/src/HybridCRT.props
+++ b/src/HybridCRT.props
@@ -2,7 +2,7 @@
 <!-- HybridCRT: https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/HybridCRT.md -->
 <!-- 取自 https://github.com/microsoft/WindowsAppSDK/blob/b708422eb1da22a10b56a06c54d7c0759f1683d1/HybridCRT.props -->
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <!-- 使用 MultiThreadedDebug 而不是 MultiThreadedDebugDLL 以避免对 VCRUNTIME140d.dll 和 MSVCP140d.dll 的依赖 -->

--- a/src/Magpie.App/Magpie.App.vcxproj
+++ b/src/Magpie.App/Magpie.App.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
@@ -45,6 +45,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformExtensionSDKLocation(`WindowsDesktop, Version=10.0.22621.0`, $(TargetPlatformIdentifier), $(TargetPlatformVersion),  $(SDKReferenceDirectoryRoot), $(SDKExtensionDirectoryRoot), $(SDKReferenceRegistryRoot)))\DesignTime\CommonConfiguration\Neutral\WindowsDesktop.props" Condition="exists('$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformExtensionSDKLocation(`WindowsDesktop, Version=10.0.22621.0`, $(TargetPlatformIdentifier), $(TargetPlatformVersion),  $(SDKReferenceDirectoryRoot), $(SDKExtensionDirectoryRoot), $(SDKReferenceRegistryRoot)))\DesignTime\CommonConfiguration\Neutral\WindowsDesktop.props')" />
     <Import Project="..\Common.Post.props" />
+    <Import Project="..\WinUI.props" />
     <Import Project="$(SolutionDir)\.conan\$(MSBuildProjectName)\conandeps.props" Condition="Exists('$(SolutionDir)\.conan\$(MSBuildProjectName)\conandeps.props')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -554,18 +555,18 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>这台计算机上缺少此项目引用的 NuGet 程序包。使用“NuGet 程序包还原”可下载这些程序包。有关更多信息，请参见 http://go.microsoft.com/fwlink/?LinkID=322105。缺少的文件是 {0}。</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
 </Project>

--- a/src/Magpie.App/ProfilePage.xaml
+++ b/src/Magpie.App/ProfilePage.xaml
@@ -272,12 +272,6 @@
 						                    Style="{StaticResource ExpanderContentSettingStyle}">
 							<CheckBox x:Uid="Profile_Performance_VSync_TripleBuffering"
 							          IsChecked="{x:Bind ViewModel.IsTripleBuffering, Mode=TwoWay}" />
-							<local:SettingsCard.ActionContent>
-								<!--  使用魔法修复动画错误  -->
-								<ComboBox Width="0"
-								          Height="0"
-								          IsTabStop="False" />
-							</local:SettingsCard.ActionContent>
 						</local:SettingsCard>
 					</muxc:Expander.Content>
 				</muxc:Expander>

--- a/src/Magpie.App/packages.config
+++ b/src/Magpie.App/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.8.2-prerelease.220830001" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2045.28" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2151.40" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
 </packages>

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" />
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
-  <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props')" />
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
@@ -29,6 +29,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\Common.Post.props" />
+    <Import Project="..\WinUI.props" />
     <Import Project="$(SolutionDir)\.conan\$(MSBuildProjectName)\conandeps.props" Condition="Exists('$(SolutionDir)\.conan\$(MSBuildProjectName)\conandeps.props')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -83,18 +84,18 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="XamlIslands.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>这台计算机上缺少此项目引用的 NuGet 程序包。使用“NuGet 程序包还原”可下载这些程序包。有关更多信息，请参见 http://go.microsoft.com/fwlink/?LinkID=322105。缺少的文件是 {0}。</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2045.28\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
 </Project>

--- a/src/Magpie/packages.config
+++ b/src/Magpie/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.8.2-prerelease.220830001" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2045.28" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2151.40" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
 </packages>

--- a/src/WinUI.props
+++ b/src/WinUI.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 根据文档，未打包的 XAML Islands 应用只能使用预发布版本的 WinUI，此文件用于解除这个限制。 -->
+<!-- 正式版 WinUI 打包为 AppX，我们将其解压提取出 dll 和 pri，然后引用它们。预发行版不会做任何操作。 -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- 从 AppX 中提取出 dll 和 pri 并添加引用-->
+  <Target Name="ExtractWinUIRuntime" BeforeTargets="PrepareForBuild">
+    <Exec Command="python $(MSBuildThisFileDirectory)extract_winui_runtime.py $(Platform)" />
+    
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="$(SolutionDir)obj\$(Platform)\WinUI\Microsoft.UI.Xaml.dll" Condition="Exists('$(SolutionDir)obj\$(Platform)\WinUI\Microsoft.UI.Xaml.dll')" />
+      <ReferenceCopyLocalPaths Include="$(SolutionDir)obj\$(Platform)\WinUI\resources.pri" Condition="Exists('$(SolutionDir)obj\$(Platform)\WinUI\resources.pri')" />
+    </ItemGroup>
+  </Target>
+  
+  <!-- 通过修改 pri.resfiles 取消对 WinUI 包中 pri 的引用，否则编译会失败。我们使用从 AppX 中提取出的 pri -->
+  <Target Name="FixResFiles" BeforeTargets="_GenerateProjectPriFileCore">
+    <Exec Command="python $(MSBuildThisFileDirectory)fix_resfiles.py $(IntDir)pri.resfiles" />
+  </Target>
+</Project>

--- a/src/WinUI.props
+++ b/src/WinUI.props
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 根据文档，未打包的 XAML Islands 应用只能使用预发布版本的 WinUI，此文件用于解除这个限制。 -->
-<!-- 正式版 WinUI 打包为 AppX，我们将其解压提取出 dll 和 pri，然后引用它们。预发行版不会做任何操作。 -->
+<!-- 正式版 WinUI 打包为 AppX，我们将其解压提取出 winmd、dll 和 pri，然后引用它们。预发行版不会做任何操作。 -->
+<!-- 这里满是丑陋的 hack，请不要盯着看。 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- 从 AppX 中提取出 dll 和 pri 并添加引用-->
-  <Target Name="ExtractWinUIRuntime" BeforeTargets="PrepareForBuild">
+  <!-- 解压 AppX 并添加引用 -->
+  <Target Name="ExtractAndReferenceWinUIRuntime" BeforeTargets="PrepareForBuild">
     <Exec Command="python $(MSBuildThisFileDirectory)extract_winui_runtime.py $(Platform)" />
     
-    <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(SolutionDir)obj\$(Platform)\WinUI\Microsoft.UI.Xaml.dll" Condition="Exists('$(SolutionDir)obj\$(Platform)\WinUI\Microsoft.UI.Xaml.dll')" />
-      <ReferenceCopyLocalPaths Include="$(SolutionDir)obj\$(Platform)\WinUI\resources.pri" Condition="Exists('$(SolutionDir)obj\$(Platform)\WinUI\resources.pri')" />
+    <ItemGroup Condition="Exists('$(SolutionDir)obj\$(Platform)\WinUI\version.txt')">
+      <ReferenceCopyLocalPaths Include="$(SolutionDir)obj\$(Platform)\WinUI\Microsoft.UI.Xaml.dll" />
+      <ReferenceCopyLocalPaths Include="$(SolutionDir)obj\$(Platform)\WinUI\resources.pri" />
+      
+      <!-- 使 AppxManifest.xml 包含 InProcessServer 元素，这是 XAML Islands 所需要的。见 XamlIslands.targets -->
+      <XamlWinmd Update="@(XamlWinmd)">
+        <SkipHarvestingWinmdRegistration>false</SkipHarvestingWinmdRegistration>
+        <Implementation>Microsoft.UI.Xaml.dll</Implementation>
+      </XamlWinmd>
     </ItemGroup>
   </Target>
   
   <!-- 通过修改 pri.resfiles 取消对 WinUI 包中 pri 的引用，否则编译会失败。我们使用从 AppX 中提取出的 pri -->
-  <Target Name="FixResFiles" BeforeTargets="_GenerateProjectPriFileCore">
+  <Target Name="FixResFiles" BeforeTargets="_GenerateProjectPriFileCore" Condition="Exists('$(SolutionDir)obj\$(Platform)\WinUI\version.txt')">
     <Exec Command="python $(MSBuildThisFileDirectory)fix_resfiles.py $(IntDir)pri.resfiles" />
   </Target>
 </Project>

--- a/src/extract_winui_runtime.py
+++ b/src/extract_winui_runtime.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import glob
+import zipfile
+import shutil
+
+if len(sys.argv) != 2:
+    raise Exception("请勿直接运行此脚本")
+
+platform = sys.argv[1]
+if not platform in ["x64", "ARM64"]:
+    raise Exception("非法参数")
+
+os.chdir(os.path.dirname(__file__) + "\\..\\packages")
+packagesFolder = os.getcwd()
+
+winuiPkg = max(glob.glob("Microsoft.UI.Xaml*"))
+
+intDir = f"..\\obj\\{platform}\\WinUI"
+
+if "prerelease" in winuiPkg:
+    # 预览版本的 WinUI 无需解压
+    shutil.rmtree(intDir, ignore_errors=True)
+else:
+    os.makedirs(intDir, exist_ok=True)
+    os.chdir(intDir)
+
+    needExtract = True
+
+    try:
+        with open("version.txt") as f:
+            if f.read() == winuiPkg:
+                needExtract = False
+    except:
+        pass
+
+    if needExtract:
+        with zipfile.ZipFile(
+            # 取最新的包
+            max(
+                glob.glob(
+                    f"{packagesFolder}\\{winuiPkg}\\tools\\AppX\\{platform}\\Release\\Microsoft.UI.Xaml*.appx"
+                )
+            )
+        ) as appx:
+            # 收集要解压的文件
+            members = ["Microsoft.UI.Xaml.dll", "resources.pri"]
+            # 编译需要 Assets 文件夹，编译完成后会删除它
+            for file in appx.namelist():
+                if file.startswith("Microsoft.UI.Xaml/Assets"):
+                    members.append(file)
+
+            appx.extractall(members=members)
+
+        with open("version.txt", mode="w") as f:
+            f.write(winuiPkg)

--- a/src/fix_resfiles.py
+++ b/src/fix_resfiles.py
@@ -1,0 +1,15 @@
+import sys
+import os
+
+if len(sys.argv) != 2:
+    raise Exception("请勿直接运行此脚本")
+
+with open(sys.argv[1], "r+") as f:
+    lines = []
+    for line in f.readlines():
+        if not "\\packages\\Microsoft.UI.Xaml" in line or "prerelease" in line:
+            lines.append(line)
+
+    f.seek(os.SEEK_SET)
+    f.truncate()
+    f.writelines(lines)


### PR DESCRIPTION
根据[文档](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/xaml-islands#supported-only-with-workarounds)，XAML Islands 在非打包应用中只能使用预发行版本的 WinUI。WinUI 已经很久没有发布过预发行版本了，为了获得最新的修复，应想办法使用正式版本。

直接升级 WinUI 包会导致编译错误，因为正式版和预发行版包的结构不同：预发行版包含 dll、winmd 和 pri，而正式版只包含 AppX。这个 PR 中添加了一些编译脚本，当引用正式版 WinUI 时，提取出 AppX 包中的 dll 和 winmd 并添加对它们的引用。另外还有一些（很多） hack 来防止编译错误。

WinUI 从 2.8.2-prerelease 升级到 2.8.6。