### PR TITLE
动态决定是否检测重复帧

### DIFF
--- a/src/Magpie.App/AboutViewModel.cpp
+++ b/src/Magpie.App/AboutViewModel.cpp
@@ -97,7 +97,7 @@ bool AboutViewModel::IsCheckForPreviewUpdates() const noexcept {
 	return AppSettings::Get().IsCheckForPreviewUpdates();
 }
 
-void AboutViewModel::IsCheckForPreviewUpdates(bool value) noexcept {
+void AboutViewModel::IsCheckForPreviewUpdates(bool value) {
 	AppSettings::Get().IsCheckForPreviewUpdates(value);
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsCheckForPreviewUpdates"));
 }
@@ -115,7 +115,7 @@ bool AboutViewModel::IsAutoCheckForUpdates() const noexcept {
 	return AppSettings::Get().IsAutoCheckForUpdates();
 }
 
-void AboutViewModel::IsAutoCheckForUpdates(bool value) noexcept {
+void AboutViewModel::IsAutoCheckForUpdates(bool value) {
 	AppSettings::Get().IsAutoCheckForUpdates(value);
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsAutoCheckForUpdates"));
 }
@@ -132,7 +132,7 @@ bool AboutViewModel::IsErrorWhileChecking() const noexcept {
 	return UpdateService::Get().Status() == UpdateStatus::ErrorWhileChecking;
 }
 
-void AboutViewModel::IsErrorWhileChecking(bool value) noexcept {
+void AboutViewModel::IsErrorWhileChecking(bool value) {
 	if (!value) {
 		UpdateService& service = UpdateService::Get();
 		if (service.Status() == UpdateStatus::ErrorWhileChecking) {
@@ -147,7 +147,7 @@ bool AboutViewModel::IsNoUpdate() const noexcept {
 	return UpdateService::Get().Status() == UpdateStatus::NoUpdate;
 }
 
-void AboutViewModel::IsNoUpdate(bool value) noexcept {
+void AboutViewModel::IsNoUpdate(bool value) const noexcept {
 	if (!value) {
 		UpdateService& service = UpdateService::Get();
 		if (service.Status() == UpdateStatus::NoUpdate) {
@@ -180,7 +180,7 @@ bool AboutViewModel::IsUpdateCardOpen() const noexcept {
 	return UpdateService::Get().Status() >= UpdateStatus::Available;
 }
 
-void AboutViewModel::IsUpdateCardOpen(bool value) noexcept {
+void AboutViewModel::IsUpdateCardOpen(bool value) {
 	if (!value) {
 		UpdateService& service = UpdateService::Get();
 		UpdateStatus status = service.Status();

--- a/src/Magpie.App/AboutViewModel.h
+++ b/src/Magpie.App/AboutViewModel.h
@@ -27,22 +27,22 @@ struct AboutViewModel : AboutViewModelT<AboutViewModel> {
 	fire_and_forget CheckForUpdates();
 
 	bool IsCheckForPreviewUpdates() const noexcept;
-	void IsCheckForPreviewUpdates(bool value) noexcept;
+	void IsCheckForPreviewUpdates(bool value);
 
 	bool IsCheckForUpdatesButtonEnabled() const noexcept;
 
 	bool IsAutoCheckForUpdates() const noexcept;
-	void IsAutoCheckForUpdates(bool value) noexcept;
+	void IsAutoCheckForUpdates(bool value);
 
 	bool IsAnyUpdateStatus() const noexcept;
 
 	bool IsCheckingForUpdates() const noexcept;
 
 	bool IsErrorWhileChecking() const noexcept;
-	void IsErrorWhileChecking(bool value) noexcept;
+	void IsErrorWhileChecking(bool value);
 
 	bool IsNoUpdate() const noexcept;
-	void IsNoUpdate(bool value) noexcept;
+	void IsNoUpdate(bool value) const noexcept;
 
 	bool IsAvailable() const noexcept;
 
@@ -52,7 +52,7 @@ struct AboutViewModel : AboutViewModelT<AboutViewModel> {
 	bool IsInstalling() const noexcept;
 
 	bool IsUpdateCardOpen() const noexcept;
-	void IsUpdateCardOpen(bool value) noexcept;
+	void IsUpdateCardOpen(bool value);
 
 	bool IsUpdateCardClosable() const noexcept;
 	bool IsCancelButtonVisible() const noexcept;

--- a/src/Magpie.App/AppSettings.cpp
+++ b/src/Magpie.App/AppSettings.cpp
@@ -206,7 +206,7 @@ static bool ShowOkCancelWarningMessage(
 
 AppSettings::~AppSettings() {}
 
-bool AppSettings::Initialize() {
+bool AppSettings::Initialize() noexcept {
 	Logger& logger = Logger::Get();
 
 	// 若程序所在目录存在配置文件则为便携模式
@@ -313,12 +313,12 @@ bool AppSettings::Initialize() {
 	return true;
 }
 
-bool AppSettings::Save() {
+bool AppSettings::Save() noexcept {
 	_UpdateWindowPlacement();
 	return _Save(*this);
 }
 
-fire_and_forget AppSettings::SaveAsync() {
+fire_and_forget AppSettings::SaveAsync() noexcept {
 	_UpdateWindowPlacement();
 
 	// 拷贝当前配置
@@ -328,7 +328,7 @@ fire_and_forget AppSettings::SaveAsync() {
 	_Save(data);
 }
 
-void AppSettings::IsPortableMode(bool value) {
+void AppSettings::IsPortableMode(bool value) noexcept {
 	if (_isPortableMode == value) {
 		return;
 	}
@@ -573,7 +573,7 @@ bool AppSettings::_Save(const _AppSettingsData& data) noexcept {
 }
 
 // 永远不会失败，遇到不合法的配置项时静默忽略
-void AppSettings::_LoadSettings(const rapidjson::GenericObject<true, rapidjson::Value>& root, uint32_t /*version*/) {
+void AppSettings::_LoadSettings(const rapidjson::GenericObject<true, rapidjson::Value>& root, uint32_t /*version*/) noexcept {
 	{
 		std::wstring language;
 		JsonHelper::ReadString(root, "language", language);
@@ -749,7 +749,7 @@ bool AppSettings::_LoadProfile(
 	const rapidjson::GenericObject<true, rapidjson::Value>& profileObj,
 	Profile& profile,
 	bool isDefault
-) const {
+) const noexcept {
 	if (!isDefault) {
 		if (!JsonHelper::ReadString(profileObj, "name", profile.name, true)) {
 			return false;
@@ -883,7 +883,7 @@ bool AppSettings::_LoadProfile(
 	return true;
 }
 
-bool AppSettings::_SetDefaultShortcuts() {
+bool AppSettings::_SetDefaultShortcuts() noexcept {
 	bool changed = false;
 
 	Shortcut& scaleShortcut = _shortcuts[(size_t)ShortcutAction::Scale];
@@ -907,7 +907,7 @@ bool AppSettings::_SetDefaultShortcuts() {
 	return changed;
 }
 
-void AppSettings::_SetDefaultScalingModes() {
+void AppSettings::_SetDefaultScalingModes() noexcept {
 	_scalingModes.resize(7);
 
 	// Lanczos

--- a/src/Magpie.App/AppSettings.cpp
+++ b/src/Magpie.App/AppSettings.cpp
@@ -410,6 +410,8 @@ void AppSettings::IsDeveloperMode(bool value) noexcept {
 		_isFontCacheDisabled = false;
 		_isSaveEffectSources = false;
 		_isWarningsAreErrors = false;
+		_duplicateFrameDetectionMode = DuplicateFrameDetectionMode::Dynamic;
+		_isStatisticsForDynamicDetectionEnabled = false;
 	}
 
 	SaveAsync();

--- a/src/Magpie.App/AppSettings.h
+++ b/src/Magpie.App/AppSettings.h
@@ -6,6 +6,7 @@
 #include <parallel_hashmap/phmap.h>
 #include <rapidjson/document.h>
 #include "Win32Utils.h"
+#include <Magpie.Core.h>
 
 namespace winrt::Magpie::App {
 
@@ -46,13 +47,16 @@ struct _AppSettingsData {
 
 	// 上一次自动检查更新的日期
 	std::chrono::system_clock::time_point _updateCheckDate;
+
+	::Magpie::Core::DuplicateFrameDetectionMode _duplicateFrameDetectionMode =
+		::Magpie::Core::DuplicateFrameDetectionMode::Dynamic;
 	
 	bool _isPortableMode = false;
 	bool _isAlwaysRunAsAdmin = false;
 	bool _isDeveloperMode = false;
 	bool _isDebugMode = false;
-	bool _isDisableEffectCache = false;
-	bool _isDisableFontCache = false;
+	bool _isEffectCacheDisabled = false;
+	bool _isFontCacheDisabled = false;
 	bool _isSaveEffectSources = false;
 	bool _isWarningsAreErrors = false;
 	bool _isAllowScalingMaximized = false;
@@ -63,6 +67,7 @@ struct _AppSettingsData {
 	bool _isMainWindowMaximized = false;
 	bool _isAutoCheckForUpdates = true;
 	bool _isCheckForPreviewUpdates = false;
+	bool _isStatisticsForDynamicDetectionEnabled = false;
 };
 
 class AppSettings : private _AppSettingsData {
@@ -206,21 +211,21 @@ public:
 		SaveAsync();
 	}
 
-	bool IsDisableEffectCache() const noexcept {
-		return _isDisableEffectCache;
+	bool IsEffectCacheDisabled() const noexcept {
+		return _isEffectCacheDisabled;
 	}
 
-	void IsDisableEffectCache(bool value) noexcept {
-		_isDisableEffectCache = value;
+	void IsEffectCacheDisabled(bool value) noexcept {
+		_isEffectCacheDisabled = value;
 		SaveAsync();
 	}
 
-	bool IsDisableFontCache() const noexcept {
-		return _isDisableFontCache;
+	bool IsFontCacheDisabled() const noexcept {
+		return _isFontCacheDisabled;
 	}
 
-	void IsDisableFontCache(bool value) noexcept {
-		_isDisableFontCache = value;
+	void IsFontCacheDisabled(bool value) noexcept {
+		_isFontCacheDisabled = value;
 		SaveAsync();
 	}
 
@@ -348,6 +353,24 @@ public:
 
 	void UpdateCheckDate(std::chrono::system_clock::time_point value) noexcept {
 		_updateCheckDate = value;
+	}
+
+	::Magpie::Core::DuplicateFrameDetectionMode DuplicateFrameDetectionMode() const noexcept {
+		return _duplicateFrameDetectionMode;
+	}
+
+	void DuplicateFrameDetectionMode(::Magpie::Core::DuplicateFrameDetectionMode value) noexcept {
+		_duplicateFrameDetectionMode = value;
+		SaveAsync();
+	}
+
+	bool IsStatisticsForDynamicDetectionEnabled() const noexcept {
+		return _isStatisticsForDynamicDetectionEnabled;
+	}
+
+	void IsStatisticsForDynamicDetectionEnabled(bool value) noexcept {
+		_isStatisticsForDynamicDetectionEnabled = value;
+		SaveAsync();
 	}
 
 private:

--- a/src/Magpie.App/AppSettings.h
+++ b/src/Magpie.App/AppSettings.h
@@ -79,11 +79,11 @@ public:
 
 	virtual ~AppSettings();
 
-	bool Initialize();
+	bool Initialize() noexcept;
 
-	bool Save();
+	bool Save() noexcept;
 
-	fire_and_forget SaveAsync();
+	fire_and_forget SaveAsync() noexcept;
 
 	const std::wstring& ConfigDir() const noexcept {
 		return _configDir;
@@ -93,7 +93,7 @@ public:
 		return _isPortableMode;
 	}
 
-	void IsPortableMode(bool value);
+	void IsPortableMode(bool value) noexcept;
 
 	int Language() const noexcept {
 		return _language;
@@ -382,14 +382,14 @@ private:
 	void _UpdateWindowPlacement() noexcept;
 	bool _Save(const _AppSettingsData& data) noexcept;
 
-	void _LoadSettings(const rapidjson::GenericObject<true, rapidjson::Value>& root, uint32_t version);
+	void _LoadSettings(const rapidjson::GenericObject<true, rapidjson::Value>& root, uint32_t version) noexcept;
 	bool _LoadProfile(
 		const rapidjson::GenericObject<true, rapidjson::Value>& profileObj,
 		Profile& profile,
 		bool isDefault = false
-	) const;
-	bool _SetDefaultShortcuts();
-	void _SetDefaultScalingModes();
+	) const noexcept;
+	bool _SetDefaultShortcuts() noexcept;
+	void _SetDefaultScalingModes() noexcept;
 
 	void _UpdateConfigPath() noexcept;
 

--- a/src/Magpie.App/Profile.h
+++ b/src/Magpie.App/Profile.h
@@ -33,13 +33,13 @@ struct Profile {
 		flags = other.flags;
 	}
 
-	DEFINE_FLAG_ACCESSOR(IsDisableWindowResizing, ::Magpie::Core::ScalingFlags::DisableWindowResizing, flags)
+	DEFINE_FLAG_ACCESSOR(IsWindowResizingDisabled, ::Magpie::Core::ScalingFlags::DisableWindowResizing, flags)
 	DEFINE_FLAG_ACCESSOR(Is3DGameMode, ::Magpie::Core::ScalingFlags::Is3DGameMode, flags)
 	DEFINE_FLAG_ACCESSOR(IsShowFPS, ::Magpie::Core::ScalingFlags::ShowFPS, flags)
 	DEFINE_FLAG_ACCESSOR(IsCaptureTitleBar, ::Magpie::Core::ScalingFlags::CaptureTitleBar, flags)
 	DEFINE_FLAG_ACCESSOR(IsAdjustCursorSpeed, ::Magpie::Core::ScalingFlags::AdjustCursorSpeed, flags)
 	DEFINE_FLAG_ACCESSOR(IsDrawCursor, ::Magpie::Core::ScalingFlags::DrawCursor, flags)
-	DEFINE_FLAG_ACCESSOR(IsDisableDirectFlip, ::Magpie::Core::ScalingFlags::DisableDirectFlip, flags)
+	DEFINE_FLAG_ACCESSOR(IsDirectFlipDisabled, ::Magpie::Core::ScalingFlags::DisableDirectFlip, flags)
 
 	std::wstring name;
 

--- a/src/Magpie.App/ProfilePage.xaml
+++ b/src/Magpie.App/ProfilePage.xaml
@@ -265,7 +265,7 @@
 						<FontIcon Glyph="&#xEE3F;" />
 					</local:SettingsCard.HeaderIcon>
 					<ToggleSwitch x:Uid="ToggleSwitch"
-					              IsOn="{x:Bind ViewModel.IsDisableWindowResizing, Mode=TwoWay}" />
+					              IsOn="{x:Bind ViewModel.IsWindowResizingDisabled, Mode=TwoWay}" />
 				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Profile_SourceWindow_CaptureTitleBar"
 				                    IsEnabled="{x:Bind ViewModel.CanCaptureTitleBar, Mode=OneWay}">
@@ -438,7 +438,7 @@
 				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Profile_Advanced_DisableDirectFlip">
 					<ToggleSwitch x:Uid="ToggleSwitch"
-					              IsOn="{x:Bind ViewModel.IsDisableDirectFlip, Mode=TwoWay}" />
+					              IsOn="{x:Bind ViewModel.IsDirectFlipDisabled, Mode=TwoWay}" />
 				</local:SettingsCard>
 			</local:SettingsGroup>
 		</local:SimpleStackPanel>

--- a/src/Magpie.App/ProfileViewModel.cpp
+++ b/src/Magpie.App/ProfileViewModel.cpp
@@ -582,19 +582,19 @@ void ProfileViewModel::IsShowFPS(bool value) {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsShowFPS"));
 }
 
-bool ProfileViewModel::IsDisableWindowResizing() const noexcept {
-	return _data->IsDisableWindowResizing();
+bool ProfileViewModel::IsWindowResizingDisabled() const noexcept {
+	return _data->IsWindowResizingDisabled();
 }
 
-void ProfileViewModel::IsDisableWindowResizing(bool value) {
-	if (_data->IsDisableWindowResizing() == value) {
+void ProfileViewModel::IsWindowResizingDisabled(bool value) {
+	if (_data->IsWindowResizingDisabled() == value) {
 		return;
 	}
 
-	_data->IsDisableWindowResizing(value);
+	_data->IsWindowResizingDisabled(value);
 	AppSettings::Get().SaveAsync();
 
-	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDisableWindowResizing"));
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsWindowResizingDisabled"));
 }
 
 bool ProfileViewModel::IsCaptureTitleBar() const noexcept {
@@ -791,19 +791,19 @@ void ProfileViewModel::LaunchParameters(const hstring& value) {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"LaunchParameters"));
 }
 
-bool ProfileViewModel::IsDisableDirectFlip() const noexcept {
-	return _data->IsDisableDirectFlip();
+bool ProfileViewModel::IsDirectFlipDisabled() const noexcept {
+	return _data->IsDirectFlipDisabled();
 }
 
-void ProfileViewModel::IsDisableDirectFlip(bool value) {
-	if (_data->IsDisableDirectFlip() == value) {
+void ProfileViewModel::IsDirectFlipDisabled(bool value) {
+	if (_data->IsDirectFlipDisabled() == value) {
 		return;
 	}
 
-	_data->IsDisableDirectFlip(value);
+	_data->IsDirectFlipDisabled(value);
 	AppSettings::Get().SaveAsync();
 
-	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDisableDirectFlip"));
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDirectFlipDisabled"));
 }
 
 fire_and_forget ProfileViewModel::_LoadIcon(FrameworkElement const& rootPage) {

--- a/src/Magpie.App/ProfileViewModel.h
+++ b/src/Magpie.App/ProfileViewModel.h
@@ -103,8 +103,8 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel> {
 	bool IsShowFPS() const noexcept;
 	void IsShowFPS(bool value);
 
-	bool IsDisableWindowResizing() const noexcept;
-	void IsDisableWindowResizing(bool value);
+	bool IsWindowResizingDisabled() const noexcept;
+	void IsWindowResizingDisabled(bool value);
 
 	bool IsCaptureTitleBar() const noexcept;
 	void IsCaptureTitleBar(bool value);
@@ -144,8 +144,8 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel> {
 	hstring LaunchParameters() const noexcept;
 	void LaunchParameters(const hstring& value);
 
-	bool IsDisableDirectFlip() const noexcept;
-	void IsDisableDirectFlip(bool value);
+	bool IsDirectFlipDisabled() const noexcept;
+	void IsDirectFlipDisabled(bool value);
 
 private:
 	fire_and_forget _LoadIcon(FrameworkElement const& rootPage);

--- a/src/Magpie.App/ProfileViewModel.idl
+++ b/src/Magpie.App/ProfileViewModel.idl
@@ -45,7 +45,7 @@ namespace Magpie.App {
 		Boolean IsFrameRateLimiterEnabled;
 		Double MaxFrameRate;
 
-		Boolean IsDisableWindowResizing;
+		Boolean IsWindowResizingDisabled;
 		Boolean IsCaptureTitleBar;
 		Boolean CanCaptureTitleBar { get; };
 
@@ -62,6 +62,6 @@ namespace Magpie.App {
 		Int32 CursorInterpolationMode;
 
 		String LaunchParameters;
-		Boolean IsDisableDirectFlip;
+		Boolean IsDirectFlipDisabled;
 	}
 }

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -763,9 +763,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>Capture method</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync</value>
-  </data>
   <data name="Overlay_FPS_Lock" xml:space="preserve">
     <value>Lock</value>
   </data>

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -832,4 +832,19 @@
   <data name="About_DeveloperModeEnabled" xml:space="preserve">
     <value>Developer mode is enabled.</value>
   </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection.Header" xml:space="preserve">
+    <value>Duplicate frame detection</value>
+  </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection_Always.Content" xml:space="preserve">
+    <value>Always</value>
+  </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection_Dynamic.Content" xml:space="preserve">
+    <value>Dynamic</value>
+  </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
+    <value>Never</value>
+  </data>
+  <data name="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+    <value>Enable statistics for dynamic detection</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -844,4 +844,7 @@
   <data name="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
     <value>Enable statistics for dynamic detection</value>
   </data>
+  <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">
+    <value>Dynamic detection</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-es.resw
+++ b/src/Magpie.App/Resources.language-es.resw
@@ -763,9 +763,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>Método de captura</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync</value>
-  </data>
   <data name="Overlay_FPS_Lock" xml:space="preserve">
     <value>Bloquear</value>
   </data>

--- a/src/Magpie.App/Resources.language-fr.resw
+++ b/src/Magpie.App/Resources.language-fr.resw
@@ -192,9 +192,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>Méthode de capture</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync</value>
-  </data>
   <data name="Overlay_FPS_Opacity" xml:space="preserve">
     <value>Opacitée</value>
   </data>

--- a/src/Magpie.App/Resources.language-it.resw
+++ b/src/Magpie.App/Resources.language-it.resw
@@ -574,9 +574,6 @@
   <data name="ExportDialog_Title" xml:space="preserve">
     <value>Esporta le modalità di ridimensionamento</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync</value>
-  </data>
   <data name="Overlay_FPS_Lock" xml:space="preserve">
     <value>Blocca</value>
   </data>

--- a/src/Magpie.App/Resources.language-ja.resw
+++ b/src/Magpie.App/Resources.language-ja.resw
@@ -760,9 +760,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>キャプチャ方式</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>垂直同期</value>
-  </data>
   <data name="Overlay_FPS_Opacity" xml:space="preserve">
     <value>不透明度</value>
   </data>

--- a/src/Magpie.App/Resources.language-ko.resw
+++ b/src/Magpie.App/Resources.language-ko.resw
@@ -489,9 +489,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>캡처 방식</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>수직동기화</value>
-  </data>
   <data name="Overlay_FPS_Lock" xml:space="preserve">
     <value>잠금</value>
   </data>

--- a/src/Magpie.App/Resources.language-pt-BR.resw
+++ b/src/Magpie.App/Resources.language-pt-BR.resw
@@ -585,9 +585,6 @@
   <data name="Overlay_FPS_Unlock" xml:space="preserve">
     <value>Desfixar</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync</value>
-  </data>
   <data name="Settings_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
     <value>Desativar cache de fonte</value>
   </data>

--- a/src/Magpie.App/Resources.language-ru.resw
+++ b/src/Magpie.App/Resources.language-ru.resw
@@ -766,9 +766,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>Способ захвата</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>Вертикальная синхронизация</value>
-  </data>
   <data name="Overlay_FPS_Lock" xml:space="preserve">
     <value>Заблокировать</value>
   </data>

--- a/src/Magpie.App/Resources.language-tr.resw
+++ b/src/Magpie.App/Resources.language-tr.resw
@@ -793,9 +793,6 @@
   <data name="Overlay_Profiler_Timings_SwitchToEffects" xml:space="preserve">
     <value>Efektleri değiştir</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync Eşitleyici</value>
-  </data>
   <data name="Settings_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
     <value>Yazı tipi önbelleği etkisizleştir</value>
   </data>

--- a/src/Magpie.App/Resources.language-uk.resw
+++ b/src/Magpie.App/Resources.language-uk.resw
@@ -757,9 +757,6 @@
   <data name="Profile_Advanced_LaunchParameters.Header" xml:space="preserve">
     <value>Параметри запуску</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>Вертикальна синхронізація</value>
-  </data>
   <data name="Overlay_FPS_Opacity" xml:space="preserve">
     <value>Прозорість</value>
   </data>

--- a/src/Magpie.App/Resources.language-vi.resw
+++ b/src/Magpie.App/Resources.language-vi.resw
@@ -391,9 +391,6 @@
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
     <value>Tổng cộng</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>VSync</value>
-  </data>
   <data name="Profile_Advanced.Header" xml:space="preserve">
     <value>Nâng cao</value>
   </data>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -844,4 +844,7 @@
   <data name="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
     <value>启用动态检测统计</value>
   </data>
+  <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">
+    <value>动态检测</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -832,4 +832,19 @@
   <data name="About_DeveloperModeEnabled" xml:space="preserve">
     <value>开发者模式已启用。</value>
   </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection.Header" xml:space="preserve">
+    <value>检测重复帧</value>
+  </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection_Always.Content" xml:space="preserve">
+    <value>总是检测</value>
+  </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection_Dynamic.Content" xml:space="preserve">
+    <value>动态检测</value>
+  </data>
+  <data name="Settings_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
+    <value>从不检测</value>
+  </data>
+  <data name="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+    <value>启用动态检测统计</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -763,9 +763,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>捕获方式</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>垂直同步</value>
-  </data>
   <data name="Overlay_FPS_Opacity" xml:space="preserve">
     <value>不透明度</value>
   </data>

--- a/src/Magpie.App/Resources.language-zh-Hant.resw
+++ b/src/Magpie.App/Resources.language-zh-Hant.resw
@@ -760,9 +760,6 @@
   <data name="Overlay_Profiler_CaptureMethod" xml:space="preserve">
     <value>截取方式</value>
   </data>
-  <data name="Overlay_Profiler_VSync" xml:space="preserve">
-    <value>垂直同步</value>
-  </data>
   <data name="Overlay_FPS_Opacity" xml:space="preserve">
     <value>透明度</value>
   </data>

--- a/src/Magpie.App/ScalingConfigurationViewModel.cpp
+++ b/src/Magpie.App/ScalingConfigurationViewModel.cpp
@@ -154,13 +154,13 @@ fire_and_forget ScalingConfigurationViewModel::_AddScalingModes(bool isInitialEx
 	_addingScalingModes = true;
 
 	ScalingModesService& scalingModesService = ScalingModesService::Get();
-	uint32_t total = scalingModesService.GetScalingModeCount();
+	uint32_t _totalSkipped = scalingModesService.GetScalingModeCount();
 	uint32_t curSize = _scalingModes.Size();
 
 	CoreDispatcher dispatcher(nullptr);
 
-	if (total - curSize <= 5) {
-		for (; curSize < total; ++curSize) {
+	if (_totalSkipped - curSize <= 5) {
+		for (; curSize < _totalSkipped; ++curSize) {
 			_scalingModes.Append(ScalingModeItem(curSize, isInitialExpanded));
 		}
 	} else {
@@ -182,14 +182,14 @@ fire_and_forget ScalingConfigurationViewModel::_AddScalingModes(bool isInitialEx
 				co_return;
 			}
 
-			total = scalingModesService.GetScalingModeCount();
+			_totalSkipped = scalingModesService.GetScalingModeCount();
 			curSize = _scalingModes.Size();
 
-			if (curSize < total) {
+			if (curSize < _totalSkipped) {
 				_scalingModes.Append(ScalingModeItem(curSize++, false));
 			}
 			
-			if (curSize >= total) {
+			if (curSize >= _totalSkipped) {
 				break;
 			}
 		}

--- a/src/Magpie.App/ScalingConfigurationViewModel.cpp
+++ b/src/Magpie.App/ScalingConfigurationViewModel.cpp
@@ -154,13 +154,13 @@ fire_and_forget ScalingConfigurationViewModel::_AddScalingModes(bool isInitialEx
 	_addingScalingModes = true;
 
 	ScalingModesService& scalingModesService = ScalingModesService::Get();
-	uint32_t _totalSkipped = scalingModesService.GetScalingModeCount();
+	uint32_t total = scalingModesService.GetScalingModeCount();
 	uint32_t curSize = _scalingModes.Size();
 
 	CoreDispatcher dispatcher(nullptr);
 
-	if (_totalSkipped - curSize <= 5) {
-		for (; curSize < _totalSkipped; ++curSize) {
+	if (total - curSize <= 5) {
+		for (; curSize < total; ++curSize) {
 			_scalingModes.Append(ScalingModeItem(curSize, isInitialExpanded));
 		}
 	} else {
@@ -182,14 +182,14 @@ fire_and_forget ScalingConfigurationViewModel::_AddScalingModes(bool isInitialEx
 				co_return;
 			}
 
-			_totalSkipped = scalingModesService.GetScalingModeCount();
+			total = scalingModesService.GetScalingModeCount();
 			curSize = _scalingModes.Size();
 
-			if (curSize < _totalSkipped) {
+			if (curSize < total) {
 				_scalingModes.Append(ScalingModeItem(curSize++, false));
 			}
 			
-			if (curSize >= _totalSkipped) {
+			if (curSize >= total) {
 				break;
 			}
 		}

--- a/src/Magpie.App/ScalingService.cpp
+++ b/src/Magpie.App/ScalingService.cpp
@@ -315,12 +315,14 @@ bool ScalingService::_StartScale(HWND hWnd, const Profile& profile) {
 	}
 
 	options.IsDebugMode(settings.IsDebugMode());
-	options.IsDisableEffectCache(settings.IsDisableEffectCache());
-	options.IsDisableFontCache(settings.IsDisableFontCache());
+	options.IsEffectCacheDisabled(settings.IsEffectCacheDisabled());
+	options.IsFontCacheDisabled(settings.IsFontCacheDisabled());
 	options.IsSaveEffectSources(settings.IsSaveEffectSources());
 	options.IsWarningsAreErrors(settings.IsWarningsAreErrors());
 	options.IsAllowScalingMaximized(settings.IsAllowScalingMaximized());
 	options.IsSimulateExclusiveFullscreen(settings.IsSimulateExclusiveFullscreen());
+	options.duplicateFrameDetectionMode = settings.DuplicateFrameDetectionMode();
+	options.IsStatisticsForDynamicDetectionEnabled(settings.IsStatisticsForDynamicDetectionEnabled());
 
 	_isAutoScaling = profile.isAutoScale;
 	_scalingRuntime->Start(hWnd, std::move(options));

--- a/src/Magpie.App/ScalingService.h
+++ b/src/Magpie.App/ScalingService.h
@@ -43,7 +43,7 @@ public:
 		});
 	}
 
-	void IsTimerOnChanged(event_token const& token) noexcept {
+	void IsTimerOnChanged(event_token const& token) {
 		_isTimerOnChangedEvent.remove(token);
 	}
 
@@ -64,7 +64,7 @@ public:
 		});
 	}
 
-	void TimerTick(event_token const& token) noexcept {
+	void TimerTick(event_token const& token) {
 		_timerTickEvent.remove(token);
 	}
 
@@ -83,7 +83,7 @@ public:
 		});
 	}
 
-	void WndToRestoreChanged(event_token const& token) noexcept {
+	void WndToRestoreChanged(event_token const& token) {
 		_wndToRestoreChangedEvent.remove(token);
 	}
 
@@ -100,7 +100,7 @@ public:
 		});
 	}
 
-	void IsRunningChanged(event_token const& token) noexcept {
+	void IsRunningChanged(event_token const& token) {
 		_isRunningChangedEvent.remove(token);
 	}
 

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -116,8 +116,8 @@
 				</local:SettingsCard>
 				<local:SettingsExpander x:Name="DeveloperModeExpander"
 				                        x:Uid="Settings_DeveloperOptions"
-				                        IsExpanded="True"
-				                        Visibility="{x:Bind ViewModel.IsDeveloperMode, Mode=OneWay}">
+				                        x:Load="{x:Bind ViewModel.IsDeveloperMode, Mode=OneWay}"
+				                        IsExpanded="True">
 					<local:SettingsExpander.HeaderIcon>
 						<FontIcon Glyph="&#xEC7A;" />
 					</local:SettingsExpander.HeaderIcon>
@@ -132,11 +132,11 @@
 						</local:SettingsCard>
 						<local:SettingsCard ContentAlignment="Left">
 							<CheckBox x:Uid="Settings_DeveloperOptions_DisableEffectCache"
-							          IsChecked="{x:Bind ViewModel.IsDisableEffectCache, Mode=TwoWay}" />
+							          IsChecked="{x:Bind ViewModel.IsEffectCacheDisabled, Mode=TwoWay}" />
 						</local:SettingsCard>
 						<local:SettingsCard ContentAlignment="Left">
 							<CheckBox x:Uid="Settings_DeveloperOptions_DisableFontCache"
-							          IsChecked="{x:Bind ViewModel.IsDisableFontCache, Mode=TwoWay}" />
+							          IsChecked="{x:Bind ViewModel.IsFontCacheDisabled, Mode=TwoWay}" />
 						</local:SettingsCard>
 						<local:SettingsCard ContentAlignment="Left">
 							<CheckBox x:Uid="Settings_DeveloperOptions_SaveEffectSources"
@@ -148,14 +148,17 @@
 						</local:SettingsCard>
 						<local:SettingsCard x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection"
 						                    IsWrapEnabled="True">
-							<ComboBox DropDownOpened="ComboBox_DropDownOpened">
+							<ComboBox DropDownOpened="ComboBox_DropDownOpened"
+							          SelectedIndex="{x:Bind ViewModel.DuplicateFrameDetectionMode, Mode=TwoWay}">
 								<ComboBoxItem x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection_Always" />
 								<ComboBoxItem x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection_Dynamic" />
 								<ComboBoxItem x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection_Never" />
 							</ComboBox>
 						</local:SettingsCard>
-						<local:SettingsCard ContentAlignment="Left">
-							<CheckBox x:Uid="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection" />
+						<local:SettingsCard ContentAlignment="Left"
+						                    IsEnabled="{x:Bind ViewModel.IsDynamicDection, Mode=OneWay}">
+							<CheckBox x:Uid="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection"
+							          IsChecked="{x:Bind ViewModel.IsStatisticsForDynamicDetectionEnabled, Mode=TwoWay}" />
 						</local:SettingsCard>
 					</local:SettingsExpander.Items>
 				</local:SettingsExpander>

--- a/src/Magpie.App/SettingsPage.xaml
+++ b/src/Magpie.App/SettingsPage.xaml
@@ -146,6 +146,17 @@
 							<CheckBox x:Uid="Settings_DeveloperOptions_WarningsAreErrors"
 							          IsChecked="{x:Bind ViewModel.IsWarningsAreErrors, Mode=TwoWay}" />
 						</local:SettingsCard>
+						<local:SettingsCard x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection"
+						                    IsWrapEnabled="True">
+							<ComboBox DropDownOpened="ComboBox_DropDownOpened">
+								<ComboBoxItem x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection_Always" />
+								<ComboBoxItem x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection_Dynamic" />
+								<ComboBoxItem x:Uid="Settings_DeveloperOptions_DuplicateFrameDetection_Never" />
+							</ComboBox>
+						</local:SettingsCard>
+						<local:SettingsCard ContentAlignment="Left">
+							<CheckBox x:Uid="Settings_DeveloperOptions_EnableStatisticsForDynamicDetection" />
+						</local:SettingsCard>
 					</local:SettingsExpander.Items>
 				</local:SettingsExpander>
 			</local:SettingsGroup>

--- a/src/Magpie.App/SettingsViewModel.cpp
+++ b/src/Magpie.App/SettingsViewModel.cpp
@@ -89,7 +89,7 @@ void SettingsViewModel::Theme(int value) {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"Theme"));
 }
 
-void SettingsViewModel::IsRunAtStartup(bool value) noexcept {
+void SettingsViewModel::IsRunAtStartup(bool value) {
 	if (value) {
 		AutoStartHelper::EnableAutoStart(
 			AppSettings::Get().IsAlwaysRunAsAdmin(),

--- a/src/Magpie.App/SettingsViewModel.cpp
+++ b/src/Magpie.App/SettingsViewModel.cpp
@@ -104,7 +104,7 @@ void SettingsViewModel::IsRunAtStartup(bool value) noexcept {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsMinimizeAtStartupEnabled"));
 }
 
-void SettingsViewModel::IsMinimizeAtStartup(bool value) noexcept {
+void SettingsViewModel::IsMinimizeAtStartup(bool value) {
 	if (!_isRunAtStartup) {
 		return;
 	}
@@ -125,7 +125,7 @@ bool SettingsViewModel::IsPortableMode() const noexcept {
 	return AppSettings::Get().IsPortableMode();
 }
 
-void SettingsViewModel::IsPortableMode(bool value) noexcept {
+void SettingsViewModel::IsPortableMode(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsPortableMode() == value) {
@@ -146,7 +146,7 @@ bool SettingsViewModel::IsShowTrayIcon() const noexcept {
 	return AppSettings::Get().IsShowTrayIcon();
 }
 
-void SettingsViewModel::IsShowTrayIcon(bool value) noexcept {
+void SettingsViewModel::IsShowTrayIcon(bool value) {
 	AppSettings::Get().IsShowTrayIcon(value);
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsShowTrayIcon"));
 
@@ -166,7 +166,7 @@ bool SettingsViewModel::IsAlwaysRunAsAdmin() const noexcept {
 	return AppSettings::Get().IsAlwaysRunAsAdmin();
 }
 
-void SettingsViewModel::IsAlwaysRunAsAdmin(bool value) noexcept {
+void SettingsViewModel::IsAlwaysRunAsAdmin(bool value) {
 	AppSettings::Get().IsAlwaysRunAsAdmin(value);
 }
 
@@ -174,7 +174,7 @@ bool SettingsViewModel::IsAllowScalingMaximized() const noexcept {
 	return AppSettings::Get().IsAllowScalingMaximized();
 }
 
-void SettingsViewModel::IsAllowScalingMaximized(bool value) noexcept {
+void SettingsViewModel::IsAllowScalingMaximized(bool value) {
 	AppSettings::Get().IsAllowScalingMaximized(value);
 
 	if (value) {
@@ -186,7 +186,7 @@ bool SettingsViewModel::IsSimulateExclusiveFullscreen() const noexcept {
 	return AppSettings::Get().IsSimulateExclusiveFullscreen();
 }
 
-void SettingsViewModel::IsSimulateExclusiveFullscreen(bool value) noexcept {
+void SettingsViewModel::IsSimulateExclusiveFullscreen(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsSimulateExclusiveFullscreen() == value) {
@@ -201,7 +201,7 @@ bool SettingsViewModel::IsInlineParams() const noexcept {
 	return AppSettings::Get().IsInlineParams();
 }
 
-void SettingsViewModel::IsInlineParams(bool value) noexcept {
+void SettingsViewModel::IsInlineParams(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsInlineParams() == value) {
@@ -216,7 +216,7 @@ bool SettingsViewModel::IsDeveloperMode() const noexcept {
 	return AppSettings::Get().IsDeveloperMode();
 }
 
-void SettingsViewModel::IsDeveloperMode(bool value) noexcept {
+void SettingsViewModel::IsDeveloperMode(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsDeveloperMode() == value) {
@@ -231,7 +231,7 @@ bool SettingsViewModel::IsDebugMode() const noexcept {
 	return AppSettings::Get().IsDebugMode();
 }
 
-void SettingsViewModel::IsDebugMode(bool value) noexcept {
+void SettingsViewModel::IsDebugMode(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsDebugMode() == value) {
@@ -242,41 +242,41 @@ void SettingsViewModel::IsDebugMode(bool value) noexcept {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDebugMode"));
 }
 
-bool SettingsViewModel::IsDisableEffectCache() const noexcept {
-	return AppSettings::Get().IsDisableEffectCache();
+bool SettingsViewModel::IsEffectCacheDisabled() const noexcept {
+	return AppSettings::Get().IsEffectCacheDisabled();
 }
 
-void SettingsViewModel::IsDisableEffectCache(bool value) noexcept {
+void SettingsViewModel::IsEffectCacheDisabled(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
-	if (settings.IsDisableEffectCache() == value) {
+	if (settings.IsEffectCacheDisabled() == value) {
 		return;
 	}
 
-	settings.IsDisableEffectCache(value);
-	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDisableEffectCache"));
+	settings.IsEffectCacheDisabled(value);
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsEffectCacheDisabled"));
 }
 
-bool SettingsViewModel::IsDisableFontCache() const noexcept {
-	return AppSettings::Get().IsDisableFontCache();
+bool SettingsViewModel::IsFontCacheDisabled() const noexcept {
+	return AppSettings::Get().IsFontCacheDisabled();
 }
 
-void SettingsViewModel::IsDisableFontCache(bool value) noexcept {
+void SettingsViewModel::IsFontCacheDisabled(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
-	if (settings.IsDisableFontCache() == value) {
+	if (settings.IsFontCacheDisabled() == value) {
 		return;
 	}
 
-	settings.IsDisableFontCache(value);
-	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDisableFontCache"));
+	settings.IsFontCacheDisabled(value);
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsFontCacheDisabled"));
 }
 
 bool SettingsViewModel::IsSaveEffectSources() const noexcept {
 	return AppSettings::Get().IsSaveEffectSources();
 }
 
-void SettingsViewModel::IsSaveEffectSources(bool value) noexcept {
+void SettingsViewModel::IsSaveEffectSources(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsSaveEffectSources() == value) {
@@ -291,7 +291,7 @@ bool SettingsViewModel::IsWarningsAreErrors() const noexcept {
 	return AppSettings::Get().IsWarningsAreErrors();
 }
 
-void SettingsViewModel::IsWarningsAreErrors(bool value) noexcept {
+void SettingsViewModel::IsWarningsAreErrors(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
 	if (settings.IsWarningsAreErrors() == value) {
@@ -302,7 +302,53 @@ void SettingsViewModel::IsWarningsAreErrors(bool value) noexcept {
 	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsWarningsAreErrors"));
 }
 
-void SettingsViewModel::_UpdateStartupOptions() noexcept {
+int SettingsViewModel::DuplicateFrameDetectionMode() const noexcept {
+	return (int)AppSettings::Get().DuplicateFrameDetectionMode();
+}
+
+void SettingsViewModel::DuplicateFrameDetectionMode(int value) {
+	if (value < 0) {
+		return;
+	}
+
+	const auto mode = (::Magpie::Core::DuplicateFrameDetectionMode)value;
+
+	AppSettings& settings = AppSettings::Get();
+	if (settings.DuplicateFrameDetectionMode() == mode) {
+		return;
+	}
+
+	settings.DuplicateFrameDetectionMode(mode);
+	
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"DuplicateFrameDetectionMode"));
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsDynamicDection"));
+
+	if (mode != ::Magpie::Core::DuplicateFrameDetectionMode::Dynamic) {
+		settings.IsStatisticsForDynamicDetectionEnabled(false);
+		_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsStatisticsForDynamicDetectionEnabled"));
+	}
+}
+
+bool SettingsViewModel::IsDynamicDection() const noexcept {
+	return AppSettings::Get().DuplicateFrameDetectionMode() == ::Magpie::Core::DuplicateFrameDetectionMode::Dynamic;
+}
+
+bool SettingsViewModel::IsStatisticsForDynamicDetectionEnabled() const noexcept {
+	return AppSettings::Get().IsStatisticsForDynamicDetectionEnabled();
+}
+
+void SettingsViewModel::IsStatisticsForDynamicDetectionEnabled(bool value) {
+	AppSettings& settings = AppSettings::Get();
+
+	if (settings.IsStatisticsForDynamicDetectionEnabled() == value) {
+		return;
+	}
+
+	settings.IsStatisticsForDynamicDetectionEnabled(value);
+	_propertyChangedEvent(*this, PropertyChangedEventArgs(L"IsStatisticsForDynamicDetectionEnabled"));
+}
+
+void SettingsViewModel::_UpdateStartupOptions() {
 	std::wstring arguments;
 	_isRunAtStartup = AutoStartHelper::IsAutoStartEnabled(arguments);
 	if (_isRunAtStartup) {

--- a/src/Magpie.App/SettingsViewModel.h
+++ b/src/Magpie.App/SettingsViewModel.h
@@ -21,7 +21,7 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel> {
 		return _isRunAtStartup;
 	}
 
-	void IsRunAtStartup(bool value) noexcept;
+	void IsRunAtStartup(bool value);
 
 	bool IsMinimizeAtStartup() const noexcept {
 		return _isMinimizeAtStartup;

--- a/src/Magpie.App/SettingsViewModel.h
+++ b/src/Magpie.App/SettingsViewModel.h
@@ -27,60 +27,68 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel> {
 		return _isMinimizeAtStartup;
 	}
 
-	void IsMinimizeAtStartup(bool value) noexcept;
+	void IsMinimizeAtStartup(bool value);
 
 	bool IsMinimizeAtStartupEnabled() const noexcept;
 
 	bool IsPortableMode() const noexcept;
-	void IsPortableMode(bool value) noexcept;
+	void IsPortableMode(bool value);
 
 	fire_and_forget OpenConfigLocation() const noexcept;
 
 	bool IsShowTrayIcon() const noexcept;
-	void IsShowTrayIcon(bool value) noexcept;
+	void IsShowTrayIcon(bool value);
 
 	bool IsProcessElevated() const noexcept;
 
 	bool IsAlwaysRunAsAdmin() const noexcept;
-	void IsAlwaysRunAsAdmin(bool value) noexcept;
+	void IsAlwaysRunAsAdmin(bool value);
 
 	bool IsAllowScalingMaximized() const noexcept;
-	void IsAllowScalingMaximized(bool value) noexcept;
+	void IsAllowScalingMaximized(bool value);
 
 	bool IsSimulateExclusiveFullscreen() const noexcept;
-	void IsSimulateExclusiveFullscreen(bool value) noexcept;
+	void IsSimulateExclusiveFullscreen(bool value);
 
 	bool IsInlineParams() const noexcept;
-	void IsInlineParams(bool value) noexcept;
+	void IsInlineParams(bool value);
 
 	bool IsDeveloperMode() const noexcept;
-	void IsDeveloperMode(bool value) noexcept;
+	void IsDeveloperMode(bool value);
 
 	bool IsDebugMode() const noexcept;
-	void IsDebugMode(bool value) noexcept;
+	void IsDebugMode(bool value);
 
-	bool IsDisableEffectCache() const noexcept;
-	void IsDisableEffectCache(bool value) noexcept;
+	bool IsEffectCacheDisabled() const noexcept;
+	void IsEffectCacheDisabled(bool value);
 
-	bool IsDisableFontCache() const noexcept;
-	void IsDisableFontCache(bool value) noexcept;
+	bool IsFontCacheDisabled() const noexcept;
+	void IsFontCacheDisabled(bool value);
 
 	bool IsSaveEffectSources() const noexcept;
-	void IsSaveEffectSources(bool value) noexcept;
+	void IsSaveEffectSources(bool value);
 
 	bool IsWarningsAreErrors() const noexcept;
-	void IsWarningsAreErrors(bool value) noexcept;
+	void IsWarningsAreErrors(bool value);
+
+	int DuplicateFrameDetectionMode() const noexcept;
+	void DuplicateFrameDetectionMode(int value);
+
+	bool IsDynamicDection() const noexcept;
+
+	bool IsStatisticsForDynamicDetectionEnabled() const noexcept;
+	void IsStatisticsForDynamicDetectionEnabled(bool value);
 
 	event_token PropertyChanged(PropertyChangedEventHandler const& handler) {
 		return _propertyChangedEvent.add(handler);
 	}
 
-	void PropertyChanged(event_token const& token) noexcept {
+	void PropertyChanged(event_token const& token) {
 		_propertyChangedEvent.remove(token);
 	}
 
 private:
-	void _UpdateStartupOptions() noexcept;
+	void _UpdateStartupOptions();
 
 	event<PropertyChangedEventHandler> _propertyChangedEvent;
 

--- a/src/Magpie.App/SettingsViewModel.idl
+++ b/src/Magpie.App/SettingsViewModel.idl
@@ -24,9 +24,12 @@ namespace Magpie.App {
 		
 		Boolean IsDeveloperMode;
 		Boolean IsDebugMode;
-		Boolean IsDisableEffectCache;
-		Boolean IsDisableFontCache;
+		Boolean IsEffectCacheDisabled;
+		Boolean IsFontCacheDisabled;
 		Boolean IsSaveEffectSources;
 		Boolean IsWarningsAreErrors;
+		Int32 DuplicateFrameDetectionMode;
+		Boolean IsDynamicDection { get; };
+		Boolean IsStatisticsForDynamicDetectionEnabled;
 	}
 }

--- a/src/Magpie.Core/BicubicEffect.h
+++ b/src/Magpie.Core/BicubicEffect.h
@@ -101,19 +101,19 @@ float4 Pass1(float2 pos) {
 	float3 top = INPUT.Load(int3(coord_top_left, 0)).rgb * rowtaps.x;
 	top += INPUT.SampleLevel(sam, float2(u_middle, uv0.y), 0).rgb * u_weight_sum;
 	top += INPUT.Load(int3(coord_bottom_right.x, coord_top_left.y, 0)).rgb * rowtaps.w;
-	float3 total = top * coltaps.x;
+	float3 _totalSkipped = top * coltaps.x;
 
 	float3 middle = INPUT.SampleLevel(sam, float2(uv0.x, v_middle), 0).rgb * rowtaps.x;
 	middle += INPUT.SampleLevel(sam, float2(u_middle, v_middle), 0).rgb * u_weight_sum;
 	middle += INPUT.SampleLevel(sam, float2(uv3.x, v_middle), 0).rgb * rowtaps.w;
-	total += middle * v_weight_sum;
+	_totalSkipped += middle * v_weight_sum;
 
 	float3 bottom = INPUT.Load(int3(coord_top_left.x, coord_bottom_right.y, 0)).rgb * rowtaps.x;
 	bottom += INPUT.SampleLevel(sam, float2(u_middle, uv3.y), 0).rgb * u_weight_sum;
 	bottom += INPUT.Load(int3(coord_bottom_right, 0)).rgb * rowtaps.w;
-	total += bottom * coltaps.w;
+	_totalSkipped += bottom * coltaps.w;
 
-	return float4(total, 1);
+	return float4(_totalSkipped, 1);
 }
 
 )";

--- a/src/Magpie.Core/BicubicEffect.h
+++ b/src/Magpie.Core/BicubicEffect.h
@@ -101,19 +101,19 @@ float4 Pass1(float2 pos) {
 	float3 top = INPUT.Load(int3(coord_top_left, 0)).rgb * rowtaps.x;
 	top += INPUT.SampleLevel(sam, float2(u_middle, uv0.y), 0).rgb * u_weight_sum;
 	top += INPUT.Load(int3(coord_bottom_right.x, coord_top_left.y, 0)).rgb * rowtaps.w;
-	float3 _totalSkipped = top * coltaps.x;
+	float3 total = top * coltaps.x;
 
 	float3 middle = INPUT.SampleLevel(sam, float2(uv0.x, v_middle), 0).rgb * rowtaps.x;
 	middle += INPUT.SampleLevel(sam, float2(u_middle, v_middle), 0).rgb * u_weight_sum;
 	middle += INPUT.SampleLevel(sam, float2(uv3.x, v_middle), 0).rgb * rowtaps.w;
-	_totalSkipped += middle * v_weight_sum;
+	total += middle * v_weight_sum;
 
 	float3 bottom = INPUT.Load(int3(coord_top_left.x, coord_bottom_right.y, 0)).rgb * rowtaps.x;
 	bottom += INPUT.SampleLevel(sam, float2(u_middle, uv3.y), 0).rgb * u_weight_sum;
 	bottom += INPUT.Load(int3(coord_bottom_right, 0)).rgb * rowtaps.w;
-	_totalSkipped += bottom * coltaps.w;
+	total += bottom * coltaps.w;
 
-	return float4(_totalSkipped, 1);
+	return float4(total, 1);
 }
 
 )";

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -170,7 +170,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 	}
 
 	if (duplicateFrameDetectionMode == DuplicateFrameDetectionMode::Always) {
-		// 总是检测重复帧
+		// 总是检查重复帧
 		if (_IsDuplicateFrame()) {
 			return UpdateState::NoChange;
 		} else {
@@ -179,6 +179,12 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 		}
 	}
 
+	///////////////////////////////////////////////
+	//
+	// 动态检查重复帧，见 #787
+	//
+	///////////////////////////////////////////////
+
 	const bool isStatisticsEnabled = options.IsStatisticsForDynamicDetectionEnabled();
 
 	if (_isCheckingForDuplicateFrame) {
@@ -186,6 +192,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 			_isCheckingForDuplicateFrame = false;
 			_framesLeft = _nextSkipCount;
 			if (_nextSkipCount < MAX_SKIP_COUNT) {
+				// 增加下一次连续跳过检查的帧数
 				++_nextSkipCount;
 			}
 		}
@@ -208,6 +215,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 			_framesLeft = uint32_t((-4 * (int)_nextSkipCount + 78) / 7);
 			
 			if (!isStatisticsEnabled) {
+				// 下一帧将检查重复帧，需要复制此帧
 				d3dDC->CopyResource(_prevFrame.get(), _output.get());
 			}
 		}

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -159,14 +159,14 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 		if (--_framesLeft == 0) {
 			_isCheckingForDuplicateFrames = false;
 			_framesLeft = _nextSkipCount;
-			if (_nextSkipCount < 16) {
+			if (_nextSkipCount < 64) {
 				_nextSkipCount *= 2;
 			}
 		}
 	} else {
 		if (--_framesLeft == 0) {
 			_isCheckingForDuplicateFrames = true;
-			_framesLeft = 4;
+			_framesLeft = _nextSkipCount == 1 ? 8 : 16;
 
 			d3dDC->CopyResource(_prevFrame.get(), _output.get());
 		}
@@ -211,7 +211,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 	if (result == 0) {
 		// 和前一帧相同
 		_isCheckingForDuplicateFrames = true;
-		_framesLeft = 4;
+		_framesLeft = 16;
 		_nextSkipCount = 1;
 		return UpdateState::NoChange;
 	}

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -163,6 +163,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 	}
 
 	if (duplicateFrameDetectionMode == DuplicateFrameDetectionMode::Always) {
+		// 总是检测重复帧
 		if (_IsDuplicateFrame()) {
 			return UpdateState::NoChange;
 		} else {
@@ -216,9 +217,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 			}
 			// 总帧数
 			++statistics.second;
-			_statistics.store(statistics);
-
-			OutputDebugString(fmt::format(L"{}/{}\n", statistics.first, statistics.second).c_str());
+			_statistics.store(statistics, std::memory_order_relaxed);
 		}
 
 		return UpdateState::NewFrame;

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -473,13 +473,11 @@ bool FrameSourceBase::_IsDuplicateFrame() {
 	d3dDC->CopyResource(_readBackBuffer.get(), _resultBuffer.get());
 
 	uint32_t result = 1;
-	{
-		D3D11_MAPPED_SUBRESOURCE ms;
-		HRESULT hr = d3dDC->Map(_readBackBuffer.get(), 0, D3D11_MAP_READ, 0, &ms);
-		if (SUCCEEDED(hr)) {
-			result = *(uint32_t*)ms.pData;
-			d3dDC->Unmap(_readBackBuffer.get(), 0);
-		}
+	D3D11_MAPPED_SUBRESOURCE ms;
+	HRESULT hr = d3dDC->Map(_readBackBuffer.get(), 0, D3D11_MAP_READ, 0, &ms);
+	if (SUCCEEDED(hr)) {
+		result = *(uint32_t*)ms.pData;
+		d3dDC->Unmap(_readBackBuffer.get(), 0);
 	}
 	return result == 0;
 }

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -33,6 +33,8 @@ public:
 	// 因为源窗口可能存在 DPI 缩放，而某些捕获方法无视 DPI 缩放
 	const RECT& SrcRect() const noexcept { return _srcRect; }
 
+	std::pair<uint32_t, uint32_t> GetStatisticsForDynamicDetection() const noexcept;
+
 	virtual const char* Name() const noexcept = 0;
 
 	virtual bool IsScreenCapture() const noexcept = 0;
@@ -81,8 +83,8 @@ private:
 	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
 	uint16_t _nextSkipCount = 1;
 	uint16_t _framesLeft = 16;
-	int _totalSkipped = 0;
-	int _errorCount = 0;
+	// (预测错误帧数/总计跳过帧数)
+	std::atomic<std::pair<uint32_t, uint32_t>> _statistics;
 	bool _isCheckingForDuplicateFrame = true;
 };
 

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -6,7 +6,7 @@ class DeviceResources;
 
 class FrameSourceBase {
 public:
-	FrameSourceBase() noexcept {}
+	FrameSourceBase() noexcept;
 
 	virtual ~FrameSourceBase() noexcept;
 
@@ -81,8 +81,8 @@ private:
 
 	// 用于检查重复帧
 	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
-	uint16_t _nextSkipCount = 1;
-	uint16_t _framesLeft = 16;
+	uint16_t _nextSkipCount;
+	uint16_t _framesLeft;
 	// (预测错误帧数/总计跳过帧数)
 	std::atomic<std::pair<uint32_t, uint32_t>> _statistics;
 	bool _isCheckingForDuplicateFrame = true;

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -71,14 +71,19 @@ protected:
 	winrt::com_ptr<ID3D11ComputeShader> _dupFrameCS;
 	std::pair<uint32_t, uint32_t> _dispatchCount;
 
+	bool _roundCornerDisabled = false;
+	bool _windowResizingDisabled = false;
+
+private:
+	bool _IsDuplicateFrame();
+
 	// 用于检查重复帧
 	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
 	uint16_t _nextSkipCount = 1;
-	uint16_t _framesLeft = 1;
-	bool _isCheckingForDuplicateFrames = false;
-
-	bool _roundCornerDisabled = false;
-	bool _windowResizingDisabled = false;
+	uint16_t _framesLeft = 16;
+	int _totalSkipped = 0;
+	int _errorCount = 0;
+	bool _isCheckingForDuplicateFrame = true;
 };
 
 }

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -83,7 +83,7 @@ private:
 	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
 	uint16_t _nextSkipCount;
 	uint16_t _framesLeft;
-	// (预测错误帧数/总计跳过帧数)
+	// (预测错误帧数, 总计跳过帧数)
 	std::atomic<std::pair<uint32_t, uint32_t>> _statistics;
 	bool _isCheckingForDuplicateFrame = true;
 };

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -66,12 +66,16 @@ protected:
 	DeviceResources* _deviceResources = nullptr;
 	winrt::com_ptr<ID3D11Texture2D> _output;
 
-	// 用于检查重复帧
-	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
 	winrt::com_ptr<ID3D11Buffer> _resultBuffer;
 	winrt::com_ptr<ID3D11Buffer> _readBackBuffer;
 	winrt::com_ptr<ID3D11ComputeShader> _dupFrameCS;
 	std::pair<uint32_t, uint32_t> _dispatchCount;
+
+	// 用于检查重复帧
+	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
+	uint16_t _nextSkipCount = 1;
+	uint16_t _framesLeft = 1;
+	bool _isCheckingForDuplicateFrames = false;
 
 	bool _roundCornerDisabled = false;
 	bool _windowResizingDisabled = false;

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -352,8 +352,8 @@ void OverlayDrawer::_DrawUI() noexcept {
 		options.duplicateFrameDetectionMode == DuplicateFrameDetectionMode::Dynamic) {
 		const std::pair<uint32_t, uint32_t> statistics =
 			renderer.FrameSource().GetStatisticsForDynamicDetection();
-		ImGui::TextUnformatted("动态检测统计: ");
-		ImGui::SameLine();
+		ImGui::TextUnformatted(StrUtils::Concat(_GetResourceString(L"Overlay_Profiler_DynamicDetection"), ": ").c_str());
+		ImGui::SameLine(0, 0);
 		ImGui::PushFont(_fontMonoNumbers);
 		ImGui::TextUnformatted(fmt::format("{}/{} ({:.1f}%)", statistics.first, statistics.second,
 			statistics.second == 0 ? 0.0f : statistics.first * 100.0f / statistics.second).c_str());
@@ -369,7 +369,7 @@ void OverlayDrawer::_EnableSrcWnd(bool /*enable*/) noexcept {
 }
 
 const std::string& OverlayDrawer::_GetResourceString(const std::wstring_view& key) noexcept {
-	static phmap::flat_hash_map<std::wstring, std::string> cache;
+	static phmap::flat_hash_map<std::wstring_view, std::string> cache;
 
 	if (auto it = cache.find(key); it != cache.end()) {
 		return it->second;

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -127,7 +127,7 @@ bool OverlayDrawer::_BuildFonts() noexcept {
 
 	ImFontAtlas& fontAtlas = *ImGui::GetIO().Fonts;
 
-	bool fontCacheDisabled = ScalingWindow::Get().Options().IsDisableFontCache();
+	bool fontCacheDisabled = ScalingWindow::Get().Options().IsFontCacheDisabled();
 	if (!fontCacheDisabled && ImGuiFontsCacheManager::Get().Load(language, fontAtlas)) {
 		_fontUI = fontAtlas.Fonts[0];
 		_fontMonoNumbers = fontAtlas.Fonts[1];

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -348,17 +348,19 @@ void OverlayDrawer::_DrawUI() noexcept {
 	ImGui::TextUnformatted(StrUtils::Concat("GPU: ", _hardwareInfo.gpuName).c_str());
 	const std::string& captureMethodStr = _GetResourceString(L"Overlay_Profiler_CaptureMethod");
 	ImGui::TextUnformatted(StrUtils::Concat(captureMethodStr.c_str(), ": ", renderer.FrameSource().Name()).c_str());
-	ImGui::PopTextWrapPos();
-
 	if (options.IsStatisticsForDynamicDetectionEnabled() &&
 		options.duplicateFrameDetectionMode == DuplicateFrameDetectionMode::Dynamic) {
-		ImGui::Spacing();
-		if (ImGui::CollapsingHeader("动态检测统计", ImGuiTreeNodeFlags_DefaultOpen)) {
-			const std::pair<uint32_t, uint32_t> statistics =
-				renderer.FrameSource().GetStatisticsForDynamicDetection();
-			ImGui::TextUnformatted(fmt::format("{}/{}", statistics.first, statistics.second).c_str());
-		}
+		const std::pair<uint32_t, uint32_t> statistics =
+			renderer.FrameSource().GetStatisticsForDynamicDetection();
+		ImGui::TextUnformatted("动态检测统计: ");
+		ImGui::SameLine();
+		ImGui::PushFont(_fontMonoNumbers);
+		ImGui::TextUnformatted(fmt::format("{}/{} ({:.1f}%)", statistics.first, statistics.second,
+			statistics.second == 0 ? 0.0f : statistics.first * 100.0f / statistics.second).c_str());
+		ImGui::PopFont();
 	}
+	ImGui::PopTextWrapPos();
+	
 
 	ImGui::End();
 }

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -351,7 +351,7 @@ static std::optional<EffectDesc> CompileEffect(const EffectOption& effectOption)
 
 	uint32_t compileFlag = 0;
 	const ScalingOptions& scalingOptions = ScalingWindow::Get().Options();
-	if (scalingOptions.IsDisableEffectCache()) {
+	if (scalingOptions.IsEffectCacheDisabled()) {
 		compileFlag |= EffectCompilerFlags::NoCache;
 	}
 	if (scalingOptions.IsSaveEffectSources()) {

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -7,6 +7,8 @@
 
 namespace Magpie::Core {
 
+class FrameSourceBase;
+
 class Renderer {
 public:
 	Renderer() noexcept;
@@ -30,6 +32,10 @@ public:
 	// 屏幕坐标而不是窗口局部坐标
 	const RECT& DestRect() const noexcept {
 		return _destRect;
+	}
+
+	const FrameSourceBase& FrameSource() const noexcept {
+		return *_frameSource;
 	}
 
 	void OnCursorVisibilityChanged(bool isVisible);
@@ -76,7 +82,7 @@ private:
 	
 	// 只能由后台线程访问
 	DeviceResources _backendResources;
-	std::unique_ptr<class FrameSourceBase> _frameSource;
+	std::unique_ptr<FrameSourceBase> _frameSource;
 	std::vector<EffectDrawer> _effectDrawers;
 
 	StepTimer _stepTimer;

--- a/src/Magpie.Core/ScalingOptions.h
+++ b/src/Magpie.Core/ScalingOptions.h
@@ -43,6 +43,7 @@ struct ScalingFlags {
 	static constexpr const uint32_t DisableDirectFlip = 1 << 13;
 	static constexpr const uint32_t DisableFontCache = 1 << 14;
 	static constexpr const uint32_t AllowScalingMaximized = 1 << 15;
+	static constexpr const uint32_t EnableStatisticsForDynamicDetection = 1 << 16;
 };
 
 enum class ScalingType {
@@ -70,11 +71,17 @@ struct EffectOption {
 	}
 };
 
+enum class DuplicateFrameDetectionMode {
+	Always,
+	Dynamic,
+	Never
+};
+
 struct ScalingOptions {
-	DEFINE_FLAG_ACCESSOR(IsDisableWindowResizing, ScalingFlags::DisableWindowResizing, flags)
+	DEFINE_FLAG_ACCESSOR(IsWindowResizingDisabled, ScalingFlags::DisableWindowResizing, flags)
 	DEFINE_FLAG_ACCESSOR(IsDebugMode, ScalingFlags::BreakpointMode, flags)
-	DEFINE_FLAG_ACCESSOR(IsDisableEffectCache, ScalingFlags::DisableEffectCache, flags)
-	DEFINE_FLAG_ACCESSOR(IsDisableFontCache, ScalingFlags::DisableFontCache, flags)
+	DEFINE_FLAG_ACCESSOR(IsEffectCacheDisabled, ScalingFlags::DisableEffectCache, flags)
+	DEFINE_FLAG_ACCESSOR(IsFontCacheDisabled, ScalingFlags::DisableFontCache, flags)
 	DEFINE_FLAG_ACCESSOR(IsSaveEffectSources, ScalingFlags::SaveEffectSources, flags)
 	DEFINE_FLAG_ACCESSOR(IsWarningsAreErrors, ScalingFlags::WarningsAreErrors, flags)
 	DEFINE_FLAG_ACCESSOR(IsAllowScalingMaximized, ScalingFlags::AllowScalingMaximized, flags)
@@ -84,7 +91,8 @@ struct ScalingOptions {
 	DEFINE_FLAG_ACCESSOR(IsCaptureTitleBar, ScalingFlags::CaptureTitleBar, flags)
 	DEFINE_FLAG_ACCESSOR(IsAdjustCursorSpeed, ScalingFlags::AdjustCursorSpeed, flags)
 	DEFINE_FLAG_ACCESSOR(IsDrawCursor, ScalingFlags::DrawCursor, flags)
-	DEFINE_FLAG_ACCESSOR(IsDisableDirectFlip, ScalingFlags::DisableDirectFlip, flags)
+	DEFINE_FLAG_ACCESSOR(IsDirectFlipDisabled, ScalingFlags::DisableDirectFlip, flags)
+	DEFINE_FLAG_ACCESSOR(IsStatisticsForDynamicDetectionEnabled, ScalingFlags::EnableStatisticsForDynamicDetection, flags)
 
 	Cropping cropping{};
 	uint32_t flags = ScalingFlags::AdjustCursorSpeed | ScalingFlags::DrawCursor;	// ScalingFlags
@@ -96,6 +104,8 @@ struct ScalingOptions {
 	CursorInterpolationMode cursorInterpolationMode = CursorInterpolationMode::NearestNeighbor;
 
 	std::vector<EffectOption> effects;
+
+	DuplicateFrameDetectionMode duplicateFrameDetectionMode = DuplicateFrameDetectionMode::Dynamic;
 };
 
 }

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -135,7 +135,7 @@ bool Win32Utils::ReadFile(const wchar_t* fileName, std::vector<BYTE>& result) {
 	return true;
 }
 
-bool Win32Utils::ReadTextFile(const wchar_t* fileName, std::string& result) {
+bool Win32Utils::ReadTextFile(const wchar_t* fileName, std::string& result) noexcept {
 	FILE* hFile;
 	if (_wfopen_s(&hFile, fileName, L"rt") || !hFile) {
 		Logger::Get().Error(StrUtils::Concat("打开文件 ", StrUtils::UTF16ToUTF8(fileName), " 失败"));
@@ -156,7 +156,7 @@ bool Win32Utils::ReadTextFile(const wchar_t* fileName, std::string& result) {
 	return true;
 }
 
-bool Win32Utils::WriteFile(const wchar_t* fileName, const void* buffer, size_t bufferSize) {
+bool Win32Utils::WriteFile(const wchar_t* fileName, const void* buffer, size_t bufferSize) noexcept {
 	FILE* hFile;
 	if (_wfopen_s(&hFile, fileName, L"wb") || !hFile) {
 		Logger::Get().Error(StrUtils::Concat("打开文件 ", StrUtils::UTF16ToUTF8(fileName), " 失败"));
@@ -172,7 +172,7 @@ bool Win32Utils::WriteFile(const wchar_t* fileName, const void* buffer, size_t b
 	return true;
 }
 
-bool Win32Utils::WriteTextFile(const wchar_t* fileName, std::string_view text) {
+bool Win32Utils::WriteTextFile(const wchar_t* fileName, std::string_view text) noexcept {
 	FILE* hFile;
 	if (_wfopen_s(&hFile, fileName, L"wt") || !hFile) {
 		Logger::Get().Error(StrUtils::Concat("打开文件 ", StrUtils::UTF16ToUTF8(fileName), " 失败"));
@@ -185,7 +185,7 @@ bool Win32Utils::WriteTextFile(const wchar_t* fileName, std::string_view text) {
 	return true;
 }
 
-bool Win32Utils::CreateDir(const std::wstring& path, bool recursive) {
+bool Win32Utils::CreateDir(const std::wstring& path, bool recursive) noexcept {
 	if (DirExists(path.c_str())) {
 		return true;
 	}
@@ -260,7 +260,7 @@ static void CALLBACK TPCallback(PTP_CALLBACK_INSTANCE, PVOID context, PTP_WORK) 
 
 #pragma warning(pop) 
 
-void Win32Utils::RunParallel(std::function<void(uint32_t)> func, uint32_t times) {
+void Win32Utils::RunParallel(std::function<void(uint32_t)> func, uint32_t times) noexcept {
 #ifdef _DEBUG
 	// 为了便于调试，DEBUG 模式下不使用线程池
 	for (UINT i = 0; i < times; ++i) {
@@ -298,7 +298,7 @@ void Win32Utils::RunParallel(std::function<void(uint32_t)> func, uint32_t times)
 #endif // _DEBUG
 }
 
-bool Win32Utils::SetForegroundWindow(HWND hWnd) {
+bool Win32Utils::SetForegroundWindow(HWND hWnd) noexcept {
 	if (::SetForegroundWindow(hWnd)) {
 		return true;
 	}

--- a/src/Shared/Win32Utils.h
+++ b/src/Shared/Win32Utils.h
@@ -22,11 +22,11 @@ struct Win32Utils {
 
 	static bool ReadFile(const wchar_t* fileName, std::vector<BYTE>& result);
 
-	static bool ReadTextFile(const wchar_t* fileName, std::string& result);
+	static bool ReadTextFile(const wchar_t* fileName, std::string& result) noexcept;
 
-	static bool WriteFile(const wchar_t* fileName, const void* buffer, size_t bufferSize);
+	static bool WriteFile(const wchar_t* fileName, const void* buffer, size_t bufferSize) noexcept;
 
-	static bool WriteTextFile(const wchar_t* fileName, std::string_view text);
+	static bool WriteTextFile(const wchar_t* fileName, std::string_view text) noexcept;
 
 	static bool FileExists(const wchar_t* fileName) noexcept {
 		DWORD attrs = GetFileAttributes(fileName);
@@ -39,7 +39,7 @@ struct Win32Utils {
 		return (attrs != INVALID_FILE_ATTRIBUTES) && (attrs & FILE_ATTRIBUTE_DIRECTORY);
 	}
 
-	static bool CreateDir(const std::wstring& path, bool recursive = false);
+	static bool CreateDir(const std::wstring& path, bool recursive = false) noexcept;
 
 	struct OSVersion : Version {
 		constexpr OSVersion() {}
@@ -145,10 +145,10 @@ struct Win32Utils {
 
 	// 并行执行 times 次 func，并行失败时回退到单线程
 	// 执行完毕后返回
-	static void RunParallel(std::function<void(uint32_t)> func, uint32_t times);
+	static void RunParallel(std::function<void(uint32_t)> func, uint32_t times) noexcept;
 
 	// 强制切换前台窗口
-	static bool SetForegroundWindow(HWND hWnd);
+	static bool SetForegroundWindow(HWND hWnd) noexcept;
 
 	// 获取 Virtual Key 的名字
 	static const std::wstring& GetKeyName(uint8_t key);


### PR DESCRIPTION
对于静态内容检测重复帧可以极大降低功耗，否则会稍微降低性能。这个 PR 引入了动态检测重复帧的机制来提高在动态帧较多的情况下的性能。算法如下：

```mermaid
flowchart TD
A[检测] --> B{"有重复帧？"}
B -->|否| C[停止一段时间]
B -->|是| A
C --> E{"有重复帧？"}
E -->|否| F(增加停止时间)
F --> C
E -->|是| G(重置停止时间)
G --> A
```

原理为如果发现多个帧不重复，则预测下一帧也不会重复，跳过对重复帧的检测；连续的动态帧越多，则跳过的帧也越多。我有意把参数设计的很保守（或许过于保守了），而且粒度较小，因为通常应用效果比检测重复帧昂贵得多，错误的预测可能会导致巨大代价。

具体而言：
1. 无论什么时候，一旦发现重复帧，则返回此流程的开始。
2. 如果连续 **16** 帧没有重复，则激活动态检测机制。这个门槛可以有效降低预测错误的机率。跳过一些帧的检测后，连续检查一定数量的帧，如果仍没有发现重复帧则增加跳过的帧数。
3. 第一次跳过一帧，然后逐渐增长，最高连续跳过 **16** 帧，连续检查的帧数则逐渐减少，最少为 **2**。在每一帧都不重复的理想情况下，最终检测重复帧的代价下降约 89%。

添加了两个开发者选项：
1. 检测重复帧支持总是检测、动态检测和从不检测三种模式。
2. 支持在动态检测重复帧时统计预测正确率，并在游戏内叠加层中显示，以帮助改进算法。启用此选项会稍微降低性能，因为需要检测本应跳过的帧。