### PR TITLE
优化 SettingsExpander 的性能

### DIFF
--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -10,56 +10,32 @@
 		<DataTemplate x:Key="EffectParametersFlyout"
 		              x:DataType="local:EffectParametersViewModel">
 			<StackPanel Margin="0,0,0,-17">
-				<ListView x:Name="BoolParamsListView"
-				          MaxWidth="260"
-				          Margin="0,0,0,15"
-				          x:Load="{x:Bind HasBoolParams, Mode=OneTime}"
-				          ItemsSource="{x:Bind BoolParams, Mode=OneTime}"
-				          SelectionMode="None">
-					<ListView.ItemContainerTransitions>
-						<TransitionCollection />
-					</ListView.ItemContainerTransitions>
-					<ListView.Resources>
-						<Style TargetType="ListViewItem">
-							<Setter Property="Margin" Value="0" />
-							<Setter Property="Padding" Value="0" />
-							<Setter Property="MinHeight" Value="0" />
-							<Setter Property="HorizontalContentAlignment" Value="Stretch" />
-							<Setter Property="IsTabStop" Value="False" />
-						</Style>
-					</ListView.Resources>
-					<ListView.ItemTemplate>
+				<ItemsControl x:Name="BoolParamsListView"
+				              MaxWidth="260"
+				              Margin="0,0,0,15"
+				              x:Load="{x:Bind HasBoolParams, Mode=OneTime}"
+				              IsTabStop="False"
+				              ItemsSource="{x:Bind BoolParams, Mode=OneTime}">
+					<ItemsControl.ItemTemplate>
 						<DataTemplate x:DataType="local:ScalingModeBoolParameter">
 							<CheckBox MinWidth="0"
 							          Content="{x:Bind Label, Mode=OneTime}"
 							          IsChecked="{x:Bind Value, Mode=TwoWay}" />
 						</DataTemplate>
-					</ListView.ItemTemplate>
-				</ListView>
-				<ListView x:Name="FloatParamsListView"
-				          Width="260"
-				          Margin="0,0,0,12"
-				          x:Load="{x:Bind HasFloatParams, Mode=OneTime}"
-				          ItemsSource="{x:Bind FloatParams, Mode=OneTime}"
-				          SelectionMode="None">
-					<ListView.Resources>
-						<Style TargetType="ListViewItem">
-							<Setter Property="Margin" Value="0" />
-							<Setter Property="Padding" Value="0" />
-							<Setter Property="MinHeight" Value="0" />
-							<Setter Property="HorizontalContentAlignment" Value="Stretch" />
-							<Setter Property="IsTabStop" Value="False" />
-						</Style>
-					</ListView.Resources>
-					<ListView.ItemContainerTransitions>
-						<TransitionCollection />
-					</ListView.ItemContainerTransitions>
-					<ListView.ItemsPanel>
+					</ItemsControl.ItemTemplate>
+				</ItemsControl>
+				<ItemsControl x:Name="FloatParamsListView"
+				              Width="260"
+				              Margin="0,0,0,12"
+				              x:Load="{x:Bind HasFloatParams, Mode=OneTime}"
+				              IsTabStop="False"
+				              ItemsSource="{x:Bind FloatParams, Mode=OneTime}">
+					<ItemsControl.ItemsPanel>
 						<ItemsPanelTemplate>
 							<StackPanel Spacing="8" />
 						</ItemsPanelTemplate>
-					</ListView.ItemsPanel>
-					<ListView.ItemTemplate>
+					</ItemsControl.ItemsPanel>
+					<ItemsControl.ItemTemplate>
 						<DataTemplate x:DataType="local:ScalingModeFloatParameter">
 							<StackPanel>
 								<Grid ColumnSpacing="4">
@@ -84,8 +60,8 @@
 								        Value="{x:Bind Value, Mode=TwoWay}" />
 							</StackPanel>
 						</DataTemplate>
-					</ListView.ItemTemplate>
-				</ListView>
+					</ItemsControl.ItemTemplate>
+				</ItemsControl>
 			</StackPanel>
 		</DataTemplate>
 	</Page.Resources>
@@ -149,11 +125,9 @@
 					</ListView.Resources>
 					<ListView.ItemTemplate>
 						<DataTemplate x:DataType="local:ScalingModeItem">
-							<local:SettingsExpander CanReorderItems="{x:Bind CanReorderEffects, Mode=OneWay}"
-							                        Description="{x:Bind Description, Mode=OneWay}"
+							<local:SettingsExpander Description="{x:Bind Description, Mode=OneWay}"
 							                        Header="{x:Bind Name, Mode=OneWay}"
-							                        IsExpanded="{x:Bind IsInitialExpanded, Mode=OneTime}"
-							                        ItemsSource="{x:Bind Effects, Mode=OneTime}">
+							                        IsExpanded="{x:Bind IsInitialExpanded, Mode=OneTime}">
 								<StackPanel Orientation="Horizontal"
 								            Spacing="4">
 									<StackPanel.Resources>
