### PR TITLE
Fix generation of effect source files in subdirectories

### DIFF
--- a/src/Magpie.Core/EffectCompiler.cpp
+++ b/src/Magpie.Core/EffectCompiler.cpp
@@ -13,6 +13,7 @@
 #include "Win32Utils.h"
 #include "EffectDesc.h"
 #include "BicubicEffect.h"
+#include <filesystem>
 
 namespace Magpie::Core {
 
@@ -1373,8 +1374,11 @@ static uint32_t CompilePasses(
 		cbHlsl.append("cbuffer __CB2 : register(b1) { uint __frameCount; };\n\n");
 	}
 
-	if ((flags & EffectCompilerFlags::SaveSources) && !Win32Utils::DirExists(CommonSharedConstants::SOURCES_DIR)) {
-		if (!CreateDirectory(CommonSharedConstants::SOURCES_DIR, nullptr)) {
+	std::wstring sourcesPathName = fmt::format(L"{}{}", CommonSharedConstants::SOURCES_DIR, StrUtils::UTF8ToUTF16(desc.name));
+	std::wstring sourcesPath = sourcesPathName.substr(0, sourcesPathName.find_last_of(L"\\"));
+
+	if ((flags & EffectCompilerFlags::SaveSources) && !Win32Utils::DirExists(sourcesPath.c_str())) {
+		if (!std::filesystem::create_directories(sourcesPath)) {
 			Logger::Get().Win32Error("创建 sources 文件夹失败");
 		}
 	}
@@ -1395,8 +1399,8 @@ static uint32_t CompilePasses(
 
 		if (flags & EffectCompilerFlags::SaveSources) {
 			std::wstring fileName = desc.passes.size() == 1
-				? fmt::format(L"{}{}.hlsl", CommonSharedConstants::SOURCES_DIR, StrUtils::UTF8ToUTF16(desc.name))
-				: fmt::format(L"{}{}_Pass{}.hlsl", CommonSharedConstants::SOURCES_DIR, StrUtils::UTF8ToUTF16(desc.name), id + 1);
+				? fmt::format(L"{}.hlsl", sourcesPathName)
+				: fmt::format(L"{}_Pass{}.hlsl", sourcesPathName, id + 1);
 
 			if (!Win32Utils::WriteFile(fileName.c_str(), source.data(), source.size())) {
 				Logger::Get().Error(fmt::format("保存 Pass{} 源码失败", id + 1));

--- a/src/Magpie.Core/EffectCompiler.cpp
+++ b/src/Magpie.Core/EffectCompiler.cpp
@@ -13,7 +13,6 @@
 #include "Win32Utils.h"
 #include "EffectDesc.h"
 #include "BicubicEffect.h"
-#include <filesystem>
 
 namespace Magpie::Core {
 
@@ -1374,11 +1373,11 @@ static uint32_t CompilePasses(
 		cbHlsl.append("cbuffer __CB2 : register(b1) { uint __frameCount; };\n\n");
 	}
 
-	std::wstring sourcesPathName = fmt::format(L"{}{}", CommonSharedConstants::SOURCES_DIR, StrUtils::UTF8ToUTF16(desc.name));
-	std::wstring sourcesPath = sourcesPathName.substr(0, sourcesPathName.find_last_of(L"\\"));
+	std::wstring sourcesPathName = StrUtils::Concat(CommonSharedConstants::SOURCES_DIR, StrUtils::UTF8ToUTF16(desc.name));
+	std::wstring sourcesPath = sourcesPathName.substr(0, sourcesPathName.find_last_of(L'\\'));
 
 	if ((flags & EffectCompilerFlags::SaveSources) && !Win32Utils::DirExists(sourcesPath.c_str())) {
-		if (!std::filesystem::create_directories(sourcesPath)) {
+		if (!Win32Utils::CreateDir(sourcesPath, true)) {
 			Logger::Get().Win32Error("创建 sources 文件夹失败");
 		}
 	}
@@ -1399,7 +1398,7 @@ static uint32_t CompilePasses(
 
 		if (flags & EffectCompilerFlags::SaveSources) {
 			std::wstring fileName = desc.passes.size() == 1
-				? fmt::format(L"{}.hlsl", sourcesPathName)
+				? StrUtils::Concat(sourcesPathName, L".hlsl")
 				: fmt::format(L"{}_Pass{}.hlsl", sourcesPathName, id + 1);
 
 			if (!Win32Utils::WriteFile(fileName.c_str(), source.data(), source.size())) {


### PR DESCRIPTION
This pull request should fix saving of intermediate effect source files when the effect file is stored in a subdirectory.

Without this patch enabling "Save source code when parsing effects" results in an error like this `|error|Win32Utils.cpp:bool __cdecl Win32Utils::WriteFile(const wchar_t *,const void *,unsigned __int64) noexcept|打开文件 sources\**\*.hlsl 失败` in the log when the effect is not stored in the root of the `Effects` directory tree.