### PR TITLE
修复对全屏窗口的支持

### DIFF
--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -357,10 +357,16 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 		}
 		
 		if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWMAXIMIZED) {
-			if (!Win32Utils::ClipMaximizedWindowRect(hwndSrc, _srcRect)) {
-				Logger::Get().Error("ClipMaximizedWindowRect 失败");
+			// 最大化的窗口可能有一部分客户区在屏幕外，但只有屏幕内是有效区域，
+			// 因此裁剪到屏幕边界
+			HMONITOR hMon = MonitorFromWindow(hwndSrc, MONITOR_DEFAULTTONEAREST);
+			MONITORINFO mi{ .cbSize = sizeof(mi) };
+			if (!GetMonitorInfo(hMon, &mi)) {
+				Logger::Get().Win32Error("GetMonitorInfo 失败");
 				return false;
 			}
+
+			IntersectRect(&_srcRect, &_srcRect, &mi.rcMonitor);
 		} else {
 			RECT windowRect;
 			if (!GetWindowRect(hwndSrc, &windowRect)) {
@@ -467,6 +473,10 @@ bool FrameSourceBase::_GetMapToOriginDPI(HWND hWnd, double& a, double& bx, doubl
 }
 
 bool FrameSourceBase::_CenterWindowIfNecessary(HWND hWnd, const RECT& rcWork) noexcept {
+	if (Win32Utils::GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED) {
+		return true;
+	}
+
 	RECT srcRect;
 	if (!Win32Utils::GetWindowFrameRect(hWnd, srcRect)) {
 		Logger::Get().Error("GetWindowFrameRect 失败");

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -357,8 +357,8 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 		}
 		
 		if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWMAXIMIZED) {
-			if (!Win32Utils::AdjustMaximizedWindowRect(hwndSrc, _srcRect)) {
-				Logger::Get().Error("AdjustMaximizedWindowRect 失败");
+			if (!Win32Utils::ClipMaximizedWindowRect(hwndSrc, _srcRect)) {
+				Logger::Get().Error("ClipMaximizedWindowRect 失败");
 				return false;
 			}
 		} else {

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -357,15 +357,10 @@ bool FrameSourceBase::_CalcSrcRect() noexcept {
 		}
 		
 		if (Win32Utils::GetWindowShowCmd(hwndSrc) == SW_SHOWMAXIMIZED) {
-			// 最大化的窗口可能有一部分客户区在屏幕外面
-			HMONITOR hMon = MonitorFromWindow(hwndSrc, MONITOR_DEFAULTTONEAREST);
-			MONITORINFO mi{ .cbSize = sizeof(mi) };
-			if (!GetMonitorInfo(hMon, &mi)) {
-				Logger::Get().Win32Error("GetMonitorInfo 失败");
+			if (!Win32Utils::AdjustMaximizedWindowRect(hwndSrc, _srcRect)) {
+				Logger::Get().Error("AdjustMaximizedWindowRect 失败");
 				return false;
 			}
-
-			IntersectRect(&_srcRect, &_srcRect, &mi.rcWork);
 		} else {
 			RECT windowRect;
 			if (!GetWindowRect(hwndSrc, &windowRect)) {

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -116,14 +116,10 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 	// Win11 中最大化的窗口的 extended frame bounds 有一部分在屏幕外面，
 	// 不清楚 Win10 是否有这种情况
 	if (GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED) {
-		HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
-		MONITORINFO mi{ .cbSize = sizeof(mi) };
-		if (!GetMonitorInfo(hMon, &mi)) {
-			Logger::Get().Win32Error("GetMonitorInfo 失败");
+		if (!AdjustMaximizedWindowRect(hWnd, rect)) {
+			Logger::Get().Error("AdjustMaximizedWindowRect 失败");
 			return false;
 		}
-
-		IntersectRect(&rect, &rect, &mi.rcWork);
 	}
 
 	// 对于使用 SetWindowRgn 自定义形状的窗口，裁剪到最小矩形边框
@@ -142,6 +138,30 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 		IntersectRect(&rect, &rect, &rgnRect);
 	}
 
+	return true;
+}
+
+// 对于最大化窗口，裁剪出 rect 中的有效区域
+bool Win32Utils::AdjustMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept {
+	assert(GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED);
+
+	HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+	MONITORINFO mi{ .cbSize = sizeof(mi) };
+	if (!GetMonitorInfo(hMon, &mi)) {
+		Logger::Get().Win32Error("GetMonitorInfo 失败");
+		return false;
+	}
+
+	BOOL hasBorder = TRUE;
+	HRESULT hr = DwmGetWindowAttribute(hWnd, DWMWA_NCRENDERING_ENABLED, &hasBorder, sizeof(hasBorder));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("DwmGetWindowAttribute 失败", hr);
+		return false;
+	}
+
+	// 当存在系统原生边框时窗口是原生最大化，有效区域在屏幕的工作区内；否则可能
+	// 是全屏最大化，比如 Chrome 的全屏
+	IntersectRect(&rect, &rect, hasBorder ? &mi.rcWork : &mi.rcMonitor);
 	return true;
 }
 

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -116,8 +116,8 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 	// Win11 中最大化的窗口的 extended frame bounds 有一部分在屏幕外面，
 	// 不清楚 Win10 是否有这种情况
 	if (GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED) {
-		if (!AdjustMaximizedWindowRect(hWnd, rect)) {
-			Logger::Get().Error("AdjustMaximizedWindowRect 失败");
+		if (!ClipMaximizedWindowRect(hWnd, rect)) {
+			Logger::Get().Error("ClipMaximizedWindowRect 失败");
 			return false;
 		}
 	}
@@ -142,7 +142,7 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 }
 
 // 对于最大化窗口，裁剪出 rect 中的有效区域
-bool Win32Utils::AdjustMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept {
+bool Win32Utils::ClipMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept {
 	assert(GetWindowShowCmd(hWnd) == SW_SHOWMAXIMIZED);
 
 	HMONITOR hMon = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -127,8 +127,8 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 		// 的窗口，缩放窗口就使用了这个技术以和 Wallpaper Engine 兼容。OS 虽然不
 		// 会阻止跨越多个屏幕，但只在一个屏幕上有画面，因此可以认为最大化的窗口只在
 		// 一个屏幕上。
-		// 注意 Win11 中最大化窗口的 extended frame bounds 包含了下边框，这对我们
-		// 没有影响，缩放时下边框始终会被裁剪掉。
+		// 注意 Win11 中最大化窗口的 extended frame bounds 包含了下边框，但对我们
+		// 没有影响，因为缩放时下边框始终会被裁剪掉。
 		IntersectRect(&rect, &rect, &mi.rcMonitor);
 	}
 

--- a/src/Shared/Win32Utils.cpp
+++ b/src/Shared/Win32Utils.cpp
@@ -123,6 +123,12 @@ bool Win32Utils::GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept {
 			return false;
 		}
 
+		// 不能裁剪到工作区，因为窗口可以使用 SetWindowPos 以任意尺寸显示“最大化”
+		// 的窗口，缩放窗口就使用了这个技术以和 Wallpaper Engine 兼容。OS 虽然不
+		// 会阻止跨越多个屏幕，但只在一个屏幕上有画面，因此可以认为最大化的窗口只在
+		// 一个屏幕上。
+		// 注意 Win11 中最大化窗口的 extended frame bounds 包含了下边框，这对我们
+		// 没有影响，缩放时下边框始终会被裁剪掉。
 		IntersectRect(&rect, &rect, &mi.rcMonitor);
 	}
 

--- a/src/Shared/Win32Utils.h
+++ b/src/Shared/Win32Utils.h
@@ -22,6 +22,8 @@ struct Win32Utils {
 
 	static bool GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept;
 
+	static bool AdjustMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept;
+
 	static bool IsWindowVisible(HWND hWnd) noexcept;
 
 	static bool ReadFile(const wchar_t* fileName, std::vector<BYTE>& result) noexcept;

--- a/src/Shared/Win32Utils.h
+++ b/src/Shared/Win32Utils.h
@@ -22,7 +22,7 @@ struct Win32Utils {
 
 	static bool GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept;
 
-	static bool AdjustMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept;
+	static bool ClipMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept;
 
 	static bool IsWindowVisible(HWND hWnd) noexcept;
 

--- a/src/Shared/Win32Utils.h
+++ b/src/Shared/Win32Utils.h
@@ -22,8 +22,6 @@ struct Win32Utils {
 
 	static bool GetWindowFrameRect(HWND hWnd, RECT& rect) noexcept;
 
-	static bool ClipMaximizedWindowRect(HWND hWnd, RECT& rect) noexcept;
-
 	static bool IsWindowVisible(HWND hWnd) noexcept;
 
 	static bool ReadFile(const wchar_t* fileName, std::vector<BYTE>& result) noexcept;


### PR DESCRIPTION
Close #876

有些全屏的窗口实际上是“最大化”的，比如 Magpie 缩放窗口为了和 Wallpaper Engine 兼容 #812 就使用了这个技术。因此现在情况比较复杂了：

1. 原生最大化窗口需要裁剪到屏幕工作区，由于最大化窗口的实现机制，窗口有一部分位于工作区外，在 Win11 中甚至下边框也是存在的。
2. 全屏最大化窗口通常会覆盖任务栏，因此应裁剪到屏幕边界，而不是工作区。Windows 不会阻止全屏最大化窗口跨越多个屏幕，但依然只会在一个屏幕上渲染，因此可以认为全屏最大化窗口和原生最大化窗口一样不能跨越多个屏幕。

以是否绘制了原生边框区分这两种窗口。