### PR TITLE
优化叠加层渲染性能

### DIFF
--- a/src/Magpie.App/Magpie.App.vcxproj
+++ b/src/Magpie.App/Magpie.App.vcxproj
@@ -613,8 +613,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -622,8 +622,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
 </Project>

--- a/src/Magpie.App/conanfile.txt
+++ b/src/Magpie.App/conanfile.txt
@@ -3,7 +3,7 @@ fmt/10.1.1
 spdlog/1.12.0
 parallel-hashmap/1.37
 rapidjson/cci.20230929
-kuba-zip/0.2.6
+kuba-zip/0.3.0
 muparser/2.3.4
 yas/7.1.0
 imgui/1.90

--- a/src/Magpie.App/packages.config
+++ b/src/Magpie.App/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2151.40" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2210.55" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
 </packages>

--- a/src/Magpie.Core/BackendDescriptorStore.cpp
+++ b/src/Magpie.Core/BackendDescriptorStore.cpp
@@ -1,0 +1,66 @@
+#include "pch.h"
+#include "BackendDescriptorStore.h"
+#include "Logger.h"
+
+namespace Magpie::Core {
+
+ID3D11ShaderResourceView* BackendDescriptorStore::GetShaderResourceView(ID3D11Texture2D* texture) noexcept {
+	if (auto it = _srvMap.find(texture); it != _srvMap.end()) {
+		return it->second.get();
+	}
+
+	winrt::com_ptr<ID3D11ShaderResourceView> srv;
+	HRESULT hr = _d3dDevice->CreateShaderResourceView(texture, nullptr, srv.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateShaderResourceView 失败", hr);
+		return nullptr;
+	}
+
+	return _srvMap.emplace(texture, std::move(srv)).first->second.get();
+}
+
+ID3D11UnorderedAccessView* BackendDescriptorStore::GetUnorderedAccessView(ID3D11Texture2D* texture) noexcept {
+	if (auto it = _uavMap.find(texture); it != _uavMap.end()) {
+		return it->second.get();
+	}
+
+	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
+
+	D3D11_UNORDERED_ACCESS_VIEW_DESC desc{
+		.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D
+	};
+
+	HRESULT hr = _d3dDevice->CreateUnorderedAccessView(texture, &desc, uav.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateUnorderedAccessView 失败", hr);
+		return nullptr;
+	}
+
+	return _uavMap.emplace(texture, std::move(uav)).first->second.get();
+}
+
+ID3D11UnorderedAccessView* BackendDescriptorStore::GetUnorderedAccessView(ID3D11Buffer* buffer, uint32_t numElements, DXGI_FORMAT format) noexcept {
+	if (auto it = _uavMap.find(buffer); it != _uavMap.end()) {
+		return it->second.get();
+	}
+
+	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
+
+	D3D11_UNORDERED_ACCESS_VIEW_DESC desc{
+		.Format = format,
+		.ViewDimension = D3D11_UAV_DIMENSION_BUFFER,
+		.Buffer{
+			.NumElements = numElements
+		}
+	};
+
+	HRESULT hr = _d3dDevice->CreateUnorderedAccessView(buffer, &desc, uav.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateUnorderedAccessView 失败", hr);
+		return nullptr;
+	}
+
+	return _uavMap.emplace(buffer, std::move(uav)).first->second.get();
+}
+
+}

--- a/src/Magpie.Core/BackendDescriptorStore.h
+++ b/src/Magpie.Core/BackendDescriptorStore.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <parallel_hashmap/phmap.h>
+
+namespace Magpie::Core {
+
+class BackendDescriptorStore {
+public:
+	BackendDescriptorStore() = default;
+	BackendDescriptorStore(const BackendDescriptorStore&) = delete;
+	BackendDescriptorStore(BackendDescriptorStore&&) = default;
+
+	void Initialize(ID3D11Device5* d3dDevice) noexcept {
+		_d3dDevice = d3dDevice;
+	}
+
+	ID3D11ShaderResourceView* GetShaderResourceView(ID3D11Texture2D* texture) noexcept;
+
+	ID3D11UnorderedAccessView* GetUnorderedAccessView(ID3D11Texture2D* texture) noexcept;
+
+	ID3D11UnorderedAccessView* GetUnorderedAccessView(
+		ID3D11Buffer* buffer,
+		uint32_t numElements,
+		DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN
+	) noexcept;
+
+private:
+	ID3D11Device5* _d3dDevice = nullptr;
+
+	phmap::flat_hash_map<ID3D11Texture2D*, winrt::com_ptr<ID3D11ShaderResourceView>> _srvMap;
+	phmap::flat_hash_map<void*, winrt::com_ptr<ID3D11UnorderedAccessView>> _uavMap;
+};
+
+}

