### PR TITLE
修复空缩放模式导致的崩溃

### DIFF
--- a/src/Magpie.App/SettingsCard.cpp
+++ b/src/Magpie.App/SettingsCard.cpp
@@ -197,15 +197,25 @@ void SettingsCard::_OnIsWrapEnabledChanged(DependencyObject const& sender, Depen
 	get_self<SettingsCard>(sender.as<class_type>())->_OnIsWrapEnabledChanged();
 }
 
+static bool IsNotEmpty(IInspectable const& value) noexcept {
+	if (!value) {
+		return false;
+	}
+
+	// 不知为何空字符串会导致崩溃，因此做额外的检查
+	std::optional<hstring> str = value.try_as<hstring>();
+	return !str || !str->empty();
+}
+
 void SettingsCard::_OnHeaderChanged() const {
 	if (FrameworkElement headerPresenter = GetTemplateChild(HeaderPresenter).try_as<FrameworkElement>()) {
-		headerPresenter.Visibility(Header() ? Visibility::Visible : Visibility::Collapsed);
+		headerPresenter.Visibility(IsNotEmpty(Header()) ? Visibility::Visible : Visibility::Collapsed);
 	}
 }
 
 void SettingsCard::_OnDescriptionChanged() const {
 	if (FrameworkElement descriptionPresenter = GetTemplateChild(DescriptionPresenter).try_as<FrameworkElement>()) {
-		descriptionPresenter.Visibility(Description() ? Visibility::Visible : Visibility::Collapsed);
+		descriptionPresenter.Visibility(IsNotEmpty(Description()) ? Visibility::Visible : Visibility::Collapsed);
 	}
 }
 


### PR DESCRIPTION
不知为何 SettingsCard 的 Header 或 Description 属性为空字符串（`box_value(L"")`）会导致崩溃，这个 PR 添加了额外的检查。