@@ -293,163 +267,180 @@
 										</Button.Flyout>
 									</Button>
 								</StackPanel>
-								<local:SettingsExpander.ItemTemplate>
-									<DataTemplate x:DataType="local:ScalingModeEffectItem">
-										<local:SettingsCard Header="{x:Bind Name}"
-										                    Loaded="EffectSettingsCard_Loaded"
-										                    Style="{StaticResource DefaultSettingsExpanderItemStyle}">
-											<StackPanel Orientation="Horizontal">
-												<StackPanel.Resources>
-													<Style BasedOn="{StaticResource DefaultButtonStyle}"
-													       TargetType="Button">
-														<Setter Property="Padding" Value="10" />
-													</Style>
-													<Style TargetType="FontIcon">
-														<Setter Property="FontSize" Value="15" />
-													</Style>
-												</StackPanel.Resources>
-												<Button x:Uid="ScalingConfiguration_ScalingModes_Scale"
-												        Margin="0,0,4,0"
-												        Visibility="{x:Bind CanScale}">
-													<Button.Content>
-														<FontIcon Glyph="&#xE740;" />
-													</Button.Content>
-													<Button.Flyout>
-														<Flyout>
-															<StackPanel Width="260"
-															            Margin="0,0,0,4">
-																<StackPanel.Resources>
-																	<Style TargetType="muxc:NumberBox">
-																		<Setter Property="HorizontalAlignment" Value="Stretch" />
-																		<Setter Property="SpinButtonPlacementMode" Value="Inline" />
-																		<!--  修复有时取消禁用后文字依然为灰色的问题  -->
-																		<Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}" />
-																	</Style>
-																</StackPanel.Resources>
-																<StackPanel Spacing="8">
-																	<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_Type" />
-																	<!--  硬编码会导致崩溃！  -->
-																	<!--  https://github.com/microsoft/microsoft-ui-xaml/issues/3612  -->
-																	<ComboBox HorizontalAlignment="Stretch"
-																	          DropDownOpened="ComboBox_DropDownOpened"
-																	          ItemsSource="{x:Bind ScalingTypes, Mode=OneTime}"
-																	          SelectedIndex="{x:Bind ScalingType, Mode=TwoWay}">
-																		<ComboBox.Resources>
-																			<Style x:Key="Description"
-																			       TargetType="TextBlock">
-																				<Setter Property="FontSize" Value="12" />
-																				<Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
-																				<Setter Property="TextWrapping" Value="WrapWholeWords" />
+								<local:SettingsExpander.Items>
+									<ListView AllowDrop="True"
+									          CanReorderItems="{x:Bind CanReorderEffects, Mode=OneWay}"
+									          ItemsSource="{x:Bind Effects, Mode=OneTime}"
+									          SelectionMode="None"
+											  TabNavigation="Local">
+										<ListView.Resources>
+											<Style TargetType="ListViewItem">
+												<Setter Property="Margin" Value="0" />
+												<Setter Property="Padding" Value="0" />
+												<Setter Property="MinHeight" Value="0" />
+												<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+												<Setter Property="IsTabStop" Value="False" />
+											</Style>
+										</ListView.Resources>
+										<ListView.ItemTemplate>
+											<DataTemplate x:DataType="local:ScalingModeEffectItem">
+												<local:SettingsCard Header="{x:Bind Name}"
+												                    Loaded="EffectSettingsCard_Loaded"
+												                    Style="{StaticResource DefaultSettingsExpanderItemStyle}">
+													<StackPanel Orientation="Horizontal">
+														<StackPanel.Resources>
+															<Style BasedOn="{StaticResource DefaultButtonStyle}"
+															       TargetType="Button">
+																<Setter Property="Padding" Value="10" />
+															</Style>
+															<Style TargetType="FontIcon">
+																<Setter Property="FontSize" Value="15" />
+															</Style>
+														</StackPanel.Resources>
+														<Button x:Uid="ScalingConfiguration_ScalingModes_Scale"
+														        Margin="0,0,4,0"
+														        Visibility="{x:Bind CanScale}">
+															<Button.Content>
+																<FontIcon Glyph="&#xE740;" />
+															</Button.Content>
+															<Button.Flyout>
+																<Flyout>
+																	<StackPanel Width="260"
+																	            Margin="0,0,0,4">
+																		<StackPanel.Resources>
+																			<Style TargetType="muxc:NumberBox">
+																				<Setter Property="HorizontalAlignment" Value="Stretch" />
+																				<Setter Property="SpinButtonPlacementMode" Value="Inline" />
+																				<!--  修复有时取消禁用后文字依然为灰色的问题  -->
+																				<Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}" />
 																			</Style>
