### PR TITLE
修复 SimpleStackPanel 的子项绑定有时不起作用的问题

### DIFF
--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -288,7 +288,7 @@
 										</ListView.ItemContainerTransitions>
 										<ListView.ItemsPanel>
 											<ItemsPanelTemplate>
-												<!--  SimpleStackPanel 不支持拖拽  -->
+												<!--  SimpleStackPanel 不支持拖放  -->
 												<StackPanel ChildrenTransitions="{StaticResource SettingsCardsAnimations}"
 												            Orientation="Vertical" />
 											</ItemsPanelTemplate>

--- a/src/Magpie.App/SimpleStackPanel.cpp
+++ b/src/Magpie.App/SimpleStackPanel.cpp
@@ -46,12 +46,14 @@ Size SimpleStackPanel::MeasureOverride(const Size& availableSize) const {
 	Size finalSize{ paddings.Width, paddings.Height };
 
 	for (UIElement const& item : Children()) {
+		// 调用 Measure 可以初始化绑定，因此即使子项不可见也要调用
+		item.Measure(childAvailableSize);
+
 		if (item.Visibility() == Visibility::Collapsed) {
 			// 不可见的子项不添加间距
 			continue;
 		}
 
-		item.Measure(childAvailableSize);
 		const Size itemSize = item.DesiredSize();
 
 		if (isVertical) {


### PR DESCRIPTION
看起来 x:bind 是在 Measure 时执行绑定，因此即使子项是隐藏的，也应调用 Measure。