--- a/src/Magpie.Core/CursorDrawer.cpp
+++ b/src/Magpie.Core/CursorDrawer.cpp
@@ -72,7 +72,7 @@ bool CursorDrawer::Initialize(DeviceResources& deviceResources, ID3D11Texture2D*
 
 	hr = d3dDevice->CreateInputLayout(
 		VertexPositionTexture::InputElements,
-		std::size(VertexPositionTexture::InputElements),
+		(UINT)std::size(VertexPositionTexture::InputElements),
 		SimpleVS,
 		std::size(SimpleVS),
 		_simpleIL.put()

--- a/src/Magpie.Core/CursorDrawer.cpp
+++ b/src/Magpie.Core/CursorDrawer.cpp
@@ -195,8 +195,8 @@ void CursorDrawer::Draw() noexcept {
 
 		d3dDC->PSSetShader(_simplePS.get(), nullptr, 0);
 		d3dDC->PSSetConstantBuffers(0, 0, nullptr);
-		ID3D11ShaderResourceView* cursorSRV = _deviceResources->GetShaderResourceView(ci->texture.get());
-		d3dDC->PSSetShaderResources(0, 1, &cursorSRV);
+		ID3D11ShaderResourceView* cursorSrv = ci->textureSrv.get();
+		d3dDC->PSSetShaderResources(0, 1, &cursorSrv);
 		ID3D11SamplerState* cursorSampler = _deviceResources->GetSampler(
 			interpolationMode == CursorInterpolationMode::NearestNeighbor
 			? D3D11_FILTER_MIN_MAG_MIP_POINT
@@ -208,17 +208,32 @@ void CursorDrawer::Draw() noexcept {
 		_SetPremultipliedAlphaBlend();
 	} else {
 		if (_tempCursorTextureSize != cursorSize) {
+			_tempCursorTexture = nullptr;
+			_tempCursorTextureRtv = nullptr;
+
+			ID3D11Device* d3dDevice = _deviceResources->GetD3DDevice();
+
 			// 创建临时纹理，如果光标尺寸变了则重新创建
 			_tempCursorTexture = DirectXHelper::CreateTexture2D(
-				_deviceResources->GetD3DDevice(),
+				d3dDevice,
 				DXGI_FORMAT_R8G8B8A8_UNORM,
 				cursorSize.cx,
 				cursorSize.cy,
 				D3D11_BIND_SHADER_RESOURCE
 			);
 			if (!_tempCursorTexture) {
+				Logger::Get().Error("创建光标纹理失败");
 				return;
 			}
+
+			HRESULT hr = d3dDevice->CreateShaderResourceView(
+				_tempCursorTexture.get(), nullptr, _tempCursorTextureRtv.put());
+			if (FAILED(hr)) {
+				Logger::Get().ComError("CreateShaderResourceView 失败", hr);
+				_tempCursorTexture = nullptr;
+				return;
+			}
+
 			_tempCursorTextureSize = cursorSize;
 		}
 
@@ -265,10 +280,7 @@ void CursorDrawer::Draw() noexcept {
 
 		d3dDC->PSSetConstantBuffers(0, 0, nullptr);
 
-		ID3D11ShaderResourceView* srvs[2]{
-			_deviceResources->GetShaderResourceView(_tempCursorTexture.get()),
-			_deviceResources->GetShaderResourceView(ci->texture.get())
-		};
+		ID3D11ShaderResourceView* srvs[2]{ _tempCursorTextureRtv.get(), ci->textureSrv.get() };
 		d3dDC->PSSetShaderResources(0, 2, srvs);
 
 		ID3D11SamplerState* samplers[2];
@@ -287,63 +299,129 @@ void CursorDrawer::Draw() noexcept {
 }
 
 const CursorDrawer::_CursorInfo* CursorDrawer::_ResolveCursor(HCURSOR hCursor) noexcept {
-	auto it = _cursorInfos.find(hCursor);
-	if (it != _cursorInfos.end()) {
+	if (auto it = _cursorInfos.find(hCursor); it != _cursorInfos.end()) {
 		return &it->second;
 	}
 
-	ICONINFO ii{};
-	if (!GetIconInfo(hCursor, &ii)) {
+	ICONINFO iconInfo{};
+	if (!GetIconInfo(hCursor, &iconInfo)) {
 		Logger::Get().Win32Error("GetIconInfo 失败");
 		return nullptr;
 	}
 
-	Utils::ScopeExit se([&ii]() {
-		if (ii.hbmColor) {
-			DeleteBitmap(ii.hbmColor);
+	Utils::ScopeExit se([&iconInfo]() {
+		if (iconInfo.hbmColor) {
+			DeleteBitmap(iconInfo.hbmColor);
 		}
-		DeleteBitmap(ii.hbmMask);
+		DeleteBitmap(iconInfo.hbmMask);
 	});
 
 	BITMAP bmp{};
-	if (!GetObject(ii.hbmMask, sizeof(bmp), &bmp)) {
+	if (!GetObject(iconInfo.hbmMask, sizeof(bmp), &bmp)) {
 		Logger::Get().Win32Error("GetObject 失败");
 		return nullptr;
 	}
 
-	_CursorInfo& ci = _cursorInfos[hCursor];
-
-	ci.hotSpot = { (LONG)ii.xHotspot, (LONG)ii.yHotspot };
-	// 单色光标的 hbmMask 高度为实际高度的两倍
-	ci.size = { bmp.bmWidth, ii.hbmColor ? bmp.bmHeight : bmp.bmHeight / 2 };
-
-	BITMAPINFO bi{};
-	bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-	bi.bmiHeader.biWidth = bmp.bmWidth;
-	bi.bmiHeader.biHeight = -bmp.bmHeight;
-	bi.bmiHeader.biPlanes = 1;
-	bi.bmiHeader.biCompression = BI_RGB;
-	bi.bmiHeader.biBitCount = 32;
-	bi.bmiHeader.biSizeImage = bmp.bmWidth * bmp.bmHeight * 4;
-
-	if (ii.hbmColor == NULL) {
-		// 单色光标
-		ci.type = _CursorType::Monochrome;
-
-		std::unique_ptr<BYTE[]> pixels(new BYTE[bi.bmiHeader.biSizeImage]);
-		HDC hdc = GetDC(NULL);
-		if (GetDIBits(hdc, ii.hbmMask, 0, bmp.bmHeight, pixels.get(), &bi, DIB_RGB_COLORS) != bmp.bmHeight) {
-			Logger::Get().Win32Error("GetDIBits 失败");
-			ReleaseDC(NULL, hdc);
-			return nullptr;
+	// 获取位图数据
+	BITMAPINFO bi{
+		.bmiHeader{
+			.biSize = sizeof(BITMAPINFOHEADER),
+			.biWidth = bmp.bmWidth,
+			.biHeight = -bmp.bmHeight,
+			.biPlanes = 1,
+			.biBitCount = 32,
+			.biCompression = BI_RGB,
+			.biSizeImage = DWORD(bmp.bmWidth * bmp.bmHeight * 4)
 		}
-		ReleaseDC(NULL, hdc);
+	};
+
+	std::unique_ptr<uint8_t[]> pixels(std::make_unique<uint8_t[]>(bi.bmiHeader.biSizeImage));
+	HDC hdcScreen = GetDC(NULL);
+	if (GetDIBits(hdcScreen, iconInfo.hbmColor ? iconInfo.hbmColor : iconInfo.hbmMask,
+		0, bmp.bmHeight, pixels.get(), &bi, DIB_RGB_COLORS) != bmp.bmHeight
+		) {
+		Logger::Get().Win32Error("GetDIBits 失败");
+		ReleaseDC(NULL, hdcScreen);
+		return nullptr;
+	}
+
+	_CursorInfo cursorInfo{
+		.hotSpot = { (LONG)iconInfo.xHotspot, (LONG)iconInfo.yHotspot },
+		// 单色光标的 hbmMask 高度为实际高度的两倍
+		.size = { bmp.bmWidth, iconInfo.hbmColor ? bmp.bmHeight : bmp.bmHeight / 2 }
+	};
+	winrt::com_ptr<ID3D11Texture2D> cursorTexture;
+
+	ID3D11Device* d3dDevice = _deviceResources->GetD3DDevice();
+
+	if (iconInfo.hbmColor) {
+		// 彩色光标或彩色掩码光标
+
+		// 若颜色掩码有 A 通道，则是彩色光标，否则是彩色掩码光标
+		bool hasAlpha = false;
+		for (DWORD i = 3; i < bi.bmiHeader.biSizeImage; i += 4) {
+			if (pixels[i] != 0) {
+				hasAlpha = true;
+				break;
+			}
+		}
+
+		if (hasAlpha) {
+			// 彩色光标
+			cursorInfo.type = _CursorType::Color;
+
+			for (size_t i = 0; i < bi.bmiHeader.biSizeImage; i += 4) {
+				// 预乘 Alpha 通道
+				double alpha = pixels[i + 3] / 255.0f;
+
+				uint8_t b = (uint8_t)std::lround(pixels[i] * alpha);
+				pixels[i] = (uint8_t)std::lround(pixels[i + 2] * alpha);
+				pixels[i + 1] = (uint8_t)std::lround(pixels[i + 1] * alpha);
+				pixels[i + 2] = b;
+				pixels[i + 3] = 255 - pixels[i + 3];
+			}
+		} else {
+			// 彩色掩码光标
+			cursorInfo.type = _CursorType::MaskedColor;
+
+			std::unique_ptr<uint8_t[]> maskPixels(std::make_unique<uint8_t[]>(bi.bmiHeader.biSizeImage));
+			if (GetDIBits(hdcScreen, iconInfo.hbmMask, 0, bmp.bmHeight, maskPixels.get(), &bi, DIB_RGB_COLORS) != bmp.bmHeight) {
+				Logger::Get().Win32Error("GetDIBits 失败");
+				ReleaseDC(NULL, hdcScreen);
+				return nullptr;
+			}
+
+			// 将 XOR 掩码复制到透明通道中
+			for (size_t i = 0; i < bi.bmiHeader.biSizeImage; i += 4) {
+				std::swap(pixels[i], pixels[i + 2]);
+				pixels[i + 3] = maskPixels[i];
+			}
+		}
+
+		const D3D11_SUBRESOURCE_DATA initData{
+			.pSysMem = pixels.get(),
+			.SysMemPitch = UINT(bmp.bmWidth * 4)
+		};
+
+		cursorTexture = DirectXHelper::CreateTexture2D(
+			d3dDevice,
+			DXGI_FORMAT_R8G8B8A8_UNORM,
+			bmp.bmWidth,
+			bmp.bmHeight,
+			D3D11_BIND_SHADER_RESOURCE,
+			D3D11_USAGE_IMMUTABLE,
+			0,
+			&initData
+		);
+	} else {
+		// 单色光标
+		cursorInfo.type = _CursorType::Monochrome;
 
 		// 红色通道是 AND 掩码，绿色通道是 XOR 掩码
 		// 构造 DXGI_FORMAT_R8G8_UNORM 的初始数据
 		const int halfSize = bi.bmiHeader.biSizeImage / 8;
-		BYTE* upPtr = &pixels[0];
-		BYTE* downPtr = &pixels[(size_t)halfSize * 4];
+		uint8_t* upPtr = &pixels[0];
+		uint8_t* downPtr = &pixels[(size_t)halfSize * 4];
 		uint8_t* targetPtr = &pixels[0];
 		for (int i = 0; i < halfSize; ++i) {
 			*targetPtr++ = *upPtr;
@@ -353,12 +431,13 @@ const CursorDrawer::_CursorInfo* CursorDrawer::_ResolveCursor(HCURSOR hCursor) n
 			downPtr += 4;
 		}
 
-		D3D11_SUBRESOURCE_DATA initData{};
-		initData.pSysMem = pixels.get();
-		initData.SysMemPitch = bmp.bmWidth * 2;
-
-		ci.texture = DirectXHelper::CreateTexture2D(
-			_deviceResources->GetD3DDevice(),
+		const D3D11_SUBRESOURCE_DATA initData{
+			.pSysMem = pixels.get(),
+			.SysMemPitch = UINT(bmp.bmWidth * 2)
+		};
+		
+		cursorTexture = DirectXHelper::CreateTexture2D(
+			d3dDevice,
 			DXGI_FORMAT_R8G8_UNORM,
 			bmp.bmWidth,
 			bmp.bmHeight / 2,
@@ -367,86 +446,21 @@ const CursorDrawer::_CursorInfo* CursorDrawer::_ResolveCursor(HCURSOR hCursor) n
 			0,
 			&initData
 		);
-		if (!ci.texture) {
-			Logger::Get().Error("创建纹理失败");
-			return nullptr;
-		}
-
-		return &ci;
 	}
 
-	std::unique_ptr<BYTE[]> pixels(new BYTE[bi.bmiHeader.biSizeImage]);
-	HDC hdc = GetDC(NULL);
-	if (GetDIBits(hdc, ii.hbmColor, 0, bmp.bmHeight, pixels.get(), &bi, DIB_RGB_COLORS) != bmp.bmHeight) {
-		Logger::Get().Win32Error("GetDIBits 失败");
-		ReleaseDC(NULL, hdc);
-		return nullptr;
-	}
-	ReleaseDC(NULL, hdc);
+	ReleaseDC(NULL, hdcScreen);
 
-	// 若颜色掩码有 A 通道，则是彩色光标，否则是彩色掩码光标
-	bool hasAlpha = false;
-	for (uint32_t i = 3; i < bi.bmiHeader.biSizeImage; i += 4) {
-		if (pixels[i] != 0) {
-			hasAlpha = true;
-			break;
-		}
-	}
-
-	if (hasAlpha) {
-		// 彩色光标
-		ci.type = _CursorType::Color;
-
-		for (size_t i = 0; i < bi.bmiHeader.biSizeImage; i += 4) {
-			// 预乘 Alpha 通道
-			double alpha = pixels[i + 3] / 255.0f;
-
-			BYTE b = (BYTE)std::lround(pixels[i] * alpha);
-			pixels[i] = (BYTE)std::lround(pixels[i + 2] * alpha);
-			pixels[i + 1] = (BYTE)std::lround(pixels[i + 1] * alpha);
-			pixels[i + 2] = b;
-			pixels[i + 3] = 255 - pixels[i + 3];
-		}
-	} else {
-		// 彩色掩码光标
-		ci.type = _CursorType::MaskedColor;
-
-		std::unique_ptr<BYTE[]> maskPixels(new BYTE[bi.bmiHeader.biSizeImage]);
-		hdc = GetDC(NULL);
-		if (GetDIBits(hdc, ii.hbmMask, 0, bmp.bmHeight, maskPixels.get(), &bi, DIB_RGB_COLORS) != bmp.bmHeight) {
-			Logger::Get().Win32Error("GetDIBits 失败");
-			ReleaseDC(NULL, hdc);
-			return nullptr;
-		}
-		ReleaseDC(NULL, hdc);
-
-		// 将 XOR 掩码复制到透明通道中
-		for (size_t i = 0; i < bi.bmiHeader.biSizeImage; i += 4) {
-			std::swap(pixels[i], pixels[i + 2]);
-			pixels[i + 3] = maskPixels[i];
-		}
-	}
-
-	D3D11_SUBRESOURCE_DATA initData{};
-	initData.pSysMem = &pixels[0];
-	initData.SysMemPitch = bmp.bmWidth * 4;
-
-	ci.texture = DirectXHelper::CreateTexture2D(
-		_deviceResources->GetD3DDevice(),
-		DXGI_FORMAT_R8G8B8A8_UNORM,
-		bmp.bmWidth,
-		bmp.bmHeight,
-		D3D11_BIND_SHADER_RESOURCE,
-		D3D11_USAGE_IMMUTABLE,
-		0,
-		&initData
-	);
-	if (!ci.texture) {
-		Logger::Get().Error("创建纹理失败");
+	if (!cursorTexture) {
+		Logger::Get().Error("创建光标纹理失败");
 		return nullptr;
 	}
 
-	return &ci;
+	HRESULT hr = d3dDevice->CreateShaderResourceView(cursorTexture.get(), nullptr, cursorInfo.textureSrv.put());
+	if (FAILED(hr)) {
+		return nullptr;
+	}
+
+	return &_cursorInfos.emplace(hCursor, std::move(cursorInfo)).first->second;
 }
 
 bool CursorDrawer::_SetPremultipliedAlphaBlend() noexcept {

--- a/src/Magpie.Core/CursorDrawer.h
+++ b/src/Magpie.Core/CursorDrawer.h
@@ -36,7 +36,7 @@ private:
 	struct _CursorInfo {
 		POINT hotSpot{};
 		SIZE size{};
-		winrt::com_ptr<ID3D11Texture2D> texture = nullptr;
+		winrt::com_ptr<ID3D11ShaderResourceView> textureSrv = nullptr;
 		_CursorType type = _CursorType::Color;
 	};
 
@@ -61,6 +61,7 @@ private:
 
 	// 用于渲染彩色掩码光标和单色光标的临时纹理
 	winrt::com_ptr<ID3D11Texture2D> _tempCursorTexture;
+	winrt::com_ptr<ID3D11ShaderResourceView> _tempCursorTextureRtv;
 	SIZE _tempCursorTextureSize{};
 };
 

--- a/src/Magpie.Core/DeviceResources.cpp
+++ b/src/Magpie.Core/DeviceResources.cpp
@@ -65,21 +65,6 @@ ID3D11SamplerState* DeviceResources::GetSampler(D3D11_FILTER filterMode, D3D11_T
 	return _samMap.emplace(key, std::move(sam)).first->second.get();
 }
 
-ID3D11RenderTargetView* DeviceResources::GetRenderTargetView(ID3D11Texture2D* texture) noexcept {
-	auto it = _rtvMap.find(texture);
-	if (it != _rtvMap.end()) {
-		return it->second.get();
-	}
-
-	winrt::com_ptr<ID3D11RenderTargetView> rtv;
-	HRESULT hr = _d3dDevice->CreateRenderTargetView(texture, nullptr, rtv.put());
-	if (FAILED(hr)) {
-		Logger::Get().ComError("CreateRenderTargetView 失败", hr);
-		return nullptr;
-	}
-
-	return _rtvMap.emplace(texture, std::move(rtv)).first->second.get();
-}
 
 ID3D11ShaderResourceView* DeviceResources::GetShaderResourceView(ID3D11Texture2D* texture) noexcept {
 	auto it = _srvMap.find(texture);

--- a/src/Magpie.Core/DeviceResources.cpp
+++ b/src/Magpie.Core/DeviceResources.cpp
@@ -65,69 +65,6 @@ ID3D11SamplerState* DeviceResources::GetSampler(D3D11_FILTER filterMode, D3D11_T
 	return _samMap.emplace(key, std::move(sam)).first->second.get();
 }
 
-
-ID3D11ShaderResourceView* DeviceResources::GetShaderResourceView(ID3D11Texture2D* texture) noexcept {
-	auto it = _srvMap.find(texture);
-	if (it != _srvMap.end()) {
-		return it->second.get();
-	}
-
-	winrt::com_ptr<ID3D11ShaderResourceView> srv;
-	HRESULT hr = _d3dDevice->CreateShaderResourceView(texture, nullptr, srv.put());
-	if (FAILED(hr)) {
-		Logger::Get().ComError("CreateShaderResourceView 失败", hr);
-		return nullptr;
-	}
-
-	return _srvMap.emplace(texture, std::move(srv)).first->second.get();
-}
-
-ID3D11UnorderedAccessView* DeviceResources::GetUnorderedAccessView(ID3D11Texture2D* texture) noexcept {
-	auto it = _uavMap.find(texture);
-	if (it != _uavMap.end()) {
-		return it->second.get();
-	}
-
-	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
-
-	D3D11_UNORDERED_ACCESS_VIEW_DESC desc{};
-	desc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
-
-	HRESULT hr = _d3dDevice->CreateUnorderedAccessView(texture, &desc, uav.put());
-	if (FAILED(hr)) {
-		Logger::Get().ComError("CreateUnorderedAccessView 失败", hr);
-		return nullptr;
-	}
-
-	return _uavMap.emplace(texture, std::move(uav)).first->second.get();
-}
-
-ID3D11UnorderedAccessView* DeviceResources::GetUnorderedAccessView(
-	ID3D11Buffer* buffer,
-	uint32_t numElements,
-	DXGI_FORMAT format
-) noexcept {
-	auto it = _uavMap.find(buffer);
-	if (it != _uavMap.end()) {
-		return it->second.get();
-	}
-
-	winrt::com_ptr<ID3D11UnorderedAccessView> uav;
-
-	D3D11_UNORDERED_ACCESS_VIEW_DESC desc{};
-	desc.Format = format;
-	desc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
-	desc.Buffer.NumElements = numElements;
-
-	HRESULT hr = _d3dDevice->CreateUnorderedAccessView(buffer, &desc, uav.put());
-	if (FAILED(hr)) {
-		Logger::Get().ComError("CreateUnorderedAccessView 失败", hr);
-		return nullptr;
-	}
-
-	return _uavMap.emplace(buffer, std::move(uav)).first->second.get();
-}
-
 static void LogAdapter(const DXGI_ADAPTER_DESC1& adapterDesc) noexcept {
 	Logger::Get().Info(fmt::format("当前图形适配器：\n\tVendorId：{:#x}\n\tDeviceId：{:#x}\n\t描述：{}",
 		adapterDesc.VendorId, adapterDesc.DeviceId, StrUtils::UTF16ToUTF8(adapterDesc.Description)));

--- a/src/Magpie.Core/DeviceResources.h
+++ b/src/Magpie.Core/DeviceResources.h
@@ -22,16 +22,6 @@ public:
 
 	ID3D11SamplerState* GetSampler(D3D11_FILTER filterMode, D3D11_TEXTURE_ADDRESS_MODE addressMode) noexcept;
 
-
-	ID3D11ShaderResourceView* GetShaderResourceView(ID3D11Texture2D* texture) noexcept;
-
-	ID3D11UnorderedAccessView* GetUnorderedAccessView(ID3D11Texture2D* texture) noexcept;
-	ID3D11UnorderedAccessView* GetUnorderedAccessView(
-		ID3D11Buffer* buffer,
-		uint32_t numElements,
-		DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN
-	) noexcept;
-
 private:
 	bool _ObtainAdapterAndDevice(int adapterIdx) noexcept;
 	bool _TryCreateD3DDevice(const winrt::com_ptr<IDXGIAdapter1>& adapter) noexcept;
@@ -40,10 +30,6 @@ private:
 	winrt::com_ptr<IDXGIAdapter4> _graphicsAdapter;
 	winrt::com_ptr<ID3D11Device5> _d3dDevice;
 	winrt::com_ptr<ID3D11DeviceContext4> _d3dDC;
-
-	phmap::flat_hash_map<ID3D11Texture2D*, winrt::com_ptr<ID3D11RenderTargetView>> _rtvMap;
-	phmap::flat_hash_map<ID3D11Texture2D*, winrt::com_ptr<ID3D11ShaderResourceView>> _srvMap;
-	phmap::flat_hash_map<void*, winrt::com_ptr<ID3D11UnorderedAccessView>> _uavMap;
 
 	phmap::flat_hash_map<
 		std::pair<D3D11_FILTER, D3D11_TEXTURE_ADDRESS_MODE>,

--- a/src/Magpie.Core/DeviceResources.h
+++ b/src/Magpie.Core/DeviceResources.h
@@ -22,7 +22,6 @@ public:
 
 	ID3D11SamplerState* GetSampler(D3D11_FILTER filterMode, D3D11_TEXTURE_ADDRESS_MODE addressMode) noexcept;
 
-	ID3D11RenderTargetView* GetRenderTargetView(ID3D11Texture2D* texture) noexcept;
 
 	ID3D11ShaderResourceView* GetShaderResourceView(ID3D11Texture2D* texture) noexcept;
 

--- a/src/Magpie.Core/DirectXHelper.cpp
+++ b/src/Magpie.Core/DirectXHelper.cpp
@@ -82,17 +82,20 @@ winrt::com_ptr<ID3D11Texture2D> DirectXHelper::CreateTexture2D(
 	UINT miscFlags,
 	const D3D11_SUBRESOURCE_DATA* pInitialData
 ) noexcept {
-	D3D11_TEXTURE2D_DESC desc{};
-	desc.Format = format;
-	desc.Width = width;
-	desc.Height = height;
-	desc.MipLevels = 1;
-	desc.ArraySize = 1;
-	desc.SampleDesc.Count = 1;
-	desc.SampleDesc.Quality = 0;
-	desc.BindFlags = bindFlags;
-	desc.Usage = usage;
-	desc.MiscFlags = miscFlags;
+	const D3D11_TEXTURE2D_DESC desc{
+		.Width = width,
+		.Height = height,
+		.MipLevels = 1,
+		.ArraySize = 1,
+		.Format = format,
+		.SampleDesc{
+			.Count = 1,
+			.Quality = 0
+		},
+		.Usage = usage,
+		.BindFlags = bindFlags,
+		.MiscFlags = miscFlags
+	};
 
 	winrt::com_ptr<ID3D11Texture2D> result;
 	HRESULT hr = d3dDevice->CreateTexture2D(&desc, pInitialData, result.put());

--- a/src/Magpie.Core/EffectDrawer.cpp
+++ b/src/Magpie.Core/EffectDrawer.cpp
@@ -9,6 +9,7 @@
 #include "EffectHelper.h"
 #include "DirectXHelper.h"
 #include "ScalingWindow.h"
+#include "BackendDescriptorStore.h"
 
 #pragma push_macro("_UNICODE")
 // Conan 的 muparser 不含 UNICODE 支持
@@ -85,6 +86,7 @@ bool EffectDrawer::Initialize(
 	const EffectDesc& desc,
 	const EffectOption& option,
 	DeviceResources& deviceResources,
+	BackendDescriptorStore& descriptorStore,
 	ID3D11Texture2D** inOutTexture
 ) noexcept {
 	_d3dDC = deviceResources.GetD3DDC();
@@ -216,7 +218,7 @@ bool EffectDrawer::Initialize(
 
 		_srvs[i].resize(passDesc.inputs.size());
 		for (UINT j = 0; j < passDesc.inputs.size(); ++j) {
-			auto srv = _srvs[i][j] = deviceResources.GetShaderResourceView(_textures[passDesc.inputs[j]].get());
+			auto srv = _srvs[i][j] = descriptorStore.GetShaderResourceView(_textures[passDesc.inputs[j]].get());
 			if (!srv) {
 				Logger::Get().Error("GetShaderResourceView 失败");
 				return false;
@@ -225,7 +227,7 @@ bool EffectDrawer::Initialize(
 
 		_uavs[i].resize(passDesc.outputs.size() * 2);
 		for (UINT j = 0; j < passDesc.outputs.size(); ++j) {
-			auto uav = _uavs[i][j] = deviceResources.GetUnorderedAccessView(_textures[passDesc.outputs[j]].get());
+			auto uav = _uavs[i][j] = descriptorStore.GetUnorderedAccessView(_textures[passDesc.outputs[j]].get());
 			if (!uav) {
 				Logger::Get().Error("GetUnorderedAccessView 失败");
 				return false;

--- a/src/Magpie.Core/EffectDrawer.h
+++ b/src/Magpie.Core/EffectDrawer.h
@@ -7,6 +7,7 @@ namespace Magpie::Core {
 
 struct EffectOption;
 class DeviceResources;
+class BackendDescriptorStore;
 
 class EffectDrawer {
 public:
@@ -18,6 +19,7 @@ public:
 		const EffectDesc& desc,
 		const EffectOption& option,
 		DeviceResources& deviceResources,
+		BackendDescriptorStore& descriptorStore,
 		ID3D11Texture2D** inOutTexture
 	) noexcept;
 

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -3,6 +3,7 @@
 namespace Magpie::Core {
 
 class DeviceResources;
+class BackendDescriptorStore;
 
 class FrameSourceBase {
 public:
@@ -14,7 +15,7 @@ public:
 	FrameSourceBase(const FrameSourceBase&) = delete;
 	FrameSourceBase(FrameSourceBase&&) = delete;
 
-	bool Initialize(DeviceResources& deviceResources) noexcept;
+	bool Initialize(DeviceResources& deviceResources, BackendDescriptorStore& descriptorStore) noexcept;
 
 	enum class UpdateState {
 		NewFrame,
@@ -66,10 +67,12 @@ protected:
 	RECT _srcRect{};
 
 	DeviceResources* _deviceResources = nullptr;
+	BackendDescriptorStore* _descriptorStore = nullptr;
 	winrt::com_ptr<ID3D11Texture2D> _output;
-	winrt::com_ptr<ID3D11ShaderResourceView> _outputSrv;
+	ID3D11ShaderResourceView* _outputSrv;
 
 	winrt::com_ptr<ID3D11Buffer> _resultBuffer;
+	ID3D11UnorderedAccessView* _resultBufferUav = nullptr;
 	winrt::com_ptr<ID3D11Buffer> _readBackBuffer;
 	winrt::com_ptr<ID3D11ComputeShader> _dupFrameCS;
 	std::pair<uint32_t, uint32_t> _dispatchCount;

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -67,6 +67,7 @@ protected:
 
 	DeviceResources* _deviceResources = nullptr;
 	winrt::com_ptr<ID3D11Texture2D> _output;
+	winrt::com_ptr<ID3D11ShaderResourceView> _outputSrv;
 
 	winrt::com_ptr<ID3D11Buffer> _resultBuffer;
 	winrt::com_ptr<ID3D11Buffer> _readBackBuffer;
@@ -81,6 +82,7 @@ private:
 
 	// 用于检查重复帧
 	winrt::com_ptr<ID3D11Texture2D> _prevFrame;
+	winrt::com_ptr<ID3D11ShaderResourceView> _prevFrameSrv;
 	uint16_t _nextSkipCount;
 	uint16_t _framesLeft;
 	// (预测错误帧数, 总计跳过帧数)

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -81,6 +81,8 @@ protected:
 	bool _windowResizingDisabled = false;
 
 private:
+	bool _InitCheckingForDuplicateFrame();
+
 	bool _IsDuplicateFrame();
 
 	// 用于检查重复帧

--- a/src/Magpie.Core/ImGuiBackend.cpp
+++ b/src/Magpie.Core/ImGuiBackend.cpp
@@ -290,7 +290,6 @@ bool ImGuiBackend::_CreateDeviceObjects() noexcept {
 bool ImGuiBackend::BuildFonts() noexcept {
 	assert(!_fontTextureView);
 
-	// 在第一帧前构建字体纹理
 	ID3D11Device5* d3dDevice = _deviceResources->GetD3DDevice();
 	ImGuiIO& io = ImGui::GetIO();
 

--- a/src/Magpie.Core/ImGuiBackend.cpp
+++ b/src/Magpie.Core/ImGuiBackend.cpp
@@ -287,10 +287,8 @@ bool ImGuiBackend::_CreateDeviceObjects() noexcept {
 	return true;
 }
 
-bool ImGuiBackend::BeginFrame() noexcept {
-	if (_fontTextureView) {
-		return true;
-	}
+bool ImGuiBackend::BuildFonts() noexcept {
+	assert(!_fontTextureView);
 
 	// 在第一帧前构建字体纹理
 	ID3D11Device5* d3dDevice = _deviceResources->GetD3DDevice();

--- a/src/Magpie.Core/ImGuiBackend.h
+++ b/src/Magpie.Core/ImGuiBackend.h
@@ -20,7 +20,6 @@ private:
 	bool _CreateDeviceObjects() noexcept;
 
 	void _SetupRenderState(ImDrawData* drawData) noexcept;
-	bool _CreateFontsTexture() noexcept;
 
 	class DeviceResources* _deviceResources = nullptr;
 
@@ -34,7 +33,6 @@ private:
 	winrt::com_ptr<ID3D11InputLayout> _inputLayout;
 	winrt::com_ptr<ID3D11Buffer> _vertexConstantBuffer;
 	winrt::com_ptr<ID3D11PixelShader> _pixelShader;
-	winrt::com_ptr<ID3D11SamplerState> _fontSampler;
 	winrt::com_ptr<ID3D11ShaderResourceView> _fontTextureView;
 	winrt::com_ptr<ID3D11BlendState> _blendState;
 	winrt::com_ptr<ID3D11RasterizerState> _rasterizerState;

--- a/src/Magpie.Core/ImGuiBackend.h
+++ b/src/Magpie.Core/ImGuiBackend.h
@@ -15,12 +15,12 @@ public:
 
 	bool BuildFonts() noexcept;
 
-	void RenderDrawData(ImDrawData* drawData) noexcept;
+	void RenderDrawData(const ImDrawData& drawData) noexcept;
 
 private:
 	bool _CreateDeviceObjects() noexcept;
 
-	void _SetupRenderState(ImDrawData* drawData) noexcept;
+	void _SetupRenderState(const ImDrawData& drawData) noexcept;
 
 	DeviceResources* _deviceResources = nullptr;
 

--- a/src/Magpie.Core/ImGuiBackend.h
+++ b/src/Magpie.Core/ImGuiBackend.h
@@ -13,7 +13,7 @@ public:
 
 	bool Initialize(DeviceResources* deviceResources) noexcept;
 
-	bool BeginFrame() noexcept;
+	bool BuildFonts() noexcept;
 
 	void RenderDrawData(ImDrawData* drawData) noexcept;
 

--- a/src/Magpie.Core/ImGuiBackend.h
+++ b/src/Magpie.Core/ImGuiBackend.h
@@ -13,7 +13,8 @@ public:
 
 	bool Initialize(DeviceResources* deviceResources) noexcept;
 
-	void BeginFrame() noexcept;
+	bool BeginFrame() noexcept;
+
 	void RenderDrawData(ImDrawData* drawData) noexcept;
 
 private:
@@ -21,7 +22,7 @@ private:
 
 	void _SetupRenderState(ImDrawData* drawData) noexcept;
 
-	class DeviceResources* _deviceResources = nullptr;
+	DeviceResources* _deviceResources = nullptr;
 
 	winrt::com_ptr<ID3D11Buffer> _vertexBuffer;
 	int _vertexBufferSize = 5000;

--- a/src/Magpie.Core/ImGuiImpl.cpp
+++ b/src/Magpie.Core/ImGuiImpl.cpp
@@ -110,7 +110,7 @@ bool ImGuiImpl::Initialize(DeviceResources* deviceResources) noexcept {
 	return true;
 }
 
-void ImGuiImpl::BeginFrame() {
+bool ImGuiImpl::BeginFrame() {
 	ImGuiIO& io = ImGui::GetIO();
 
 	// Setup display size (every frame to accommodate for window resizing)
@@ -126,9 +126,11 @@ void ImGuiImpl::BeginFrame() {
 		io.AddKeyEvent(ImGuiKey_Enter, false);
 	}
 
-	bool originWantCaptureMouse = io.WantCaptureMouse;
+	const bool originWantCaptureMouse = io.WantCaptureMouse;
 
-	_backend.BeginFrame();
+	if (!_backend.BeginFrame()) {
+		return false;
+	}
 	ImGui::NewFrame();
 
 	// 将所有 ImGUI 窗口限制在视口内
@@ -165,6 +167,8 @@ void ImGuiImpl::BeginFrame() {
 			cm.OnCursorLeaveOverlay();
 		}
 	}
+
+	return true;
 }
 
 void ImGuiImpl::EndFrame() {

--- a/src/Magpie.Core/ImGuiImpl.cpp
+++ b/src/Magpie.Core/ImGuiImpl.cpp
@@ -174,12 +174,12 @@ void ImGuiImpl::Draw() noexcept {
 	const RECT& scalingRect = ScalingWindow::Get().WndRect();
 	const RECT& destRect = ScalingWindow::Get().Renderer().DestRect();
 
-	ImDrawData* drawData = ImGui::GetDrawData();
-	drawData->DisplayPos = ImVec2(
+	ImDrawData& drawData = *ImGui::GetDrawData();
+	drawData.DisplayPos = ImVec2(
 		float(scalingRect.left - destRect.left),
 		float(scalingRect.top - destRect.top)
 	);
-	drawData->DisplaySize = ImVec2(
+	drawData.DisplaySize = ImVec2(
 		float(destRect.right - scalingRect.left),
 		float(destRect.bottom - scalingRect.top)
 	);

--- a/src/Magpie.Core/ImGuiImpl.h
+++ b/src/Magpie.Core/ImGuiImpl.h
@@ -15,7 +15,7 @@ public:
 
 	bool Initialize(DeviceResources* deviceResource) noexcept;
 
-	void BeginFrame();
+	bool BeginFrame();
 
 	void EndFrame();
 

--- a/src/Magpie.Core/ImGuiImpl.h
+++ b/src/Magpie.Core/ImGuiImpl.h
@@ -15,16 +15,18 @@ public:
 
 	bool Initialize(DeviceResources* deviceResource) noexcept;
 
-	bool BeginFrame();
+	bool BuildFonts() noexcept;
 
-	void EndFrame();
+	void NewFrame() noexcept;
 
-	void ClearStates();
+	void Draw() noexcept;
+
+	void ClearStates() noexcept;
 
 	void MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
 
 	// 将提示窗口限制在屏幕内
-	static void Tooltip(const char* content, float maxWidth = -1.0f);
+	static void Tooltip(const char* content, float maxWidth = -1.0f) noexcept;
 private:
 	void _UpdateMousePos() noexcept;
 

--- a/src/Magpie.Core/Magpie.Core.vcxproj
+++ b/src/Magpie.Core/Magpie.Core.vcxproj
@@ -42,6 +42,7 @@
     </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="BackendDescriptorStore.h" />
     <ClInclude Include="BicubicEffect.h" />
     <ClInclude Include="CursorManager.h" />
     <ClInclude Include="CursorDrawer.h" />
@@ -76,6 +77,7 @@
     <ClInclude Include="YasHelper.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="BackendDescriptorStore.cpp" />
     <ClCompile Include="CursorManager.cpp" />
     <ClCompile Include="CursorDrawer.cpp" />
     <ClCompile Include="DeviceResources.cpp" />

--- a/src/Magpie.Core/Magpie.Core.vcxproj
+++ b/src/Magpie.Core/Magpie.Core.vcxproj
@@ -106,6 +106,12 @@
     <FxCompile Include="shaders\DuplicateFrameCS.hlsl">
       <ShaderType>Compute</ShaderType>
     </FxCompile>
+    <FxCompile Include="shaders\ImGuiImplPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+    </FxCompile>
+    <FxCompile Include="shaders\ImGuiImplVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+    </FxCompile>
     <FxCompile Include="shaders\MaskedCursorPS.hlsl">
       <ShaderType>Pixel</ShaderType>
     </FxCompile>

--- a/src/Magpie.Core/Magpie.Core.vcxproj.filters
+++ b/src/Magpie.Core/Magpie.Core.vcxproj.filters
@@ -91,7 +91,6 @@
   <ItemGroup>
     <ClCompile Include="ScalingRuntime.cpp" />
     <ClCompile Include="pch.cpp" />
-    <ClCompile Include="DllMain.cpp" />
     <ClCompile Include="EffectCacheManager.cpp" />
     <ClCompile Include="EffectCompiler.cpp" />
     <ClCompile Include="TextureLoader.cpp">
@@ -152,6 +151,9 @@
       <Filter>Shaders</Filter>
     </FxCompile>
     <FxCompile Include="shaders\DuplicateFrameCS.hlsl">
+      <Filter>Shaders</Filter>
+    </FxCompile>
+    <FxCompile Include="shaders\ImGuiImplVS.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
   </ItemGroup>

--- a/src/Magpie.Core/Magpie.Core.vcxproj.filters
+++ b/src/Magpie.Core/Magpie.Core.vcxproj.filters
@@ -156,6 +156,9 @@
     <FxCompile Include="shaders\ImGuiImplVS.hlsl">
       <Filter>Shaders</Filter>
     </FxCompile>
+    <FxCompile Include="shaders\ImGuiImplPS.hlsl">
+      <Filter>Shaders</Filter>
+    </FxCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Magpie.Core/Magpie.Core.vcxproj.filters
+++ b/src/Magpie.Core/Magpie.Core.vcxproj.filters
@@ -87,6 +87,7 @@
     <ClInclude Include="ImGuiBackend.h">
       <Filter>Overlay</Filter>
     </ClInclude>
+    <ClInclude Include="BackendDescriptorStore.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ScalingRuntime.cpp" />
@@ -136,6 +137,7 @@
     <ClCompile Include="ImGuiBackend.cpp">
       <Filter>Overlay</Filter>
     </ClCompile>
+    <ClCompile Include="BackendDescriptorStore.cpp" />
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="shaders\SimpleVS.hlsl">

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -134,11 +134,7 @@ bool OverlayDrawer::_BuildFonts() noexcept {
 		_fontMonoNumbers = fontAtlas.Fonts[1];
 		_fontFPS = fontAtlas.Fonts[2];
 	} else {
-		fontAtlas.Flags |= ImFontAtlasFlags_NoPowerOfTwoHeight;
-		if (!ScalingWindow::Get().Options().Is3DGameMode()) {
-			// 非 3D 游戏模式无需 ImGui 绘制光标
-			fontAtlas.Flags |= ImFontAtlasFlags_NoMouseCursors;
-		}
+		fontAtlas.Flags |= ImFontAtlasFlags_NoPowerOfTwoHeight | ImFontAtlasFlags_NoMouseCursors;
 
 		std::wstring fontPath = GetSystemFontsFolder();
 		if (Win32Utils::GetOSVersion().IsWin11()) {

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -52,7 +52,7 @@ bool OverlayDrawer::Initialize(DeviceResources* deviceResources) noexcept {
 	return true;
 }
 
-void OverlayDrawer::Draw() noexcept {
+void OverlayDrawer::Draw(uint32_t count) noexcept {
 	bool isShowFPS = ScalingWindow::Get().Options().IsShowFPS();
 
 	if (!_isUIVisiable && !isShowFPS) {
@@ -60,24 +60,26 @@ void OverlayDrawer::Draw() noexcept {
 	}
 
 	if (_isFirstFrame) {
-		// ImGui 的第一帧不会显示，我们连续渲染两帧
+		// 刚显示时需连续渲染三帧：第一帧不会显示，第二帧不会将窗口限制在视口内
 		_isFirstFrame = false;
-		Draw();
+		count = 3;
 	}
 
-	if (!_imguiImpl.BeginFrame()) {
-		return;
-	}
+	for (uint32_t i = 0; i < count; ++i) {
+		_imguiImpl.NewFrame();
 
-	if (isShowFPS) {
-		_DrawFPS();
-	}
+		if (isShowFPS) {
+			_DrawFPS();
+		}
 
-	if (_isUIVisiable) {
-		_DrawUI();
+		if (_isUIVisiable) {
+			_DrawUI();
+		}
+
+		ImGui::Render();
 	}
 	
-	_imguiImpl.EndFrame();
+	_imguiImpl.Draw();
 }
 
 void OverlayDrawer::SetUIVisibility(bool value) noexcept {
@@ -124,48 +126,53 @@ static const std::wstring& GetSystemFontsFolder() noexcept {
 
 bool OverlayDrawer::_BuildFonts() noexcept {
 	const std::wstring& language = GetAppLanguage();
-
 	ImFontAtlas& fontAtlas = *ImGui::GetIO().Fonts;
 
-	bool fontCacheDisabled = ScalingWindow::Get().Options().IsFontCacheDisabled();
+	const bool fontCacheDisabled = ScalingWindow::Get().Options().IsFontCacheDisabled();
 	if (!fontCacheDisabled && ImGuiFontsCacheManager::Get().Load(language, fontAtlas)) {
 		_fontUI = fontAtlas.Fonts[0];
 		_fontMonoNumbers = fontAtlas.Fonts[1];
 		_fontFPS = fontAtlas.Fonts[2];
-		return true;
-	}
-
-	fontAtlas.Flags |= ImFontAtlasFlags_NoPowerOfTwoHeight;
-	if (!ScalingWindow::Get().Options().Is3DGameMode()) {
-		// 非 3D 游戏模式无需 ImGui 绘制光标
-		fontAtlas.Flags |= ImFontAtlasFlags_NoMouseCursors;
-	}
-
-	std::wstring fontPath = GetSystemFontsFolder();
-	if (Win32Utils::GetOSVersion().IsWin11()) {
-		fontPath += L"\\SegUIVar.ttf";
 	} else {
-		fontPath += L"\\segoeui.ttf";
+		fontAtlas.Flags |= ImFontAtlasFlags_NoPowerOfTwoHeight;
+		if (!ScalingWindow::Get().Options().Is3DGameMode()) {
+			// 非 3D 游戏模式无需 ImGui 绘制光标
+			fontAtlas.Flags |= ImFontAtlasFlags_NoMouseCursors;
+		}
+
+		std::wstring fontPath = GetSystemFontsFolder();
+		if (Win32Utils::GetOSVersion().IsWin11()) {
+			fontPath += L"\\SegUIVar.ttf";
+		} else {
+			fontPath += L"\\segoeui.ttf";
+		}
+
+		std::vector<uint8_t> fontData;
+		if (!Win32Utils::ReadFile(fontPath.c_str(), fontData)) {
+			Logger::Get().Error("读取字体文件失败");
+			return false;
+		}
+
+		{
+			// 构建 ImFontAtlas 前 uiRanges 不能析构，因为 ImGui 只保存了指针
+			ImVector<ImWchar> uiRanges;
+			_BuildFontUI(language, fontData, uiRanges);
+			_BuildFontFPS(fontData);
+
+			if (!fontAtlas.Build()) {
+				Logger::Get().Error("构建 ImFontAtlas 失败");
+				return false;
+			}
+		}
+
+		if (!fontCacheDisabled) {
+			ImGuiFontsCacheManager::Get().Save(language, fontAtlas);
+		}
 	}
 
-	std::vector<uint8_t> fontData;
-	if (!Win32Utils::ReadFile(fontPath.c_str(), fontData)) {
-		Logger::Get().Error("读取字体文件失败");
-		return false;
-	}
-
-	// 构建字体前 uiRanges 不能析构，因为 ImGui 只保存了指针
-	ImVector<ImWchar> uiRanges;
-	_BuildFontUI(language, fontData, uiRanges);
-	_BuildFontFPS(fontData);
-
-	if (!fontAtlas.Build()) {
+	if (!_imguiImpl.BuildFonts()) {
 		Logger::Get().Error("构建字体失败");
 		return false;
-	}
-
-	if (!fontCacheDisabled) {
-		ImGuiFontsCacheManager::Get().Save(language, fontAtlas);
 	}
 
 	return true;

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -65,7 +65,9 @@ void OverlayDrawer::Draw() noexcept {
 		Draw();
 	}
 
-	_imguiImpl.BeginFrame();
+	if (!_imguiImpl.BeginFrame()) {
+		return;
+	}
 
 	if (isShowFPS) {
 		_DrawFPS();

--- a/src/Magpie.Core/OverlayDrawer.h
+++ b/src/Magpie.Core/OverlayDrawer.h
@@ -13,8 +13,8 @@ public:
 	OverlayDrawer(OverlayDrawer&&) = delete;
 
 	bool Initialize(DeviceResources* deviceResources) noexcept;
-
-	void Draw() noexcept;
+	
+	void Draw(uint32_t count) noexcept;
 
 	bool IsUIVisiable() const noexcept {
 		return _isUIVisiable;

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -281,6 +281,7 @@ void Renderer::Render() noexcept {
 }
 
 void Renderer::ToggleOverlay() noexcept {
+	// FIXME: 退出缩放时可能崩溃
 	if (!_overlayDrawer) {
 		_overlayDrawer = std::make_unique<OverlayDrawer>();
 		if (!_overlayDrawer->Initialize(&_frontendResources)) {

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -335,7 +335,7 @@ bool Renderer::_InitFrameSource() noexcept {
 
 	Logger::Get().Info(StrUtils::Concat("当前捕获模式：", _frameSource->Name()));
 
-	if (!_frameSource->Initialize(_backendResources)) {
+	if (!_frameSource->Initialize(_backendResources, _backendDescriptorStore)) {
 		Logger::Get().Error("初始化 FrameSource 失败");
 		return false;
 	}
@@ -424,6 +424,7 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 			effectDescs[i],
 			effects[i],
 			_backendResources,
+			_backendDescriptorStore,
 			&inOutTexture
 		)) {
 			Logger::Get().Error(fmt::format("初始化效果#{} ({}) 失败", i, StrUtils::UTF16ToUTF8(effects[i].name)));
@@ -456,6 +457,7 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 				*bicubicDesc,
 				bicubicOption,
 				_backendResources,
+				_backendDescriptorStore,
 				&inOutTexture
 				)) {
 				Logger::Get().Error("初始化降采样效果失败");
@@ -645,6 +647,9 @@ ID3D11Texture2D* Renderer::_InitBackend() noexcept {
 		return nullptr;
 	}
 
+	ID3D11Device5* d3dDevice = _backendResources.GetD3DDevice();
+	_backendDescriptorStore.Initialize(d3dDevice);
+
 	if (!_InitFrameSource()) {
 		return nullptr;
 	}
@@ -654,7 +659,7 @@ ID3D11Texture2D* Renderer::_InitBackend() noexcept {
 		return nullptr;
 	}
 
-	HRESULT hr = _backendResources.GetD3DDevice()->CreateFence(
+	HRESULT hr = d3dDevice->CreateFence(
 		_fenceValue, D3D11_FENCE_FLAG_NONE, IID_PPV_ARGS(&_d3dFence));
 	if (FAILED(hr)) {
 		Logger::Get().ComError("CreateFence 失败", hr);

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -294,7 +294,6 @@ void Renderer::Render() noexcept {
 }
 
 void Renderer::ToggleOverlay() noexcept {
-	// FIXME: 退出缩放时可能崩溃
 	if (!_overlayDrawer) {
 		_overlayDrawer = std::make_unique<OverlayDrawer>();
 		if (!_overlayDrawer->Initialize(&_frontendResources)) {

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -66,6 +66,7 @@ private:
 	winrt::com_ptr<IDXGISwapChain4> _swapChain;
 	Win32Utils::ScopedHandle _frameLatencyWaitableObject;
 	winrt::com_ptr<ID3D11Texture2D> _backBuffer;
+	winrt::com_ptr<ID3D11RenderTargetView> _backBufferRtv;
 	uint64_t _lastAccessMutexKey = 0;
 
 	CursorDrawer _cursorDrawer;

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -46,7 +46,7 @@ public:
 private:
 	bool _CreateSwapChain() noexcept;
 
-	void _FrontendRender() noexcept;
+	void _FrontendRender(uint32_t imguiFrames = 1) noexcept;
 
 	void _BackendThreadProc() noexcept;
 

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "DeviceResources.h"
+#include "BackendDescriptorStore.h"
 #include "EffectDrawer.h"
 #include "Win32Utils.h"
 #include "CursorDrawer.h"
@@ -83,6 +84,7 @@ private:
 	
 	// 只能由后台线程访问
 	DeviceResources _backendResources;
+	Magpie::Core::BackendDescriptorStore _backendDescriptorStore;
 	std::unique_ptr<FrameSourceBase> _frameSource;
 	std::vector<EffectDrawer> _effectDrawers;
 

--- a/src/Magpie.Core/ScalingRuntime.h
+++ b/src/Magpie.Core/ScalingRuntime.h
@@ -44,15 +44,18 @@ public:
 private:
 	void _ScalingThreadProc() noexcept;
 
-	// 确保 _dqc 完成初始化
-	void _EnsureDispatcherQueue() const noexcept;
+	// 确保 _dispatcher 完成初始化
+	const winrt::DispatcherQueue& _Dispatcher() noexcept;
 
 	// 主线程使用 DispatcherQueue 和缩放线程沟通，因此无需约束内存定序，只需确保原子性即可
 	std::atomic<HWND> _hwndSrc;
 	winrt::event<winrt::delegate<bool>> _isRunningChangedEvent;
 
-	winrt::Windows::System::DispatcherQueueController _dqc{ nullptr };
-	// 应在 _dqc 后初始化
+	winrt::DispatcherQueue _dispatcher{ nullptr };
+	std::atomic<bool> _dispatcherInitialized = false;
+	// 只能在主线程访问，省下检查 _dispatcherInitialized 的开销
+	bool _dispatcherInitializedCache = false;
+	// 应在 _dispatcher 后初始化
 	std::thread _scalingThread;
 };
 

--- a/src/Magpie.Core/shaders/DuplicateFrameCS.hlsl
+++ b/src/Magpie.Core/shaders/DuplicateFrameCS.hlsl
@@ -6,7 +6,6 @@ Texture2D tex2 : register(t1);
 
 SamplerState sam : register(s0);
 
-
 [numthreads(8, 8, 1)]
 void main(uint3 tid : SV_GroupThreadID, uint3 gid : SV_GroupID) {
 	if (result[0]) {

--- a/src/Magpie.Core/shaders/ImGuiImplPS.hlsl
+++ b/src/Magpie.Core/shaders/ImGuiImplPS.hlsl
@@ -1,0 +1,6 @@
+sampler sampler0;
+Texture2D texture0;
+
+float4 main(float2 coord : TEXCOORD, float4 color : COLOR) : SV_Target {
+	return color * float4(1, 1, 1, texture0.Sample(sampler0, coord).r);
+}

--- a/src/Magpie.Core/shaders/ImGuiImplPS.hlsl
+++ b/src/Magpie.Core/shaders/ImGuiImplPS.hlsl
@@ -1,6 +1,6 @@
-sampler sampler0;
-Texture2D texture0;
+SamplerState sam : register(s0);
+Texture2D tex : register(t0);
 
 float4 main(float2 coord : TEXCOORD, float4 color : COLOR) : SV_Target {
-	return color * float4(1, 1, 1, texture0.Sample(sampler0, coord).r);
+	return color * float4(1, 1, 1, tex.Sample(sam, coord).r);
 }

--- a/src/Magpie.Core/shaders/ImGuiImplVS.hlsl
+++ b/src/Magpie.Core/shaders/ImGuiImplVS.hlsl
@@ -1,0 +1,16 @@
+cbuffer vertexBuffer : register(b0) {
+	float4x4 projectionMatrix;
+};
+
+void main(
+	float4 pos : SV_POSITION,
+	float2 coord : TEXCOORD,
+	float4 color : COLOR,
+	out float2 outCoord : TEXCOORD,
+	out float4 outColor : COLOR,
+	out float4 outPos : SV_POSITION
+) {
+	outPos = mul(projectionMatrix, float4(pos.xy, 0.f, 1.f));
+	outCoord = coord;
+	outColor = color;
+}

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -85,8 +85,8 @@
   <Import Project="XamlIslands.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -94,8 +94,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2151.40\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.UI.Xaml.2.8.6\build\native\Microsoft.UI.Xaml.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.2210.55\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
 </Project>

--- a/src/Magpie/packages.config
+++ b/src/Magpie/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.8.6" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2151.40" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2210.55" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
1. 将渲染 ImGui 使用的着色器从运行时编译改为预先编译。
2. 叠加层支持在一帧里渲染多次，因为我们只在必要时才渲染新帧，参见 https://github.com/ocornut/imgui/issues/2268 。对于某些输入（我们的情况是鼠标操作）ImGui 不会立刻更新，所以不得不重复渲染几次。具体而言，在 WM_LBUTTONUP，WM_RBUTTONUP 两个消息中渲染两次，在显示第一帧前渲染三次，我暂时没有在其他地方遇到这个问题。（还有一个方案是比较 ImDrawData 的哈希，这更好维护，但性能相对较低，因为它要求每帧至少渲染两次。）