### PR TITLE
缩放配置页面不再展示添加/删除动画

### DIFF
--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -110,7 +110,6 @@
 			<local:SettingsGroup x:Uid="ScalingConfiguration_ScalingModes">
 				<!--  Padding 是为了缓解一个动画 bug  -->
 				<ListView Padding="0,0,0,45"
-				          ItemContainerTransitions="{x:Bind ViewModel.ScalingModesListTransitions, Mode=OneWay}"
 				          ItemsSource="{x:Bind ViewModel.ScalingModes, Mode=OneTime}"
 				          SelectionMode="None"
 				          TabNavigation="Local">
@@ -120,6 +119,12 @@
 							                        Spacing="2" />
 						</ItemsPanelTemplate>
 					</ListView.ItemsPanel>
+					<ListView.ItemContainerTransitions>
+						<TransitionCollection>
+							<ContentThemeTransition />
+							<RepositionThemeTransition IsStaggeringEnabled="False" />
+						</TransitionCollection>
+					</ListView.ItemContainerTransitions>
 					<ListView.Resources>
 						<Style TargetType="ListViewItem">
 							<Setter Property="Padding" Value="0" />

--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -280,6 +280,12 @@
 									          ItemsSource="{x:Bind Effects, Mode=OneTime}"
 									          SelectionMode="None"
 									          TabNavigation="Local">
+										<ListView.ItemContainerTransitions>
+											<TransitionCollection>
+												<ContentThemeTransition />
+												<RepositionThemeTransition IsStaggeringEnabled="False" />
+											</TransitionCollection>
+										</ListView.ItemContainerTransitions>
 										<ListView.Resources>
 											<Style TargetType="ListViewItem">
 												<Setter Property="Margin" Value="0" />

--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -286,6 +286,13 @@
 												<RepositionThemeTransition IsStaggeringEnabled="False" />
 											</TransitionCollection>
 										</ListView.ItemContainerTransitions>
+										<ListView.ItemsPanel>
+											<ItemsPanelTemplate>
+												<!--  SimpleStackPanel 不支持拖拽  -->
+												<StackPanel ChildrenTransitions="{StaticResource SettingsCardsAnimations}"
+												            Orientation="Vertical" />
+											</ItemsPanelTemplate>
+										</ListView.ItemsPanel>
 										<ListView.Resources>
 											<Style TargetType="ListViewItem">
 												<Setter Property="Margin" Value="0" />

