### PR TITLE
禁止缩放完整性级别更高的窗口

### DIFF
--- a/src/Magpie.App/ScalingService.h
+++ b/src/Magpie.App/ScalingService.h
@@ -128,7 +128,7 @@ private:
 
 	void _ScaleForegroundWindow();
 
-	bool _CheckSrcWnd(HWND hWnd) noexcept;
+	bool _CheckSrcWnd(HWND hWnd, bool checkIL) noexcept;
 
 	std::unique_ptr<::Magpie::Core::ScalingRuntime> _scalingRuntime;
 	CoreDispatcher _dispatcher{ nullptr };

--- a/src/Shared/Win32Utils.h
+++ b/src/Shared/Win32Utils.h
@@ -159,6 +159,8 @@ struct Win32Utils {
 
 	static bool IsProcessElevated() noexcept;
 
+	static bool GetProcessIntegrityLevel(HANDLE hQueryToken, DWORD& integrityLevel) noexcept;
+
 	// VARIANT 封装，自动管理生命周期
 	struct Variant : public VARIANT {
 		Variant() noexcept {


### PR DESCRIPTION
由于 UIPI (用户界面特权隔离)，当高完整性级别 (integrity level) 的窗口位于前台时，很多调用会失败，比如设置光标位置、禁用圆角等。虽然也可以在这种情况下允许功能降级，但可能造成困惑 #831。出于一致性考虑，禁止缩放完整性级别更高的窗口。