### PR TITLE
防止 3D 游戏模式下打开叠加层可能导致的崩溃

### DIFF
--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -298,7 +298,9 @@ bool OverlayDrawer::_BuildFonts() noexcept {
 
 	ImFontAtlas& fontAtlas = *ImGui::GetIO().Fonts;
 
-	bool fontCacheDisabled = MagApp::Get().GetOptions().IsDisableFontCache();
+	const MagOptions& options = MagApp::Get().GetOptions();
+	// 3D 游戏模式下字体纹理中有光标纹理，不支持缓存
+	const bool fontCacheDisabled = options.IsDisableFontCache() || options.Is3DGameMode();
 	if (!fontCacheDisabled && ImGuiFontsCacheManager::Get().Load(language, fontAtlas)) {
 		_fontUI = fontAtlas.Fonts[0];
 		_fontMonoNumbers = fontAtlas.Fonts[1];


### PR DESCRIPTION
Close #649

3D 游戏模式下打开叠加层时光标由 ImGui 渲染，因此字体纹理中含有光标数据，和非 3D 游戏模式中的字体纹理不兼容，这是导致打开叠加层时崩溃的原因。#643 重写了架构，光标不再交给 ImGui 渲染，因此不存在这个 bug。

这个修复针对 v0.10，只是简单的在 3D 游戏模式下禁用字体缓存。