--- a/src/Magpie.App/ScalingConfigurationViewModel.cpp
+++ b/src/Magpie.App/ScalingConfigurationViewModel.cpp
@@ -18,11 +18,6 @@ using namespace ::Magpie::Core;
 namespace winrt::Magpie::App::implementation {
 
 ScalingConfigurationViewModel::ScalingConfigurationViewModel() {
-	_scalingModesListTransitions.Append(Animation::ContentThemeTransition());
-	Animation::RepositionThemeTransition respositionAnime;
-	respositionAnime.IsStaggeringEnabled(false);
-	_scalingModesListTransitions.Append(std::move(respositionAnime));
-
 	_AddScalingModes();
 
 	_scalingModeAddedRevoker = ScalingModesService::Get().ScalingModeAdded(
@@ -203,22 +198,6 @@ fire_and_forget ScalingConfigurationViewModel::_AddScalingModes(bool isInitialEx
 	}
 
 	_addingScalingModes = false;
-
-	if (!_scalingModesInitialized) {
-		_scalingModesInitialized = true;
-
-		// 在所有缩放模式初始化完毕后再展示添加/删除动画
-		if (dispatcher) {
-			auto weakThis = get_weak();
-			co_await 10ms;
-			co_await dispatcher;
-			if (!weakThis.get()) {
-				co_return;
-			}
-		}
-		
-		_scalingModesListTransitions.Append(Animation::AddDeleteThemeTransition());
-	}
 }
 
 void ScalingConfigurationViewModel::_ScalingModesService_Added(EffectAddedWay way) {
@@ -226,7 +205,7 @@ void ScalingConfigurationViewModel::_ScalingModesService_Added(EffectAddedWay wa
 }
 
 void ScalingConfigurationViewModel::_ScalingModesService_Moved(uint32_t index, bool isMoveUp) {
-	uint32_t targetIndex = isMoveUp ? index - 1 : index + 1;
+	const uint32_t targetIndex = isMoveUp ? index - 1 : index + 1;
 
 	ScalingModeItem targetItem = _scalingModes.GetAt(targetIndex).as<ScalingModeItem>();
 	_scalingModes.RemoveAt(targetIndex);

--- a/src/Magpie.App/ScalingConfigurationViewModel.h
+++ b/src/Magpie.App/ScalingConfigurationViewModel.h
@@ -35,10 +35,6 @@ struct ScalingConfigurationViewModel : ScalingConfigurationViewModelT<ScalingCon
 		_propertyChangedEvent(*this, PropertyChangedEventArgs(L"ShowErrorMessage"));
 	}
 
-	Animation::TransitionCollection ScalingModesListTransitions() const noexcept {
-		return _scalingModesListTransitions;
-	}
-
 	IObservableVector<IInspectable> ScalingModes() const noexcept {
 		return _scalingModes;
 	}
@@ -83,8 +79,6 @@ private:
 
 	event<PropertyChangedEventHandler> _propertyChangedEvent;
 
-	Animation::TransitionCollection _scalingModesListTransitions;
-
 	IObservableVector<IInspectable> _scalingModes = single_threaded_observable_vector<IInspectable>();
 
 	WinRTUtils::EventRevoker _scalingModeAddedRevoker;
@@ -96,9 +90,7 @@ private:
 	int _newScalingModeCopyFrom = 0;
 
 	bool _showErrorMessage = false;
-
 	bool _addingScalingModes = false;
-	bool _scalingModesInitialized = false;
 };
 
 }

--- a/src/Magpie.App/ScalingConfigurationViewModel.idl
+++ b/src/Magpie.App/ScalingConfigurationViewModel.idl
@@ -8,7 +8,6 @@ namespace Magpie.App {
 
         Boolean ShowErrorMessage;
         
-        Windows.UI.Xaml.Media.Animation.TransitionCollection ScalingModesListTransitions { get; };
         IObservableVector<IInspectable> ScalingModes { get; };
 
         void PrepareForAdd();

--- a/src/Magpie.App/SettingsExpander.Resource.xaml
+++ b/src/Magpie.App/SettingsExpander.Resource.xaml
@@ -81,12 +81,8 @@
 								                    IsClickEnabled="False" />
 							</muxc:Expander.Header>
 							<muxc:Expander.Content>
-								<Grid>
-									<Grid.RowDefinitions>
-										<RowDefinition Height="Auto" />
-										<RowDefinition Height="*" />
-										<RowDefinition Height="Auto" />
-									</Grid.RowDefinitions>
+								<local:SimpleStackPanel Background="{ThemeResource SettingsCardBackground}"
+								                        ChildrenTransitions="{StaticResource SettingsCardsAnimations}">
 									<ContentPresenter Content="{TemplateBinding ItemsHeader}" />
 									<!--  ItemsRepeater 无法在 XAML Islands 中使用，见 https://github.com/microsoft/microsoft-ui-xaml/issues/2349  -->
 									<ItemsControl x:Name="PART_ItemsContainer"
@@ -95,7 +91,7 @@
 									              ItemTemplate="{Binding ItemTemplate, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
 									<ContentPresenter Grid.Row="2"
 									                  Content="{TemplateBinding ItemsFooter}" />
-								</Grid>
+								</local:SimpleStackPanel>
 							</muxc:Expander.Content>
 						</muxc:Expander>
 					</ControlTemplate>


### PR DESCRIPTION
Close #878 

添加/删除项目的动画会导致 bug，除了 #878 的动画 bug，还会导致缩放模式在错误的时机折叠，我没有调查具体原因。除了这两个 bug，还有其他原因使我决定删除这个动画：

1. 动画过于冗长，而且无法设置时长。删除这个动画能使 UI 响应更快
2. 和整体风格保持一致，导航栏以及其他页面都没有添加/删除动画

添加了其他动画让 UI 不那么朴素。