### PR TITLE
简化 ScalingRuntime 状态

### DIFF
--- a/src/Magpie.App/ScalingService.h
+++ b/src/Magpie.App/ScalingService.h
@@ -120,7 +120,7 @@ private:
 
 	fire_and_forget _CheckForegroundTimer_Tick(Threading::ThreadPoolTimer const& timer);
 
-	void _Settings_IsAutoRestoreChanged(bool);
+	void _Settings_IsAutoRestoreChanged(bool value);
 
 	fire_and_forget _ScalingRuntime_IsRunningChanged(bool isRunning);
 

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -279,7 +279,9 @@ void ScalingWindow::Render() noexcept {
 }
 
 void ScalingWindow::ToggleOverlay() noexcept {
-	_renderer->SetOverlayVisibility(!_renderer->IsOverlayVisible());
+	if (_renderer) {
+		_renderer->SetOverlayVisibility(!_renderer->IsOverlayVisible());
+	}
 }
 
 void ScalingWindow::RecreateAfterSrcRepositioned() noexcept {


### PR DESCRIPTION
Close #826 

不再使用 _hwndSrc 作为是否正在缩放的标志，而是使用专用的 _state 成员，有三种状态：

```mermaid
flowchart LR
    Idle--Start()-->Initializing
    Initializing--缩放成功-->Scaling
    Initializing--缩放失败-->Idle
    Scaling--缩放结束-->Idle
```

对于用户来说，Initializing 和 Scaling 为正在缩放状态。当正在缩放时，按下热键可停止缩放，反之则执行缩放。

还修复了一个退出时死锁的 bug。