### PR TITLE
优化原子操作的性能

### DIFF
--- a/src/Magpie.App/EffectsService.cpp
+++ b/src/Magpie.App/EffectsService.cpp
@@ -99,11 +99,11 @@ fire_and_forget EffectsService::StartInitialize() {
 		_effectsMap.emplace(effect.name, (uint32_t)_effects.size() - 1);
 	}
 
-	_initialized = true;
+	_initialized.store(true, std::memory_order_release);
 }
 
 void EffectsService::WaitForInitialize() {
-	while (!_initialized) {
+	while (!_initialized.load(std::memory_order_acquire)) {
 		Sleep(0);
 	}
 }

--- a/src/Magpie.Core/DesktopDuplicationFrameSource.cpp
+++ b/src/Magpie.Core/DesktopDuplicationFrameSource.cpp
@@ -69,7 +69,7 @@ static winrt::com_ptr<IDXGIOutput1> GetDXGIOutput(HMONITOR hMonitor) {
 }
 
 DesktopDuplicationFrameSource::~DesktopDuplicationFrameSource() {
-	_exiting = true;
+	_exiting.store(true, std::memory_order_release);
 	WaitForSingleObject(_hDDPThread, 1000);
 }
 
@@ -208,7 +208,7 @@ bool DesktopDuplicationFrameSource::Initialize() {
 
 
 FrameSourceBase::UpdateState DesktopDuplicationFrameSource::Update() {
-	UINT newFrameState = _newFrameState.load();
+	const UINT newFrameState = _newFrameState.load(std::memory_order_acquire);
 	if (newFrameState == 2) {
 		// 第一帧之前不渲染
 		return UpdateState::Waiting;
@@ -216,7 +216,7 @@ FrameSourceBase::UpdateState DesktopDuplicationFrameSource::Update() {
 		return UpdateState::NoUpdate;
 	}
 
-	// 不必等待，当 newFrameState 变化时 DDP 线程已将锁释放
+	// 不必等待，当 newFrameState 变化时捕获线程已将锁释放
 	HRESULT hr = _sharedTexMutex->AcquireSync(1, 0);
 	if (hr == static_cast<HRESULT>(WAIT_TIMEOUT)) {
 		return UpdateState::Waiting;
@@ -227,7 +227,8 @@ FrameSourceBase::UpdateState DesktopDuplicationFrameSource::Update() {
 		return UpdateState::Error;
 	}
 
-	_newFrameState.store(0);
+	// 捕获线程不会读取 _newFrameState，因此 relaxed 就够了
+	_newFrameState.store(0, std::memory_order_relaxed);
 
 	MagApp::Get().GetDeviceResources().GetD3DDC()->CopyResource(_output.get(), _sharedTex.get());
 
@@ -291,7 +292,7 @@ DWORD WINAPI DesktopDuplicationFrameSource::_DDPThreadProc(LPVOID lpThreadParame
 	winrt::com_ptr<IDXGIResource> dxgiRes;
 	SmallVector<uint8_t, 0> dupMetaData;
 
-	while (!that._exiting.load()) {
+	while (!that._exiting.load(std::memory_order_acquire)) {
 		if (dxgiRes) {
 			that._outputDup->ReleaseFrame();
 		}
@@ -365,7 +366,7 @@ DWORD WINAPI DesktopDuplicationFrameSource::_DDPThreadProc(LPVOID lpThreadParame
 
 		hr = that._ddpSharedTexMutex->AcquireSync(0, 100);
 		while (hr == static_cast<HRESULT>(WAIT_TIMEOUT)) {
-			if (that._exiting.load()) {
+			if (that._exiting.load(std::memory_order_acquire)) {
 				return 0;
 			}
 
@@ -380,7 +381,7 @@ DWORD WINAPI DesktopDuplicationFrameSource::_DDPThreadProc(LPVOID lpThreadParame
 
 		that._ddpD3dDC->CopySubresourceRegion(that._ddpSharedTex.get(), 0, 0, 0, 0, d3dRes.get(), 0, &that._frameInMonitor);
 		that._ddpSharedTexMutex->ReleaseSync(1);
-		that._newFrameState.store(1);
+		that._newFrameState.store(1, std::memory_order_release);
 	}
 
 	return 0;

--- a/src/Magpie.Core/DesktopDuplicationFrameSource.cpp
+++ b/src/Magpie.Core/DesktopDuplicationFrameSource.cpp
@@ -227,7 +227,7 @@ FrameSourceBase::UpdateState DesktopDuplicationFrameSource::Update() {
 		return UpdateState::Error;
 	}
 
-	// 捕获线程不会读取 _newFrameState，因此 relaxed 就够了
+	// 不需要对捕获线程可见
 	_newFrameState.store(0, std::memory_order_relaxed);
 
 	MagApp::Get().GetDeviceResources().GetD3DDC()->CopyResource(_output.get(), _sharedTex.get());

--- a/src/Magpie.Core/ImGuiImpl.h
+++ b/src/Magpie.Core/ImGuiImpl.h
@@ -30,7 +30,6 @@ private:
 
 	HANDLE _hHookThread = NULL;
 	DWORD _hookThreadId = 0;
-	std::atomic<float> _wheelData = 0;
 };
 
 }

--- a/src/Magpie.Core/MagRuntime.h
+++ b/src/Magpie.Core/MagRuntime.h
@@ -14,7 +14,7 @@ public:
 	~MagRuntime();
 
 	HWND HwndSrc() const {
-		return _running ? _hwndSrc : 0;
+		return _hwndSrc.load(std::memory_order_relaxed);
 	}
 
 	void Run(HWND hwndSrc, const MagOptions& options);
@@ -24,7 +24,7 @@ public:
 	void Stop();
 
 	bool IsRunning() const {
-		return _running;
+		return HwndSrc();
 	}
 
 	// 调用者应处理线程同步
@@ -50,8 +50,8 @@ private:
 	void _EnsureDispatcherQueue() const noexcept;
 
 	std::thread _magWindThread;
-	std::atomic<bool> _running = false;
-	HWND _hwndSrc = 0;
+	// 主线程使用 DispatcherQueue 和缩放线程沟通，因此无需约束内存定序，只需确保原子性即可
+	std::atomic<HWND> _hwndSrc;
 	winrt::Windows::System::DispatcherQueueController _dqc{ nullptr };
 
 	winrt::event<winrt::delegate<bool>> _isRunningChangedEvent;

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -265,7 +265,7 @@ struct TPContext {
 
 static void CALLBACK TPCallback(PTP_CALLBACK_INSTANCE, PVOID context, PTP_WORK) {
 	TPContext* ctxt = (TPContext*)context;
-	uint32_t id = ++ctxt->id;
+	const uint32_t id = ctxt->id.fetch_add(1, std::memory_order_relaxed) + 1;
 	ctxt->func(id);
 }
 


### PR DESCRIPTION
最近学习了原子操作，发现我以前有着很大误解。内存定序不影响原子对象本身，它决定了编译器和 CPU 能否对**其他**变量的读取或写入进行重排。比如释放操作要求该操作前的对其他变量的访问不能重排到该操作后，这就保证了释放操作执行后内存状态和代码字面上一致。

因此原子对象有两个特性：
1. 原子对象的修改始终是原子的，和内存定序无关
2. 可以用于同步对其他变量的访问，这也是自旋锁可以用原子对象实现的原因

重新检查了代码，发现对原子对象的操作全部使用 memory_order_seq_cst 定序，这没有问题，但会影响性能，因为它强制受影响的内存访问传播到每个核心。很多操作对内存定序没有要求，memory_order_relaxed 就足够了。