-																		</ComboBox.Resources>
-																		<ComboBox.ItemTemplate>
-																			<DataTemplate x:DataType="local:ScalingType">
-																				<StackPanel>
-																					<TextBlock Text="{x:Bind Name, Mode=OneTime}" />
-																					<TextBlock Style="{StaticResource Description}"
-																					           Text="{x:Bind Desc, Mode=OneTime}" />
-																				</StackPanel>
-																			</DataTemplate>
-																		</ComboBox.ItemTemplate>
-																	</ComboBox>
-																</StackPanel>
-																<StackPanel Margin="0,15,0,0"
-																            Spacing="15"
-																            Visibility="{x:Bind IsShowScalingFactors, Mode=OneWay}">
-																	<StackPanel.Resources>
-																		<Style TargetType="muxc:NumberBox">
-																			<Setter Property="HorizontalAlignment" Value="Stretch" />
-																			<Setter Property="SmallChange" Value="0.1" />
-																			<Setter Property="LargeChange" Value="0.5" />
-																			<Setter Property="SpinButtonPlacementMode" Value="Inline" />
+																		</StackPanel.Resources>
+																		<StackPanel Spacing="8">
+																			<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_Type" />
+																			<!--  硬编码会导致崩溃！  -->
+																			<!--  https://github.com/microsoft/microsoft-ui-xaml/issues/3612  -->
+																			<ComboBox HorizontalAlignment="Stretch"
+																			          DropDownOpened="ComboBox_DropDownOpened"
+																			          ItemsSource="{x:Bind ScalingTypes, Mode=OneTime}"
+																			          SelectedIndex="{x:Bind ScalingType, Mode=TwoWay}">
+																				<ComboBox.Resources>
+																					<Style x:Key="Description"
+																					       TargetType="TextBlock">
+																						<Setter Property="FontSize" Value="12" />
+																						<Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+																						<Setter Property="TextWrapping" Value="WrapWholeWords" />
+																					</Style>
+																				</ComboBox.Resources>
+																				<ComboBox.ItemTemplate>
+																					<DataTemplate x:DataType="local:ScalingType">
+																						<StackPanel>
+																							<TextBlock Text="{x:Bind Name, Mode=OneTime}" />
+																							<TextBlock Style="{StaticResource Description}"
+																							           Text="{x:Bind Desc, Mode=OneTime}" />
+																						</StackPanel>
+																					</DataTemplate>
+																				</ComboBox.ItemTemplate>
+																			</ComboBox>
+																		</StackPanel>
+																		<StackPanel Margin="0,15,0,0"
+																		            Spacing="15"
+																		            Visibility="{x:Bind IsShowScalingFactors, Mode=OneWay}">
+																			<StackPanel.Resources>
+																				<Style TargetType="muxc:NumberBox">
+																					<Setter Property="HorizontalAlignment" Value="Stretch" />
+																					<Setter Property="SmallChange" Value="0.1" />
+																					<Setter Property="LargeChange" Value="0.5" />
+																					<Setter Property="SpinButtonPlacementMode" Value="Inline" />
+																				</Style>
+																			</StackPanel.Resources>
+																			<StackPanel Spacing="8">
+																				<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_WidthFactor" />
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
+																				                Value="{x:Bind ScalingFactorX, Mode=TwoWay}" />
+																			</StackPanel>
+																			<StackPanel Spacing="8">
+																				<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_HeightFactor" />
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
+																				                Value="{x:Bind ScalingFactorY, Mode=TwoWay}" />
+																			</StackPanel>
+																		</StackPanel>
+																		<StackPanel Margin="0,15,0,0"
+																		            Spacing="15"
+																		            Visibility="{x:Bind IsShowScalingPixels, Mode=OneWay}">
+																			<StackPanel.Resources>
+																				<Style TargetType="muxc:NumberBox">
+																					<Setter Property="HorizontalAlignment" Value="Stretch" />
+																					<Setter Property="SmallChange" Value="1" />
+																					<Setter Property="LargeChange" Value="10" />
+																					<Setter Property="SpinButtonPlacementMode" Value="Inline" />
+																				</Style>
+																			</StackPanel.Resources>
+																			<StackPanel Spacing="8">
+																				<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_WidthPixels" />
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
+																				                Value="{x:Bind ScalingPixelsX, Mode=TwoWay}" />
+																			</StackPanel>
+																			<StackPanel Spacing="8">
+																				<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_HeightPixels" />
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
+																				                Value="{x:Bind ScalingPixelsY, Mode=TwoWay}" />
+																			</StackPanel>
+																		</StackPanel>
+																	</StackPanel>
+																</Flyout>
+															</Button.Flyout>
+														</Button>
+														<Button x:Uid="ScalingConfiguration_Parameters"
+														        Margin="0,0,4,0"
+														        Visibility="{x:Bind HasParameters}">
+															<Button.Content>
+																<FontIcon Glyph="&#xE9E9;" />
+															</Button.Content>
+															<Button.Flyout>
+																<Flyout>
+																	<Flyout.FlyoutPresenterStyle>
+																		<Style BasedOn="{StaticResource DefaultFlyoutPresenterStyle}"
+																		       TargetType="FlyoutPresenter">
+																			<Setter Property="MaxHeight" Value="450" />
 																		</Style>
