### PR TITLE
几处 UI 优化

### DIFF
--- a/src/Magpie.App/CaptionButtonsControl.cpp
+++ b/src/Magpie.App/CaptionButtonsControl.cpp
@@ -64,7 +64,7 @@ void CaptionButtonsControl::ReleaseButton(CaptionButton button) {
 
 		switch (_pressedButton.value()) {
 		case CaptionButton::Minimize:
-			PostMessage(hwndMain, WM_SYSCOMMAND, SC_MINIMIZE | HTMINBUTTON, 0);
+			PostMessage(hwndMain, WM_SYSCOMMAND, SC_MINIMIZE, 0);
 			break;
 		case CaptionButton::Maximize:
 		{
@@ -74,7 +74,7 @@ void CaptionButtonsControl::ReleaseButton(CaptionButton button) {
 			PostMessage(
 				hwndMain,
 				WM_SYSCOMMAND,
-				(_isWindowMaximized ? SC_RESTORE : SC_MAXIMIZE) | HTMAXBUTTON,
+				_isWindowMaximized ? SC_RESTORE : SC_MAXIMIZE,
 				MAKELPARAM(cursorPos.x, cursorPos.y)
 			);
 			break;

--- a/src/Magpie.App/HomePage.cpp
+++ b/src/Magpie.App/HomePage.cpp
@@ -3,6 +3,13 @@
 #if __has_include("HomePage.g.cpp")
 #include "HomePage.g.cpp"
 #endif
+#include "XamlUtils.h"
 
 namespace winrt::Magpie::App::implementation {
+
+void HomePage::TimerSlider_Loaded(IInspectable const& sender, RoutedEventArgs const&) const {
+	// 修正 Slider 中 Tooltip 的主题
+	XamlUtils::UpdateThemeOfTooltips(sender.as<Controls::Slider>(), ActualTheme());
+}
+
 }

--- a/src/Magpie.App/HomePage.h
+++ b/src/Magpie.App/HomePage.h
@@ -4,6 +4,8 @@
 namespace winrt::Magpie::App::implementation {
 
 struct HomePage : HomePageT<HomePage> {
+	void TimerSlider_Loaded(IInspectable const& sender, RoutedEventArgs const&) const;
+
 	Magpie::App::HomeViewModel ViewModel() const noexcept {
 		return _viewModel;
 	}

--- a/src/Magpie.App/HomePage.xaml
+++ b/src/Magpie.App/HomePage.xaml
@@ -100,6 +100,7 @@
 						                    Style="{StaticResource ExpanderContentSettingStyle}">
 							<local:SettingsCard.ActionContent>
 								<Slider Width="150"
+								        Loaded="TimerSlider_Loaded"
 								        Maximum="5"
 								        Minimum="1"
 								        TickFrequency="1"

--- a/src/Magpie.App/PageFrame.cpp
+++ b/src/Magpie.App/PageFrame.cpp
@@ -51,11 +51,11 @@ void PageFrame::Loaded(IInspectable const&, RoutedEventArgs const&) {
 }
 
 void PageFrame::ScrollViewer_PointerPressed(IInspectable const&, PointerRoutedEventArgs const&) {
-	XamlUtils::CloseXamlPopups(XamlRoot());
+	XamlUtils::CloseComboBoxPopup(XamlRoot());
 }
 
 void PageFrame::ScrollViewer_ViewChanging(IInspectable const&, ScrollViewerViewChangingEventArgs const&) {
-	XamlUtils::CloseXamlPopups(XamlRoot());
+	XamlUtils::CloseComboBoxPopup(XamlRoot());
 }
 
 void PageFrame::ScrollViewer_KeyDown(IInspectable const& sender, KeyRoutedEventArgs const& args) {

--- a/src/Magpie.App/RootPage.cpp
+++ b/src/Magpie.App/RootPage.cpp
@@ -95,7 +95,7 @@ void RootPage::Loaded(IInspectable const&, RoutedEventArgs const&) {
 	IsTabStop(false);
 
 	// 设置 NavigationView 内的 Tooltip 的主题
-	XamlUtils::UpdateThemeOfTooltips(*this, ActualTheme());
+	XamlUtils::UpdateThemeOfTooltips(RootNavigationView(), ActualTheme());
 }
 
 void RootPage::NavigationView_SelectionChanged(
@@ -190,7 +190,7 @@ fire_and_forget RootPage::NavigationView_ItemInvoked(MUXC::NavigationView const&
 	}
 }
 
-void RootPage::ComboBox_DropDownOpened(IInspectable const&, IInspectable const&) {
+void RootPage::ComboBox_DropDownOpened(IInspectable const&, IInspectable const&) const {
 	XamlUtils::UpdateThemeOfXamlPopups(XamlRoot(), ActualTheme());
 }
 

--- a/src/Magpie.App/RootPage.h
+++ b/src/Magpie.App/RootPage.h
@@ -30,7 +30,7 @@ struct RootPage : RootPageT<RootPage> {
 		return _newProfileViewModel;
 	}
 
-	void ComboBox_DropDownOpened(IInspectable const&, IInspectable const&);
+	void ComboBox_DropDownOpened(IInspectable const&, IInspectable const&) const;
 
 	void NewProfileConfirmButton_Click(IInspectable const&, RoutedEventArgs const&);
 

--- a/src/Magpie.App/ScalingModeItem.cpp
+++ b/src/Magpie.App/ScalingModeItem.cpp
@@ -276,7 +276,8 @@ void ScalingModeItem::RenameButton_Click() {
 		return;
 	}
 
-	XamlUtils::CloseXamlPopups(Application::Current().as<App>().RootPage().XamlRoot());
+	// Flyout 没有 IsOpen 可供绑定，只能用变通方法关闭
+	XamlUtils::ClosePopups(Application::Current().as<App>().RootPage().XamlRoot());
 
 	_Data().name = _trimedRenameText;
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"Name"));

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -356,9 +356,9 @@ protected:
 		}
 		case WM_SYSCOMMAND:
 		{
-			// 最小化时关闭 ComboBox
-			// 不能在 WM_SIZE 中处理，该消息发送于最小化之后，会导致 ComboBox 无法交互
-			if (wParam == SC_MINIMIZE && _content) {
+			// 最小化时关闭 ComboBox。不能在 WM_SIZE 中处理，该消息发送于最小化之后，会导致 ComboBox 无法交互
+			// 根据文档，wParam 的低四位供系统内部使用
+			if ((wParam & 0xFFF0) == SC_MINIMIZE && _content) {
 				XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
 			}
 

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -359,7 +359,7 @@ protected:
 			// 最小化时关闭 ComboBox
 			// 不能在 WM_SIZE 中处理，该消息发送于最小化之后，会导致 ComboBox 无法交互
 			if (wParam == SC_MINIMIZE && _content) {
-				XamlUtils::CloseXamlPopups(_content.XamlRoot());
+				XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
 			}
 
 			break;
@@ -370,7 +370,7 @@ protected:
 				if (LOWORD(wParam) != WA_INACTIVE) {
 					SetFocus(_hwndXamlIsland);
 				} else {
-					XamlUtils::CloseXamlPopups(_content.XamlRoot());
+					XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
 				}
 			}
 

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -356,22 +356,32 @@ protected:
 		}
 		case WM_SYSCOMMAND:
 		{
-			// 最小化时关闭 ComboBox。不能在 WM_SIZE 中处理，该消息发送于最小化之后，会导致 ComboBox 无法交互
 			// 根据文档，wParam 的低四位供系统内部使用
-			if ((wParam & 0xFFF0) == SC_MINIMIZE && _content) {
-				XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
+			switch (wParam & 0xFFF0) {
+			case SC_MINIMIZE:
+			{
+				// 最小化前关闭 ComboBox。不能在 WM_SIZE 中处理，该消息发送于最小化之后，会导致 ComboBox 无法交互
+				if (_content) {
+					XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
+				}
+				break;
+			}
+			case SC_KEYMENU:
+			{
+				// 禁用按 Alt 键会激活系统菜单的行为，它使用户界面无法交互
+				if (lParam == 0) {
+					return 0;
+				}
+				break;
+			}
 			}
 
 			break;
 		}
 		case WM_ACTIVATE:
 		{
-			if (_hwndXamlIsland) {
-				if (LOWORD(wParam) != WA_INACTIVE) {
-					SetFocus(_hwndXamlIsland);
-				} else {
-					XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
-				}
+			if (LOWORD(wParam) == WA_INACTIVE && _content) {
+				XamlUtils::CloseComboBoxPopup(_content.XamlRoot());
 			}
 
 			return 0;

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -368,7 +368,7 @@ protected:
 			}
 			case SC_KEYMENU:
 			{
-				// 禁用按 Alt 键会激活系统菜单的行为，它使用户界面无法交互
+				// 禁用按 Alt 键会激活窗口菜单的行为，它使用户界面无法交互
 				if (lParam == 0) {
 					return 0;
 				}

--- a/src/Shared/XamlUtils.cpp
+++ b/src/Shared/XamlUtils.cpp
@@ -12,17 +12,17 @@ using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Media;
 
 
-void XamlUtils::CloseXamlPopups(const XamlRoot& root) {
-	if (!root) {
-		return;
-	}
-
+void XamlUtils::CloseComboBoxPopup(const XamlRoot& root) {
 	for (const auto& popup : VisualTreeHelper::GetOpenPopupsForXamlRoot(root)) {
 		winrt::hstring className = winrt::get_class_name(popup.Child());
-		if (className == winrt::name_of<ContentDialog>() || className == winrt::name_of<Shapes::Rectangle>()) {
-			continue;
+		if (className == winrt::name_of<Canvas>()) {
+			popup.IsOpen(false);
 		}
+	}
+}
 
+void XamlUtils::ClosePopups(const XamlRoot& root) {
+	for (const auto& popup : VisualTreeHelper::GetOpenPopupsForXamlRoot(root)) {
 		popup.IsOpen(false);
 	}
 }
@@ -44,8 +44,7 @@ void XamlUtils::RepositionXamlPopups(const winrt::Windows::UI::Xaml::XamlRoot& r
 		if (closeFlyoutPresenter) {
 			auto className = winrt::get_class_name(popup.Child());
 			if (className == winrt::name_of<winrt::Controls::FlyoutPresenter>() ||
-				className == winrt::name_of<winrt::Controls::MenuFlyoutPresenter>()
-				) {
+				className == winrt::name_of<winrt::Controls::MenuFlyoutPresenter>()) {
 				popup.IsOpen(false);
 				continue;
 			}

--- a/src/Shared/XamlUtils.h
+++ b/src/Shared/XamlUtils.h
@@ -2,7 +2,9 @@
 #include <winrt/Windows.UI.Xaml.h>
 
 struct XamlUtils {
-	static void CloseXamlPopups(const winrt::Windows::UI::Xaml::XamlRoot& root);
+	static void CloseComboBoxPopup(const winrt::Windows::UI::Xaml::XamlRoot& root);
+
+	static void ClosePopups(const winrt::Windows::UI::Xaml::XamlRoot& root);
 
 	static void UpdateThemeOfXamlPopups(
 		const winrt::Windows::UI::Xaml::XamlRoot& root,


### PR DESCRIPTION
1. 修复在页面上点击鼠标或滚动会导致 Toast 关闭的问题，XamlUtils::CloseXamlPopups 的 bug
2. 修复最小化导致 ComboBox 无法交互的问题，这是以前修复过的，但自定义标题栏后又出现了
3. 修复 Alt 键使用户界面无法交互的问题，这也是以前修复过的，不知为何失效了
4. 修复 Win10 中 Slider 的 Tooltip 主题错误