### PR TITLE
防止窗口启动时不在可见区域

### DIFF
--- a/src/Magpie/MainWindow.h
+++ b/src/Magpie/MainWindow.h
@@ -15,6 +15,8 @@ protected:
 	LRESULT _MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
 
 private:
+	void _CreateWindow(HINSTANCE hInstance, const RECT& windowRect) noexcept;
+
 	void _UpdateTheme();
 
 	static LRESULT CALLBACK _TitleBarWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept;

--- a/src/Magpie/XamlApp.cpp
+++ b/src/Magpie/XamlApp.cpp
@@ -57,8 +57,8 @@ bool XamlApp::Initialize(HINSTANCE hInstance, const wchar_t* arguments) {
 	_mainWndRect = {
 		(int)std::lroundf(options.MainWndRect.X),
 		(int)std::lroundf(options.MainWndRect.Y),
-		(int)std::lroundf(options.MainWndRect.Width),
-		(int)std::lroundf(options.MainWndRect.Height)
+		(int)std::lroundf(options.MainWndRect.X + options.MainWndRect.Width),
+		(int)std::lroundf(options.MainWndRect.Y + options.MainWndRect.Height)
 	};
 	_isMainWndMaximized = options.IsWndMaximized;
 
@@ -137,12 +137,7 @@ void XamlApp::SaveSettings() {
 		WINDOWPLACEMENT wp{};
 		wp.length = sizeof(wp);
 		if (GetWindowPlacement(_mainWindow.Handle(), &wp)) {
-			_mainWndRect = {
-				wp.rcNormalPosition.left,
-				wp.rcNormalPosition.top,
-				wp.rcNormalPosition.right - wp.rcNormalPosition.left,
-				wp.rcNormalPosition.bottom - wp.rcNormalPosition.top
-			};
+			_mainWndRect = wp.rcNormalPosition;
 			_isMainWndMaximized = wp.showCmd == SW_MAXIMIZE;
 		} else {
 			Logger::Get().Win32Error("GetWindowPlacement 失败");

--- a/src/Magpie/XamlApp.h
+++ b/src/Magpie/XamlApp.h
@@ -51,7 +51,6 @@ private:
 	winrt::Magpie::App::App _uwpApp{ nullptr };
 
 	MainWindow _mainWindow;
-	// right 存储宽，bottom 存储高
 	RECT _mainWndRect{};
 	bool _isMainWndMaximized = false;
 };


### PR DESCRIPTION
fix #706

创建主窗口前检查起始位置是否存在屏幕。具体而言检查两个点：

1. 窗口中心点：确保大部分窗口内容可见
2. 上边框中心点：确保大部分标题栏可见

如果窗口不在任何屏幕上，则由 OS 决定启动位置。