### PR TITLE
修复找不到可用显卡时回落到 WARP 失败的问题

### DIFF
--- a/src/Magpie.Core/DeviceResources.cpp
+++ b/src/Magpie.Core/DeviceResources.cpp
@@ -182,6 +182,14 @@ bool DeviceResources::_ObtainGraphicsAdapterAndD3DDevice() noexcept {
 		return false;
 	}
 
+	if (_TryCreateD3DDevice(adapter.get())) {
+		DXGI_ADAPTER_DESC1 desc;
+		adapter->GetDesc1(&desc);
+
+		LogAdapter(desc);
+		return true;
+	}
+
 	Logger::Get().Info("已创建 WARP 设备");
 	return true;
 }

--- a/src/Magpie.Core/DeviceResources.cpp
+++ b/src/Magpie.Core/DeviceResources.cpp
@@ -178,19 +178,19 @@ bool DeviceResources::_ObtainGraphicsAdapterAndD3DDevice() noexcept {
 	// https://docs.microsoft.com/en-us/windows/win32/direct3darticles/directx-warp
 	HRESULT hr = _dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&adapter));
 	if (FAILED(hr)) {
+		Logger::Get().ComError("EnumWarpAdapter 失败", hr);
+		return false;
+	}
+
+	if (!_TryCreateD3DDevice(adapter.get())) {
 		Logger::Get().ComError("创建 WARP 设备失败", hr);
 		return false;
 	}
 
-	if (_TryCreateD3DDevice(adapter.get())) {
-		DXGI_ADAPTER_DESC1 desc;
-		adapter->GetDesc1(&desc);
+	DXGI_ADAPTER_DESC1 desc;
+	adapter->GetDesc1(&desc);
+	LogAdapter(desc);
 
-		LogAdapter(desc);
-		return true;
-	}
-
-	Logger::Get().Info("已创建 WARP 设备");
 	return true;
 }
 

--- a/src/Magpie.Core/DeviceResources.cpp
+++ b/src/Magpie.Core/DeviceResources.cpp
@@ -188,8 +188,10 @@ bool DeviceResources::_ObtainGraphicsAdapterAndD3DDevice() noexcept {
 	}
 
 	DXGI_ADAPTER_DESC1 desc;
-	adapter->GetDesc1(&desc);
-	LogAdapter(desc);
+	hr = adapter->GetDesc1(&desc);
+	if (SUCCEEDED(hr)) {
+		LogAdapter(desc);
+	}
 
 	return true;
 }


### PR DESCRIPTION
Close #838 

Magpie 需要显卡支持 DirectX 功能级别 11，如果没有可用的显卡，应回落到使用 CPU 渲染，即 Basic Render Driver Adapter（WARP）。这个 PR 修复因为忘记调用 _TryCreateD3DDevice 导致的回落失败。