### PR TITLE
优化发布脚本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
         description: 'Tag'
         required: false
         type: string
+      prerelease:
+        description: 'Prerelease'
+        required: true
+        type: boolean
 jobs:
   release:
     runs-on: windows-latest
@@ -46,4 +50,5 @@ jobs:
         MINOR: ${{ inputs.minor }}
         PATCH: ${{ inputs.patch }}
         TAG: ${{ inputs.tag }}
+        PRERELEASE: ${{ inputs.prerelease }}
         ACCESS_TOKEN: ${{ secrets.CONTENTS_ACCESS_TOKEN }}


### PR DESCRIPTION
fix #764

1. 修复没有正确上传导致的 zip 损坏
2. 支持发布预览版
3. 自动生成的发行说明为比较两个 tag