-																	</StackPanel.Resources>
-																	<StackPanel Spacing="8">
-																		<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_WidthFactor" />
-																		<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
-																		                Value="{x:Bind ScalingFactorX, Mode=TwoWay}" />
-																	</StackPanel>
-																	<StackPanel Spacing="8">
-																		<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_HeightFactor" />
-																		<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
-																		                Value="{x:Bind ScalingFactorY, Mode=TwoWay}" />
-																	</StackPanel>
-																</StackPanel>
-																<StackPanel Margin="0,15,0,0"
-																            Spacing="15"
-																            Visibility="{x:Bind IsShowScalingPixels, Mode=OneWay}">
-																	<StackPanel.Resources>
-																		<Style TargetType="muxc:NumberBox">
-																			<Setter Property="HorizontalAlignment" Value="Stretch" />
-																			<Setter Property="SmallChange" Value="1" />
-																			<Setter Property="LargeChange" Value="10" />
-																			<Setter Property="SpinButtonPlacementMode" Value="Inline" />
-																		</Style>
-																	</StackPanel.Resources>
-																	<StackPanel Spacing="8">
-																		<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_WidthPixels" />
-																		<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
-																		                Value="{x:Bind ScalingPixelsX, Mode=TwoWay}" />
-																	</StackPanel>
-																	<StackPanel Spacing="8">
-																		<TextBlock x:Uid="ScalingConfiguration_ScalingModes_ScaleFlyout_HeightPixels" />
-																		<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingConfigurationPage.NumberFormatter, Mode=OneTime}"
-																		                Value="{x:Bind ScalingPixelsY, Mode=TwoWay}" />
-																	</StackPanel>
-																</StackPanel>
-															</StackPanel>
-														</Flyout>
-													</Button.Flyout>
-												</Button>
-												<Button x:Uid="ScalingConfiguration_Parameters"
-												        Margin="0,0,4,0"
-												        Visibility="{x:Bind HasParameters}">
-													<Button.Content>
-														<FontIcon Glyph="&#xE9E9;" />
-													</Button.Content>
-													<Button.Flyout>
-														<Flyout>
-															<Flyout.FlyoutPresenterStyle>
-																<Style BasedOn="{StaticResource DefaultFlyoutPresenterStyle}"
-																       TargetType="FlyoutPresenter">
-																	<Setter Property="MaxHeight" Value="450" />
-																</Style>
-															</Flyout.FlyoutPresenterStyle>
-															<ContentControl Content="{x:Bind Parameters, Mode=OneTime}"
-															                ContentTemplate="{StaticResource EffectParametersFlyout}" />
-														</Flyout>
-													</Button.Flyout>
-												</Button>
-												<Button x:Uid="ScalingConfiguration_ScalingModes_Delete"
-												        Click="{x:Bind Remove}">
-													<Button.Content>
-														<FontIcon Glyph="&#xE74D;" />
-													</Button.Content>
-												</Button>
-												<StackPanel Orientation="Horizontal"
-												            Visibility="{x:Bind CanMove, Mode=OneWay}">
-													<AppBarSeparator Margin="4,0,0,0" />
-													<Button x:Uid="ScalingConfiguration_ScalingModes_MoveUp"
-													        Margin="4,0,0,0"
-													        Click="{x:Bind MoveUp}"
-													        IsEnabled="{x:Bind CanMoveUp, Mode=OneWay}">
-														<Button.Content>
-															<FontIcon Glyph="&#xE74A;" />
-														</Button.Content>
-													</Button>
-													<Button x:Uid="ScalingConfiguration_ScalingModes_MoveDown"
-													        Margin="4,0,0,0"
-													        Click="{x:Bind MoveDown}"
-													        IsEnabled="{x:Bind CanMoveDown, Mode=OneWay}">
-														<Button.Content>
-															<FontIcon Glyph="&#xE74B;" />
-														</Button.Content>
-													</Button>
-												</StackPanel>
-											</StackPanel>
-										</local:SettingsCard>
-									</DataTemplate>
-								</local:SettingsExpander.ItemTemplate>
+																	</Flyout.FlyoutPresenterStyle>
+																	<ContentControl Content="{x:Bind Parameters, Mode=OneTime}"
+																	                ContentTemplate="{StaticResource EffectParametersFlyout}" />
+																</Flyout>
+															</Button.Flyout>
+														</Button>
+														<Button x:Uid="ScalingConfiguration_ScalingModes_Delete"
+														        Click="{x:Bind Remove}">
+															<Button.Content>
+																<FontIcon Glyph="&#xE74D;" />
+															</Button.Content>
+														</Button>
+														<StackPanel Orientation="Horizontal"
+														            Visibility="{x:Bind CanMove, Mode=OneWay}">
+															<AppBarSeparator Margin="4,0,0,0" />
+															<Button x:Uid="ScalingConfiguration_ScalingModes_MoveUp"
+															        Margin="4,0,0,0"
+															        Click="{x:Bind MoveUp}"
+															        IsEnabled="{x:Bind CanMoveUp, Mode=OneWay}">
+																<Button.Content>
+																	<FontIcon Glyph="&#xE74A;" />
+																</Button.Content>
+															</Button>
+															<Button x:Uid="ScalingConfiguration_ScalingModes_MoveDown"
+															        Margin="4,0,0,0"
+															        Click="{x:Bind MoveDown}"
+															        IsEnabled="{x:Bind CanMoveDown, Mode=OneWay}">
+																<Button.Content>
+																	<FontIcon Glyph="&#xE74B;" />
+																</Button.Content>
+															</Button>
+														</StackPanel>
+													</StackPanel>
+												</local:SettingsCard>
+											</DataTemplate>
+										</ListView.ItemTemplate>
+									</ListView>
+								</local:SettingsExpander.Items>
 								<local:SettingsExpander.ItemsHeader>
 									<muxc:InfoBar x:Uid="ScalingConfiguration_ScalingModes_HasUnkownEffects"
 									              MinHeight="0"

