### PR TITLE
修复新配置候选窗口有时会包含不可见的窗口的问题

### DIFF
--- a/src/Magpie.App/NewProfileViewModel.cpp
+++ b/src/Magpie.App/NewProfileViewModel.cpp
@@ -11,8 +11,21 @@
 
 namespace winrt::Magpie::App::implementation {
 
-static bool IsCandidateWindow(HWND hWnd) {
-	if (!IsWindowVisible(hWnd)) {
+// 检查窗口是否可见应查看整个所有者链
+static bool IsWindowAndOwnerVisible(HWND hWnd) noexcept {
+	do {
+		if (!IsWindowVisible(hWnd)) {
+			return false;
+		}
+
+		hWnd = GetWindowOwner(hWnd);
+	} while (hWnd);
+
+	return true;
+}
+
+static bool IsCandidateWindow(HWND hWnd) noexcept {
+	if (!IsWindowAndOwnerVisible(hWnd)) {
 		return false;
 	}
 
@@ -60,7 +73,7 @@ static bool IsCandidateWindow(HWND hWnd) {
 	}
 }
 
-static SmallVector<HWND> GetDesktopWindows() {
+static SmallVector<HWND> GetDesktopWindows() noexcept {
 	SmallVector<HWND> windows;
 	
 	// EnumWindows 可以枚举到 UWP 窗口，官方文档已经过时。无法枚举到全屏状态下的 UWP 窗口


### PR DESCRIPTION
判断窗口是否可见比想象中复杂，我们应查看父窗口链和所有者链，只要其中有一个窗口是隐藏的，该窗口也是隐藏的。[IsWindowVisible](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-iswindowvisible) 不检查所有者窗口，结果不准确。