### PR TITLE
优化双线性插值下单色光标和彩色掩码光标的渲染效果

### DIFF
--- a/src/Magpie.Core/CursorDrawer.h
+++ b/src/Magpie.Core/CursorDrawer.h
@@ -63,8 +63,6 @@ private:
 	winrt::com_ptr<ID3D11Texture2D> _tempCursorTexture;
 	winrt::com_ptr<ID3D11ShaderResourceView> _tempCursorTextureRtv;
 	SIZE _tempCursorTextureSize{};
-
-	bool _useBilinearInterpolation = false;
 };
 
 }

--- a/src/Magpie.Core/CursorDrawer.h
+++ b/src/Magpie.Core/CursorDrawer.h
@@ -63,6 +63,8 @@ private:
 	winrt::com_ptr<ID3D11Texture2D> _tempCursorTexture;
 	winrt::com_ptr<ID3D11ShaderResourceView> _tempCursorTextureRtv;
 	SIZE _tempCursorTextureSize{};
+
+	bool _useBilinearInterpolation = false;
 };
 
 }

--- a/src/Magpie.Core/shaders/MaskedCursorPS.hlsl
+++ b/src/Magpie.Core/shaders/MaskedCursorPS.hlsl
@@ -1,15 +1,16 @@
 Texture2D originTex : register(t0);
 Texture2D cursorTex : register(t1);
-SamplerState originSampler : register(s0);
-SamplerState cursorSampler : register(s1);
+
+// 双线性插值会转换为彩色光标，这里只需考虑最近邻插值
+SamplerState pointSampler : register(s0);
 
 float4 main(float2 coord : TEXCOORD) : SV_TARGET {
-	float4 mask = cursorTex.Sample(cursorSampler, coord);
+	float4 mask = cursorTex.Sample(pointSampler, coord);
 	
 	if (mask.a < 0.5f) {
 		return float4(mask.rgb, 1);
 	} else {
-		float3 origin = originTex.Sample(originSampler, coord).rgb;
+		float3 origin = originTex.Sample(pointSampler, coord).rgb;
 		// 255.001953 的由来见 https://stackoverflow.com/questions/52103720/why-does-d3dcolortoubyte4-multiplies-components-by-255-001953f
 		return float4((uint3(origin * 255.001953f) ^ uint3(mask.rgb * 255.001953f)) / 255.0f, 1);
 	}

--- a/src/Magpie.Core/shaders/MaskedCursorPS.hlsl
+++ b/src/Magpie.Core/shaders/MaskedCursorPS.hlsl
@@ -1,7 +1,6 @@
 Texture2D originTex : register(t0);
 Texture2D cursorTex : register(t1);
 
-// 双线性插值会转换为彩色光标，这里只需考虑最近邻插值
 SamplerState pointSampler : register(s0);
 
 float4 main(float2 coord : TEXCOORD) : SV_TARGET {

--- a/src/Magpie.Core/shaders/MonochromeCursorPS.hlsl
+++ b/src/Magpie.Core/shaders/MonochromeCursorPS.hlsl
@@ -1,7 +1,6 @@
 Texture2D originTex : register(t0);
 Texture2D<float2> cursorTex : register(t1);
 
-// 双线性插值会转换为彩色光标，这里只需考虑最近邻插值
 SamplerState pointSampler : register(s0);
 
 float4 main(float2 coord : TEXCOORD) : SV_TARGET {

--- a/src/Magpie.Core/shaders/MonochromeCursorPS.hlsl
+++ b/src/Magpie.Core/shaders/MonochromeCursorPS.hlsl
@@ -1,13 +1,14 @@
 Texture2D originTex : register(t0);
 Texture2D<float2> cursorTex : register(t1);
-SamplerState originSampler : register(s0);
-SamplerState cursorSampler : register(s1);
+
+// 双线性插值会转换为彩色光标，这里只需考虑最近邻插值
+SamplerState pointSampler : register(s0);
 
 float4 main(float2 coord : TEXCOORD) : SV_TARGET {
-	float2 mask = cursorTex.Sample(cursorSampler, coord);
+	float2 mask = cursorTex.Sample(pointSampler, coord);
 	
 	if (mask.x > 0.5f) {
-		float3 origin = originTex.Sample(originSampler, coord).rgb;
+		float3 origin = originTex.Sample(pointSampler, coord).rgb;
 
 		if (mask.y > 0.5f) {
 			return float4(1 - origin, 1);


### PR DESCRIPTION
Close #853 

Desktop Duplication 的文档记录了不同类型的光标的工作方式：[DXGI_OUTDUPL_POINTER_SHAPE_TYPE](https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_2/ne-dxgi1_2-dxgi_outdupl_pointer_shape_type)

单色光标和彩色掩码光标均涉及到掩码操作，双线性插值对它们没有意义，但有些老游戏使用这两种光标却不使用掩码。在当前实现下，即使使用双线性插值，这些光标依然有锐利的边缘，这是因为从不应用掩码状态到应用掩码/透明状态是突变的。

双线性插值下的单色光标：
![image](https://github.com/Blinue/Magpie/assets/34770031/54d73add-a33c-483d-9d78-2bdb6b27cbd4)

此 PR：
![image](https://github.com/Blinue/Magpie/assets/34770031/1a3b1f20-a77d-4b53-854b-93c18f3cccc2)

此 PR 将兼容的单色光标和彩色掩码光标转换为彩色光标。彩色光标的优势在于：

1. 渲染更快，因为可以使用图形管线的混合状态来实现透明度，避免了复制原始纹理。
2. 可以使用预乘 Alpha 优化线性插值结果，使得透明像素和非透明像素之间有着平滑的过渡。

对于使用了掩码的光标不支持双线性插值，它们将始终使用最近邻插值。这样的光标非常少，且双线性插值对它们没有意义，比如最常见的有着反色区域的 I 形光标。