### PR TITLE
优化窗口边框的裁剪

### DIFF
--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -364,7 +364,7 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 
 				// 如果上边框在客户区内，则裁剪上边框
 				if (windowRect.top == _srcRect.top) {
-					_srcRect.top += GetTopBorderHeight(hwndSrc, _srcRect);
+					_srcRect.top += GetTopBorderHeight(hwndSrc, _srcRect, windowRect);
 				}
 			}
 		}

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -271,6 +271,17 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 			Logger::Get().Error("GetWindowFrameRect 失败");
 			return false;
 		}
+
+		if (Win32Utils::GetOSVersion().IsWin11()) {
+			if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWNORMAL) {
+				uint32_t value = 0;
+				DwmGetWindowAttribute(hwndSrc, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS, &value, sizeof(value));
+				// 保留上边框
+				_srcRect.left += value;
+				_srcRect.right -= value;
+				_srcRect.bottom -= value;
+			}
+		}
 	} else {
 		std::wstring className = Win32Utils::GetWndClassName(hwndSrc);
 		if (className == L"ApplicationFrameWindow" || className == L"Windows.UI.Core.CoreWindow") {

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -228,7 +228,7 @@ static BOOL CALLBACK EnumChildProc(
 	return TRUE;
 }
 
-static HWND FindClientWindowOfUWP(HWND hwndSrc, const wchar_t* clientWndClassName) {
+static HWND FindClientWindowOfUWP(HWND hwndSrc, const wchar_t* clientWndClassName) noexcept {
 	// 查找所有窗口类名为 ApplicationFrameInputSinkWindow 的子窗口
 	// 该子窗口一般为客户区
 	EnumChildWndParam param{};
@@ -262,6 +262,62 @@ static HWND FindClientWindowOfUWP(HWND hwndSrc, const wchar_t* clientWndClassNam
 	return param.childWindows[maxIdx];
 }
 
+static bool GetClientRectOfUWP(HWND hWnd, RECT& rect) noexcept {
+	std::wstring className = Win32Utils::GetWndClassName(hWnd);
+	if (className != L"ApplicationFrameWindow" && className != L"Windows.UI.Core.CoreWindow") {
+		return false;
+	}
+
+	// 客户区窗口类名为 ApplicationFrameInputSinkWindow
+	HWND hwndClient = FindClientWindowOfUWP(hWnd, L"ApplicationFrameInputSinkWindow");
+	if (!hwndClient) {
+		return false;
+	}
+
+	if (!Win32Utils::GetClientScreenRect(hwndClient, rect)) {
+		Logger::Get().Win32Error("GetClientScreenRect 失败");
+		return false;
+	}
+
+	return true;
+}
+
+// 获取窗口上边框高度，不适用于最大化的窗口
+static uint32_t GetTopBorderHeight(HWND hWnd, const RECT& clientRect, const RECT& windowRect) noexcept {
+	// 检查该窗口是否禁用了非客户区域的绘制
+	BOOL hasBorder = TRUE;
+	HRESULT hr = DwmGetWindowAttribute(hWnd, DWMWA_NCRENDERING_ENABLED, &hasBorder, sizeof(hasBorder));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("DwmGetWindowAttribute 失败", hr);
+		return 0;
+	}
+
+	if (!hasBorder) {
+		return 0;
+	}
+
+	// 如果左右下三边均存在边框，那么应视为存在上边框：
+	// * Win10 中窗口很可能绘制了假的上边框，这是很常见的创建无边框窗口的方法
+	// * Win11 中 DWM 会将上边框绘制到客户区
+	if (windowRect.top == clientRect.top && (windowRect.left == clientRect.left ||
+		windowRect.right == clientRect.right || windowRect.bottom == clientRect.bottom)) {
+		return 0;
+	}
+
+	if (Win32Utils::GetOSVersion().IsWin11()) {
+		uint32_t borderThickness = 0;
+		hr = DwmGetWindowAttribute(hWnd, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS, &borderThickness, sizeof(borderThickness));
+		if (FAILED(hr)) {
+			Logger::Get().ComError("DwmGetWindowAttribute 失败", hr);
+			return 0;
+		}
+
+		return borderThickness;
+	} else {
+		return 1;
+	}
+}
+
 bool FrameSourceBase::_CalcSrcRect() noexcept {
 	const ScalingOptions& options = ScalingWindow::Get().Options();
 	const HWND hwndSrc = ScalingWindow::Get().HwndSrc();
@@ -272,34 +328,45 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 			return false;
 		}
 
-		if (Win32Utils::GetOSVersion().IsWin11()) {
-			if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWNORMAL) {
-				uint32_t value = 0;
-				DwmGetWindowAttribute(hwndSrc, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS, &value, sizeof(value));
-				// 保留上边框
-				_srcRect.left += value;
-				_srcRect.right -= value;
-				_srcRect.bottom -= value;
+		if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWNORMAL) {
+			RECT clientRect;
+			if (!Win32Utils::GetClientScreenRect(hwndSrc, clientRect)) {
+				Logger::Get().Win32Error("GetClientScreenRect 失败");
+				return false;
 			}
+
+			// 左右下三边裁剪至客户区
+			_srcRect.left = std::max(_srcRect.left, clientRect.left);
+			_srcRect.right = std::min(_srcRect.right, clientRect.right);
+			_srcRect.bottom = std::min(_srcRect.bottom, clientRect.bottom);
+
+			// 裁剪上边框
+			RECT windowRect;
+			if (!GetWindowRect(hwndSrc, &windowRect)) {
+				Logger::Get().Win32Error("GetWindowRect 失败");
+				return false;
+			}
+			_srcRect.top += GetTopBorderHeight(hwndSrc, clientRect, windowRect);
 		}
 	} else {
-		std::wstring className = Win32Utils::GetWndClassName(hwndSrc);
-		if (className == L"ApplicationFrameWindow" || className == L"Windows.UI.Core.CoreWindow") {
-			// "Modern App"
-			// 客户区窗口类名为 ApplicationFrameInputSinkWindow
-			HWND hwndClient = FindClientWindowOfUWP(hwndSrc, L"ApplicationFrameInputSinkWindow");
-			if (hwndClient) {
-				if (!Win32Utils::GetClientScreenRect(hwndClient, _srcRect)) {
-					Logger::Get().Win32Error("GetClientScreenRect 失败");
+		if (!GetClientRectOfUWP(hwndSrc, _srcRect)) {
+			if (!Win32Utils::GetClientScreenRect(hwndSrc, _srcRect)) {
+				Logger::Get().Error("GetClientScreenRect 失败");
+				return false;
+			}
+
+			if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWNORMAL) {
+				RECT windowRect;
+				if (!GetWindowRect(hwndSrc, &windowRect)) {
+					Logger::Get().Win32Error("GetWindowRect 失败");
+					return false;
+				}
+
+				// 如果上边框在客户区内，则裁剪上边框
+				if (windowRect.top == _srcRect.top) {
+					_srcRect.top += GetTopBorderHeight(hwndSrc, _srcRect);
 				}
 			}
-		}
-	}
-
-	if (_srcRect == RECT{}) {
-		if (!Win32Utils::GetClientScreenRect(hwndSrc, _srcRect)) {
-			Logger::Get().Win32Error("GetClientScreenRect 失败");
-			return false;
 		}
 	}
 

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -267,10 +267,9 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 	const HWND hwndSrc = ScalingWindow::Get().HwndSrc();
 
 	if (options.IsCaptureTitleBar() && _CanCaptureTitleBar()) {
-		HRESULT hr = DwmGetWindowAttribute(hwndSrc,
-			DWMWA_EXTENDED_FRAME_BOUNDS, &_srcRect, sizeof(_srcRect));
-		if (FAILED(hr)) {
-			Logger::Get().ComError("DwmGetWindowAttribute 失败", hr);
+		if (!Win32Utils::GetWindowFrameRect(hwndSrc, _srcRect)) {
+			Logger::Get().Error("GetWindowFrameRect 失败");
+			return false;
 		}
 	} else {
 		std::wstring className = Win32Utils::GetWndClassName(hwndSrc);
@@ -386,8 +385,8 @@ bool FrameSourceBase::_GetMapToOriginDPI(HWND hWnd, double& a, double& bx, doubl
 
 bool FrameSourceBase::_CenterWindowIfNecessary(HWND hWnd, const RECT& rcWork) noexcept {
 	RECT srcRect;
-	if (!GetWindowRect(hWnd, &srcRect)) {
-		Logger::Get().Win32Error("GetWindowRect 失败");
+	if (!Win32Utils::GetWindowFrameRect(hWnd, srcRect)) {
+		Logger::Get().Error("GetWindowFrameRect 失败");
 		return false;
 	}
 

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
@@ -136,7 +136,8 @@ void GraphicsCaptureFrameSource::OnCursorVisibilityChanged(bool isVisible, bool 
 	}
 }
 
-// Graphics Capture 的捕获区域没有文档记录，这里的计算是我实验了多种窗口后得出的
+// Graphics Capture 的捕获区域没有文档记录，这里的计算是我实验了多种窗口后得出的，
+// 高度依赖实现细节，未来可能会失效
 static bool CalcWindowCapturedFrameBounds(HWND hWnd, RECT& rect) noexcept {
 	// Win10 中捕获区域为 extended frame bounds；Win11 中 DwmGetWindowAttribute
 	// 对最大化的窗口返回值和 Win10 不同，可能是 OS 的 bug，应进一步处理
@@ -193,6 +194,11 @@ bool GraphicsCaptureFrameSource::_CaptureWindow(IGraphicsCaptureItemInterop* int
 	RECT frameBounds;
 	if (!CalcWindowCapturedFrameBounds(hwndSrc, frameBounds)) {
 		Logger::Get().Error("CalcWindowCapturedFrameBounds 失败");
+		return false;
+	}
+
+	if (_srcRect.left <= frameBounds.left || _srcRect.top <= frameBounds.top) {
+		Logger::Get().Error("裁剪边框错误");
 		return false;
 	}
 

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
@@ -153,7 +153,10 @@ bool GraphicsCaptureFrameSource::_CaptureWindow(IGraphicsCaptureItemInterop* int
 		Win32Utils::GetClientScreenRect(hwndSrc, clientRect);
 
 		RECT windowRect;
-		GetWindowRect(hwndSrc, &windowRect);
+		if (!GetWindowRect(hwndSrc, &windowRect)) {
+			Logger::Get().Win32Error("GetWindowRect 失败");
+			return false;
+		}
 
 		if (clientRect.top == windowRect.top) {
 			// 使用自定义标题栏的窗口最大化时会捕获到屏幕外的区域！
@@ -205,7 +208,7 @@ bool GraphicsCaptureFrameSource::_CaptureWindow(IGraphicsCaptureItemInterop* int
 	// 如果窗口使用 ITaskbarList 隐藏了任务栏图标也不会出现在 Alt+Tab 列表。这种情况很罕见
 	_taskbarList = winrt::try_create_instance<ITaskbarList>(CLSID_TaskbarList);
 	if (_taskbarList && SUCCEEDED(_taskbarList->HrInit())) {
-		HRESULT hr = _taskbarList->AddTab(hwndSrc);
+		hr = _taskbarList->AddTab(hwndSrc);
 		if (SUCCEEDED(hr)) {
 			Logger::Get().Info("已添加任务栏图标");
 

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
@@ -136,51 +136,68 @@ void GraphicsCaptureFrameSource::OnCursorVisibilityChanged(bool isVisible, bool 
 	}
 }
 
-bool GraphicsCaptureFrameSource::_CaptureWindow(IGraphicsCaptureItemInterop* interop) noexcept {
-	const HWND hwndSrc = ScalingWindow::Get().HwndSrc();
-
-	// Graphics Capture 的捕获区域没有文档记录，下面是实验了多种窗口后得出的结果
-	RECT srcFrameBounds{};
-	HRESULT hr = DwmGetWindowAttribute(hwndSrc,
-		DWMWA_EXTENDED_FRAME_BOUNDS, &srcFrameBounds, sizeof(srcFrameBounds));
+// Graphics Capture 的捕获区域没有文档记录，这里的计算是我实验了多种窗口后得出的
+static bool CalcWindowCapturedFrameBounds(HWND hWnd, RECT& rect) noexcept {
+	// Win10 中捕获区域为 extended frame bounds，Win11 却有所不同
+	HRESULT hr = DwmGetWindowAttribute(hWnd,
+		DWMWA_EXTENDED_FRAME_BOUNDS, &rect, sizeof(rect));
 	if (FAILED(hr)) {
 		Logger::Get().ComError("DwmGetWindowAttribute 失败", hr);
 		return false;
 	}
+	
+	if(!Win32Utils::GetOSVersion().IsWin11() || Win32Utils::GetWindowShowCmd(hWnd) != SW_SHOWMAXIMIZED) {
+		return true;
+	}
 
-	if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWMAXIMIZED) {
-		RECT clientRect;
-		Win32Utils::GetClientScreenRect(hwndSrc, clientRect);
+	// Win11 中最大化的窗口的捕获区域和 Win10 不同，这很可能是 OS 的 bug
+	// 检查窗口是否自定义了标题栏，即上边界是否存在非客户区
+	RECT clientRect;
+	if (!Win32Utils::GetClientScreenRect(hWnd, clientRect)) {
+		Logger::Get().Error("GetClientScreenRect 失败");
+		return false;
+	}
 
-		RECT windowRect;
-		if (!GetWindowRect(hwndSrc, &windowRect)) {
-			Logger::Get().Win32Error("GetWindowRect 失败");
+	RECT windowRect;
+	if (!GetWindowRect(hWnd, &windowRect)) {
+		Logger::Get().Win32Error("GetWindowRect 失败");
+		return false;
+	}
+
+	if (clientRect.top == windowRect.top) {
+		// 自定义了标题栏的窗口捕获区域为客户区，即使部分客户区位于屏幕之外
+		IntersectRect(&rect, &rect, &clientRect);
+	} else {
+		// 使用原生标题栏的窗口最大化时只会捕获屏幕内的区域
+		HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+		MONITORINFO mi{ .cbSize = sizeof(mi) };
+		if (!GetMonitorInfo(hMon, &mi)) {
+			Logger::Get().Win32Error("GetMonitorInfo 失败");
 			return false;
 		}
+		IntersectRect(&rect, &rect, &mi.rcWork);
+	}
 
-		if (clientRect.top == windowRect.top) {
-			// 使用自定义标题栏的窗口最大化时会捕获到屏幕外的区域！
-			IntersectRect(&srcFrameBounds, &srcFrameBounds, &clientRect);
-		} else {
-			// 使用原生标题栏的窗口最大化时只会捕获屏幕内的区域
-			HMONITOR hMon = MonitorFromWindow(hwndSrc, MONITOR_DEFAULTTONEAREST);
-			MONITORINFO mi{ .cbSize = sizeof(mi) };
-			if (!GetMonitorInfo(hMon, &mi)) {
-				Logger::Get().Win32Error("GetMonitorInfo 失败");
-				return false;
-			}
-			IntersectRect(&srcFrameBounds, &srcFrameBounds, &mi.rcWork);
-		}
+	return true;
+}
+
+bool GraphicsCaptureFrameSource::_CaptureWindow(IGraphicsCaptureItemInterop* interop) noexcept {
+	const HWND hwndSrc = ScalingWindow::Get().HwndSrc();
+
+	RECT frameBounds;
+	if (!CalcWindowCapturedFrameBounds(hwndSrc, frameBounds)) {
+		Logger::Get().Error("CalcWindowCapturedFrameBounds 失败");
+		return false;
 	}
 
 	// 在源窗口存在 DPI 缩放时有时会有一像素的偏移（取决于窗口在屏幕上的位置）
 	// 可能是 DwmGetWindowAttribute 的 bug
 	_frameBox = {
-		UINT(_srcRect.left - srcFrameBounds.left),
-		UINT(_srcRect.top - srcFrameBounds.top),
+		UINT(_srcRect.left - frameBounds.left),
+		UINT(_srcRect.top - frameBounds.top),
 		0,
-		UINT(_srcRect.right - srcFrameBounds.left),
-		UINT(_srcRect.bottom - srcFrameBounds.top),
+		UINT(_srcRect.right - frameBounds.left),
+		UINT(_srcRect.bottom - frameBounds.top),
 		1
 	};
 
@@ -208,7 +225,7 @@ bool GraphicsCaptureFrameSource::_CaptureWindow(IGraphicsCaptureItemInterop* int
 	// 如果窗口使用 ITaskbarList 隐藏了任务栏图标也不会出现在 Alt+Tab 列表。这种情况很罕见
 	_taskbarList = winrt::try_create_instance<ITaskbarList>(CLSID_TaskbarList);
 	if (_taskbarList && SUCCEEDED(_taskbarList->HrInit())) {
-		hr = _taskbarList->AddTab(hwndSrc);
+		HRESULT hr = _taskbarList->AddTab(hwndSrc);
 		if (SUCCEEDED(hr)) {
 			Logger::Get().Info("已添加任务栏图标");
 

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
@@ -126,9 +126,11 @@ void GraphicsCaptureFrameSource::OnCursorVisibilityChanged(bool isVisible, bool 
 	// 显示光标时必须重启捕获
 	if (isVisible) {
 		_StopCapture();
-		SystemParametersInfo(SPI_SETCURSORS, 0, nullptr, 0);
-
-		if (!onDestory) {
+		
+		if (onDestory) {
+			// FIXME: 这里尝试修复拖动窗口时光标不显示的问题，但有些环境下不起作用
+			SystemParametersInfo(SPI_SETCURSORS, 0, nullptr, 0);
+		} else {
 			_StartCapture();
 		}
 	}

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -453,7 +453,7 @@ bool ScalingWindow::_CheckForeground(HWND hwndForeground) const noexcept {
 		return true;
 	}
 
-	// 允许稍微重叠，否则前台窗口最大化时会意外退出
+	// 允许稍微重叠，减少意外停止缩放的机率
 	SIZE rectSize = Win32Utils::GetSizeOfRect(rectForground);
 	return rectSize.cx < 8 || rectSize.cy < 8;
 }

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -455,7 +455,9 @@ protected:
 
 		// Win10 中窗口边框始终只有一个像素宽，Win11 中的窗口边框宽度和 DPI 缩放有关
 		if (Win32Utils::GetOSVersion().IsWin11()) {
-			return (_currentDpi + USER_DEFAULT_SCREEN_DPI / 2) / USER_DEFAULT_SCREEN_DPI;
+			uint32_t value = 0;
+			DwmGetWindowAttribute(_hWnd, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS, &value, sizeof(value));
+			return value;
 		} else {
 			return 1;
 		}

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -8,7 +8,7 @@
 #include <dwmapi.h>
 #include <parallel_hashmap/phmap.h>
 
-std::wstring Win32Utils::GetWndClassName(HWND hWnd) {
+std::wstring Win32Utils::GetWndClassName(HWND hWnd) noexcept {
 	// 窗口类名最多 256 个字符
 	std::wstring className(256, 0);
 	int num = GetClassName(hWnd, &className[0], (int)className.size() + 1);
@@ -21,7 +21,7 @@ std::wstring Win32Utils::GetWndClassName(HWND hWnd) {
 	return className;
 }
 
-std::wstring Win32Utils::GetWndTitle(HWND hWnd) {
+std::wstring Win32Utils::GetWndTitle(HWND hWnd) noexcept {
 	int len = GetWindowTextLength(hWnd);
 	if (len == 0) {
 		return {};
@@ -33,7 +33,7 @@ std::wstring Win32Utils::GetWndTitle(HWND hWnd) {
 	return title;
 }
 
-std::wstring Win32Utils::GetPathOfWnd(HWND hWnd) {
+std::wstring Win32Utils::GetPathOfWnd(HWND hWnd) noexcept {
 	ScopedHandle hProc;
 
 	DWORD dwProcId = 0;
@@ -73,7 +73,7 @@ std::wstring Win32Utils::GetPathOfWnd(HWND hWnd) {
 	return fileName;
 }
 
-UINT Win32Utils::GetWindowShowCmd(HWND hWnd) {
+UINT Win32Utils::GetWindowShowCmd(HWND hWnd) noexcept {
 	assert(hWnd != NULL);
 
 	WINDOWPLACEMENT wp{};
@@ -85,7 +85,7 @@ UINT Win32Utils::GetWindowShowCmd(HWND hWnd) {
 	return wp.showCmd;
 }
 
-bool Win32Utils::GetClientScreenRect(HWND hWnd, RECT& rect) {
+bool Win32Utils::GetClientScreenRect(HWND hWnd, RECT& rect) noexcept {
 	if (!GetClientRect(hWnd, &rect)) {
 		Logger::Get().Win32Error("GetClientRect 出错");
 		return false;
@@ -105,7 +105,30 @@ bool Win32Utils::GetClientScreenRect(HWND hWnd, RECT& rect) {
 	return true;
 }
 
-bool Win32Utils::ReadFile(const wchar_t* fileName, std::vector<BYTE>& result) {
+bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
+	HRESULT hr = DwmGetWindowAttribute(hWnd,
+		DWMWA_EXTENDED_FRAME_BOUNDS, &rect, sizeof(rect));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("DwmGetWindowAttribute 失败", hr);
+		return false;
+	}
+
+	// 最大化的窗口有一部分在屏幕外面
+	if (GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED) {
+		HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+		MONITORINFO mi{ .cbSize = sizeof(mi) };
+		if (!GetMonitorInfo(hMon, &mi)) {
+			Logger::Get().Win32Error("GetMonitorInfo 失败");
+			return false;
+		}
+
+		IntersectRect(&rect, &rect, &mi.rcWork);
+	}
+
+	return true;
+}
+
+bool Win32Utils::ReadFile(const wchar_t* fileName, std::vector<BYTE>& result) noexcept {
 	Logger::Get().Info(StrUtils::Concat("读取文件：", StrUtils::UTF16ToUTF8(fileName)));
 
 	CREATEFILE2_EXTENDED_PARAMETERS extendedParams = {};

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -113,7 +113,8 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 		return false;
 	}
 
-	// 最大化的窗口有一部分在屏幕外面
+	// Win11 中最大化的窗口的 extended frame bounds 有一部分在屏幕外面，
+	// 不清楚 Win10 是否有这种情况
 	if (GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED) {
 		HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
 		MONITORINFO mi{ .cbSize = sizeof(mi) };

--- a/src/Shared/Win32Utils.h
+++ b/src/Shared/Win32Utils.h
@@ -10,17 +10,19 @@ struct Win32Utils {
 		return r1.right > r2.left && r1.bottom > r2.top && r1.left < r2.right&& r1.top < r2.bottom;
 	}
 
-	static std::wstring GetWndClassName(HWND hWnd);
+	static std::wstring GetWndClassName(HWND hWnd) noexcept;
 
-	static std::wstring GetWndTitle(HWND hWnd);
+	static std::wstring GetWndTitle(HWND hWnd) noexcept;
 
-	static std::wstring GetPathOfWnd(HWND hWnd);
+	static std::wstring GetPathOfWnd(HWND hWnd) noexcept;
 
-	static UINT GetWindowShowCmd(HWND hWnd);
+	static UINT GetWindowShowCmd(HWND hWnd) noexcept;
 
-	static bool GetClientScreenRect(HWND hWnd, RECT& rect);
+	static bool GetClientScreenRect(HWND hWnd, RECT& rect) noexcept;
 
-	static bool ReadFile(const wchar_t* fileName, std::vector<BYTE>& result);
+	static bool GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept;
+
+	static bool ReadFile(const wchar_t* fileName, std::vector<BYTE>& result) noexcept;
 
 	static bool ReadTextFile(const wchar_t* fileName, std::string& result) noexcept;
 


### PR DESCRIPTION
1. 优化了对最大化窗口的支持
   * 修复 Win11 中最大化窗口的不正确裁剪，这是因为 Win11 中 DwmGetWindowAttribute 返回值发生了变化，且 Graphics Capture 捕获区域也和 Win10 不同。由于缺少文档，我测试了很多类型的窗口来做适配，因此现在的实现高度依赖 OS 的实现细节，可能会在未来失效。
   * 修复 Desktop Duplication 无法捕获最大化的窗口的问题。
   * 修复最大化窗口被认为跨越了多个屏幕的问题。
2. 自动裁剪上边框。这里要考虑太多因素，因为 Win32 窗口实现可谓花样百出。
   1. 如果窗口已最大化，则认为它没有上边框。
   2. 如果窗口禁用了非客户区绘制，则认为它没有上边框。这可以使用 DwmGetWindowAttribute 查询。
   3. 如果窗口使用系统原生边框，则认为它有上边框（仅限捕获标题栏时）。
   4. 如果窗口将客户区扩展到整个窗口，则 DWM 也不会绘制边框。这类窗口的例子包括 https://github.com/melak47/BorderlessWindow 、steam、很多国产应用，基本上没有系统原生边框的窗口都使用这个技术。
   5. 如果窗口自定义了标题栏，而保留了左右下三个方向的原生边框，则认为它**有**上边框。在 Win11 中，DWM 会绘制原生上边框；在 Win10 中，这类窗口很可能会自行绘制上边框（如 Chrome、UWP 等）或者使用 DwmExtendFrameIntoClientArea 保留系统原生上边框（如 Magpie 主窗口、Windows Terminal 等）。
4. 启用捕获标题栏时也裁剪窗口边框，包括上边框。