--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -272,7 +272,7 @@
 									          CanReorderItems="{x:Bind CanReorderEffects, Mode=OneWay}"
 									          ItemsSource="{x:Bind Effects, Mode=OneTime}"
 									          SelectionMode="None"
-											  TabNavigation="Local">
+									          TabNavigation="Local">
 										<ListView.Resources>
 											<Style TargetType="ListViewItem">
 												<Setter Property="Margin" Value="0" />
@@ -405,7 +405,8 @@
 																		</Style>
 																	</Flyout.FlyoutPresenterStyle>
 																	<ContentControl Content="{x:Bind Parameters, Mode=OneTime}"
-																	                ContentTemplate="{StaticResource EffectParametersFlyout}" />
+																	                ContentTemplate="{StaticResource EffectParametersFlyout}"
+																	                IsTabStop="False" />
 																</Flyout>
 															</Button.Flyout>
 														</Button>

--- a/src/Magpie.App/SettingsCard.cpp
+++ b/src/Magpie.App/SettingsCard.cpp
@@ -168,17 +168,6 @@ void SettingsCard::OnPointerReleased(PointerRoutedEventArgs const& args) {
 	if (_isCursorCaptured && IsClickEnabled()) {
 		base_type::OnPointerReleased(args);
 		VisualStateManager::GoToState(*this, _isCursorOnControl ? PointerOverState : NormalState, true);
-	} else {
-		// 修复 SettingsExcpander.Items 中的 SettingsCard 对于鼠标点击会错误设置焦点的问题
-		Dispatcher().TryRunAsync(CoreDispatcherPriority::Normal, [this]() {
-			for (auto parent = VisualTreeHelper::GetParent(*this); parent; parent = VisualTreeHelper::GetParent(parent)) {
-				Control control = parent.try_as<Control>();
-				if (control && control.IsTabStop()) {
-					control.Focus(FocusState::Pointer);
-					break;
-				}
-			}
-		});
 	}
 
 	_isCursorCaptured = false;

--- a/src/Magpie.App/SettingsExpander.cpp
+++ b/src/Magpie.App/SettingsExpander.cpp
@@ -24,7 +24,7 @@ Style SettingsExpanderItemStyleSelector::SelectStyleCore(IInspectable const&, De
 	return _defaultStyle;
 }
 
-static constexpr const wchar_t* PART_ItemsListView = L"PART_ItemsListView";
+static constexpr const wchar_t* PART_ItemsContainer = L"PART_ItemsContainer";
 
 const DependencyProperty SettingsExpander::_headerProperty = DependencyProperty::Register(
 	L"Header",
@@ -103,13 +103,6 @@ const DependencyProperty SettingsExpander::_itemContainerStyleSelectorProperty =
 	nullptr
 );
 
-const DependencyProperty SettingsExpander::_canReorderItemsProperty = DependencyProperty::Register(
-	L"CanReorderItems",
-	xaml_typename<bool>(),
-	xaml_typename<class_type>(),
-	PropertyMetadata(box_value(false))
-);
-
 SettingsExpander::SettingsExpander() {
 	DefaultStyleKey(box_value(GetRuntimeClassName()));
 	Items(single_threaded_vector<IInspectable>());
@@ -135,17 +128,17 @@ void SettingsExpander::_OnItemsConnectedPropertyChanged(DependencyObject const& 
 }
 
 void SettingsExpander::_OnItemsConnectedPropertyChanged() {
-	ListView listView = GetTemplateChild(PART_ItemsListView).as<ListView>();
-	if (!listView) {
+	ItemsControl itemsContainer = GetTemplateChild(PART_ItemsContainer).as<ItemsControl>();
+	if (!itemsContainer) {
 		return;
 	}
 
 	IInspectable datasource = ItemsSource();
-	listView.ItemsSource(datasource ? datasource : Items());
+	itemsContainer.ItemsSource(datasource ? datasource : Items());
 
 	// 应用样式
 	StyleSelector styleSelector = ItemContainerStyleSelector();
-	for (IInspectable item : listView.Items()) {
+	for (IInspectable const& item : itemsContainer.Items()) {
 		SettingsCard element = item.try_as<SettingsCard>();
 		if (!element) {
 			continue;

--- a/src/Magpie.App/SettingsExpander.h
+++ b/src/Magpie.App/SettingsExpander.h
@@ -42,7 +42,6 @@ struct SettingsExpander : SettingsExpander_base<SettingsExpander> {
 	static DependencyProperty ItemsSourceProperty() { return _itemsSourceProperty; }
 	static DependencyProperty ItemTemplateProperty() { return _itemTemplateProperty; }
 	static DependencyProperty ItemContainerStyleSelectorProperty() { return _itemContainerStyleSelectorProperty; }
-	static DependencyProperty CanReorderItemsProperty() { return _canReorderItemsProperty; }
 
 	IInspectable Header() const { return GetValue(_headerProperty); }
 	void Header(IInspectable const& value) const { SetValue(_headerProperty, value); }
@@ -87,9 +86,6 @@ struct SettingsExpander : SettingsExpander_base<SettingsExpander> {
 		SetValue(_itemContainerStyleSelectorProperty, value);
 	}
 
-	bool CanReorderItems() const { return GetValue(_canReorderItemsProperty).as<bool>(); }
-	void CanReorderItems(bool value) const { SetValue(_canReorderItemsProperty, box_value(value)); }
-
 	void OnApplyTemplate();
 
 private:
@@ -104,7 +100,6 @@ private:
 	static const DependencyProperty _itemsSourceProperty;
 	static const DependencyProperty _itemTemplateProperty;
 	static const DependencyProperty _itemContainerStyleSelectorProperty;
-	static const DependencyProperty _canReorderItemsProperty;
 
 	static void _OnIsExpandedChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args);
 	static void _OnItemsConnectedPropertyChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const&);

--- a/src/Magpie.App/SettingsExpander.h
+++ b/src/Magpie.App/SettingsExpander.h
@@ -1,32 +1,7 @@
 ﻿#pragma once
-#include "SettingsExpanderItemStyleSelector.g.h"
 #include "SettingsExpander.g.h"
 
 namespace winrt::Magpie::App::implementation {
-
-struct SettingsExpanderItemStyleSelector : SettingsExpanderItemStyleSelectorT<SettingsExpanderItemStyleSelector> {
-	Style DefaultStyle() const {
-		return _defaultStyle;
-	}
-
-	void DefaultStyle(Style const& value) {
-		_defaultStyle = value;
-	}
-
-	Style ClickableStyle() const {
-		return _clickableStyle;
-	}
-
-	void ClickableStyle(Style const& value) {
-		_clickableStyle = value;
-	}
-
-	Style SelectStyleCore(IInspectable const&, DependencyObject const& container);
-
-private:
-	Style _defaultStyle{ nullptr };
-	Style _clickableStyle{ nullptr };
-};
 
 struct SettingsExpander : SettingsExpander_base<SettingsExpander> {
 	SettingsExpander();
@@ -41,7 +16,6 @@ struct SettingsExpander : SettingsExpander_base<SettingsExpander> {
 	static DependencyProperty ItemsProperty() { return _itemsProperty; }
 	static DependencyProperty ItemsSourceProperty() { return _itemsSourceProperty; }
 	static DependencyProperty ItemTemplateProperty() { return _itemTemplateProperty; }
-	static DependencyProperty ItemContainerStyleSelectorProperty() { return _itemContainerStyleSelectorProperty; }
 
 	IInspectable Header() const { return GetValue(_headerProperty); }
 	void Header(IInspectable const& value) const { SetValue(_headerProperty, value); }
@@ -79,13 +53,6 @@ struct SettingsExpander : SettingsExpander_base<SettingsExpander> {
 	IInspectable ItemTemplate() const { return GetValue(_itemTemplateProperty); }
 	void ItemTemplate(IInspectable const& value) const { SetValue(_itemTemplateProperty, value); }
 
-	Controls::StyleSelector ItemContainerStyleSelector() const {
-		return GetValue(_itemContainerStyleSelectorProperty).as<Controls::StyleSelector>();
-	}
-	void ItemContainerStyleSelector(Controls::StyleSelector const& value) const {
-		SetValue(_itemContainerStyleSelectorProperty, value);
-	}
-
 	void OnApplyTemplate();
 
 private:
@@ -99,7 +66,6 @@ private:
 	static const DependencyProperty _itemsProperty;
 	static const DependencyProperty _itemsSourceProperty;
 	static const DependencyProperty _itemTemplateProperty;
-	static const DependencyProperty _itemContainerStyleSelectorProperty;
 
 	static void _OnIsExpandedChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args);
 	static void _OnItemsConnectedPropertyChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const&);
@@ -113,9 +79,6 @@ private:
 }
 
 namespace winrt::Magpie::App::factory_implementation {
-
-struct SettingsExpanderItemStyleSelector : SettingsExpanderItemStyleSelectorT<SettingsExpanderItemStyleSelector, implementation::SettingsExpanderItemStyleSelector> {
-};
 
 struct SettingsExpander : SettingsExpanderT<SettingsExpander, implementation::SettingsExpander> {
 };

--- a/src/Magpie.App/SettingsExpander.idl
+++ b/src/Magpie.App/SettingsExpander.idl
@@ -1,42 +1,40 @@
 namespace Magpie.App {
-    runtimeclass SettingsExpanderItemStyleSelector : Windows.UI.Xaml.Controls.StyleSelector {
-        SettingsExpanderItemStyleSelector();
-        
-        Windows.UI.Xaml.Style DefaultStyle;
-        Windows.UI.Xaml.Style ClickableStyle;
-    }
+	runtimeclass SettingsExpanderItemStyleSelector : Windows.UI.Xaml.Controls.StyleSelector {
+		SettingsExpanderItemStyleSelector();
+		
+		Windows.UI.Xaml.Style DefaultStyle;
+		Windows.UI.Xaml.Style ClickableStyle;
+	}
 
-    [Windows.UI.Xaml.Markup.ContentProperty("Content")]
-    runtimeclass SettingsExpander : Windows.UI.Xaml.Controls.Control {
-        SettingsExpander();
-        
-        static Windows.UI.Xaml.DependencyProperty HeaderProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty HeaderIconProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ContentProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ItemsHeaderProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ItemsFooterProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty IsExpandedProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ItemsProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty ItemContainerStyleSelectorProperty { get; };
-        static Windows.UI.Xaml.DependencyProperty CanReorderItemsProperty { get; };
+	[Windows.UI.Xaml.Markup.ContentProperty("Content")]
+	runtimeclass SettingsExpander : Windows.UI.Xaml.Controls.Control {
+		SettingsExpander();
+		
+		static Windows.UI.Xaml.DependencyProperty HeaderProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty HeaderIconProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ContentProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ItemsHeaderProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ItemsFooterProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty IsExpandedProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ItemsProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; };
+		static Windows.UI.Xaml.DependencyProperty ItemContainerStyleSelectorProperty { get; };
 
-        Object Header;
-        Object Description;
-        Windows.UI.Xaml.Controls.IconElement HeaderIcon;
-        Object Content;
-        Windows.UI.Xaml.UIElement ItemsHeader;
-        Windows.UI.Xaml.UIElement ItemsFooter;
-        Boolean IsExpanded;
-        IVector<Object> Items;
-        Object ItemsSource;
-        Object ItemTemplate;
-        Windows.UI.Xaml.Controls.StyleSelector ItemContainerStyleSelector;
-        Boolean CanReorderItems;
+		Object Header;
+		Object Description;
+		Windows.UI.Xaml.Controls.IconElement HeaderIcon;
+		Object Content;
+		Windows.UI.Xaml.UIElement ItemsHeader;
+		Windows.UI.Xaml.UIElement ItemsFooter;
+		Boolean IsExpanded;
+		IVector<Object> Items;
+		Object ItemsSource;
+		Object ItemTemplate;
+		Windows.UI.Xaml.Controls.StyleSelector ItemContainerStyleSelector;
 
-        event SignalDelegate Expanded;
-        event SignalDelegate Collapsed;
-    }
+		event SignalDelegate Expanded;
+		event SignalDelegate Collapsed;
+	}
 }

--- a/src/Magpie.App/SettingsExpander.idl
+++ b/src/Magpie.App/SettingsExpander.idl
@@ -1,11 +1,4 @@
 namespace Magpie.App {
-	runtimeclass SettingsExpanderItemStyleSelector : Windows.UI.Xaml.Controls.StyleSelector {
-		SettingsExpanderItemStyleSelector();
-		
-		Windows.UI.Xaml.Style DefaultStyle;
-		Windows.UI.Xaml.Style ClickableStyle;
-	}
-
 	[Windows.UI.Xaml.Markup.ContentProperty("Content")]
 	runtimeclass SettingsExpander : Windows.UI.Xaml.Controls.Control {
 		SettingsExpander();
@@ -20,7 +13,6 @@ namespace Magpie.App {
 		static Windows.UI.Xaml.DependencyProperty ItemsProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; };
-		static Windows.UI.Xaml.DependencyProperty ItemContainerStyleSelectorProperty { get; };
 
 		Object Header;
 		Object Description;
@@ -32,7 +24,6 @@ namespace Magpie.App {
 		IVector<Object> Items;
 		Object ItemsSource;
 		Object ItemTemplate;
-		Windows.UI.Xaml.Controls.StyleSelector ItemContainerStyleSelector;
 
 		event SignalDelegate Expanded;
 		event SignalDelegate Collapsed;

--- a/src/Magpie.App/SettingsExpander.xaml
+++ b/src/Magpie.App/SettingsExpander.xaml
@@ -96,15 +96,8 @@
 									<!--  ItemsRepeater 无法在 XAML Islands 中使用，见 https://github.com/microsoft/microsoft-ui-xaml/issues/2349  -->
 									<ItemsControl x:Name="PART_ItemsContainer"
 									              Grid.Row="1"
-									              AllowDrop="True"
 									              IsTabStop="False"
-									              ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}">
-										<ItemsControl.ItemContainerStyle>
-											<Style TargetType="ContentPresenter">
-												<Setter Property="TabFocusNavigation" Value="Local" />
-											</Style>
-										</ItemsControl.ItemContainerStyle>
-									</ItemsControl>
+									              ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
 									<ContentPresenter Grid.Row="2"
 									                  Content="{TemplateBinding ItemsFooter}" />
 								</Grid>

--- a/src/Magpie.App/SettingsExpander.xaml
+++ b/src/Magpie.App/SettingsExpander.xaml
@@ -34,10 +34,6 @@
 		</Style.Setters>
 	</Style>
 
-	<local:SettingsExpanderItemStyleSelector x:Key="SettingsExpanderItemStyleSelector"
-	                                         ClickableStyle="{StaticResource ClickableSettingsExpanderItemStyle}"
-	                                         DefaultStyle="{StaticResource DefaultSettingsExpanderItemStyle}" />
-
 	<!--  Implicitly applied default style  -->
 	<Style BasedOn="{StaticResource DefaultSettingsExpanderStyle}"
 	       TargetType="local:SettingsExpander" />
@@ -62,7 +58,6 @@
 			<Setter Property="FontWeight" Value="Normal" />
 			<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
 			<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-			<Setter Property="ItemContainerStyleSelector" Value="{StaticResource SettingsExpanderItemStyleSelector}" />
 			<Setter Property="FocusVisualMargin" Value="-3" />
 			<Setter Property="Template">
 				<Setter.Value>

--- a/src/Magpie.App/SettingsExpander.xaml
+++ b/src/Magpie.App/SettingsExpander.xaml
@@ -94,26 +94,17 @@
 									</Grid.RowDefinitions>
 									<ContentPresenter Content="{TemplateBinding ItemsHeader}" />
 									<!--  ItemsRepeater 无法在 XAML Islands 中使用，见 https://github.com/microsoft/microsoft-ui-xaml/issues/2349  -->
-									<ListView x:Name="PART_ItemsListView"
-									          Grid.Row="1"
-									          AllowDrop="True"
-									          CanReorderItems="{TemplateBinding CanReorderItems}"
-									          ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-									          SelectionMode="None"
-									          TabNavigation="Local">
-										<ListView.Resources>
-											<Style TargetType="ListViewItem">
-												<Setter Property="Margin" Value="0" />
-												<Setter Property="Padding" Value="0" />
-												<Setter Property="MinHeight" Value="0" />
-												<Setter Property="HorizontalContentAlignment" Value="Stretch" />
-												<Setter Property="IsTabStop" Value="False" />
+									<ItemsControl x:Name="PART_ItemsContainer"
+									              Grid.Row="1"
+									              AllowDrop="True"
+									              IsTabStop="False"
+									              ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}">
+										<ItemsControl.ItemContainerStyle>
+											<Style TargetType="ContentPresenter">
+												<Setter Property="TabFocusNavigation" Value="Local" />
 											</Style>
-										</ListView.Resources>
-										<ListView.ItemContainerTransitions>
-											<TransitionCollection />
-										</ListView.ItemContainerTransitions>
-									</ListView>
+										</ItemsControl.ItemContainerStyle>
+									</ItemsControl>
 									<ContentPresenter Grid.Row="2"
 									                  Content="{TemplateBinding ItemsFooter}" />
 								</Grid>

--- a/src/Magpie.App/ShortcutDialog.xaml
+++ b/src/Magpie.App/ShortcutDialog.xaml
@@ -24,7 +24,8 @@
 	              Margin="0,64,0,0"
 	              HorizontalAlignment="Center"
 	              VerticalAlignment="Top"
-	              HorizontalContentAlignment="Center">
+	              HorizontalContentAlignment="Center"
+	              IsTabStop="False">
 		<ItemsControl.ItemsPanel>
 			<ItemsPanelTemplate>
 				<StackPanel Orientation="Horizontal"


### PR DESCRIPTION
1. SettingsExpander.Items 的容器从 ListView 换成更轻量的 ItemsControl，这也意味着不支持拖拽排序了，ScalingConfigurationPage 改为使用独立的 ListView。
2. 删除 SettingsExpanderItemStyleSelector，改为直接从资源中检索样式。
3. 删除 SettingsExpander 的 ItemContainerStyleSelector 和 CanReorderItems 属性。
4. ScalingConfigurationPage 的两个 ListView 改为 ItemsControl。
5. 优化 ShortcutDialog 和 ScalingConfigurationPage 的键盘导航。