### PR TITLE
修复缩放配置页面的设置项错误折叠的问题

### DIFF
--- a/src/Magpie.App/ScalingConfigurationPage.xaml
+++ b/src/Magpie.App/ScalingConfigurationPage.xaml
@@ -113,12 +113,6 @@
 				          ItemsSource="{x:Bind ViewModel.ScalingModes, Mode=OneTime}"
 				          SelectionMode="None"
 				          TabNavigation="Local">
-					<ListView.ItemsPanel>
-						<ItemsPanelTemplate>
-							<local:SimpleStackPanel Orientation="Vertical"
-							                        Spacing="2" />
-						</ItemsPanelTemplate>
-					</ListView.ItemsPanel>
 					<ListView.ItemContainerTransitions>
 						<TransitionCollection>
 							<ContentThemeTransition />
@@ -127,6 +121,7 @@
 					</ListView.ItemContainerTransitions>
 					<ListView.Resources>
 						<Style TargetType="ListViewItem">
+							<Setter Property="Margin" Value="0,0,0,2" />
 							<Setter Property="Padding" Value="0" />
 							<Setter Property="MinHeight" Value="0" />
 							<Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -527,7 +522,7 @@
 						</DataTemplate>
 					</ListView.ItemTemplate>
 				</ListView>
-				<Border Margin="0,-40,0,0">
+				<Border Margin="0,-50,0,0">
 					<Button HorizontalAlignment="Right"
 					        Style="{StaticResource AccentButtonStyle}">
 						<Button.Flyout>


### PR DESCRIPTION
![动画](https://github.com/Blinue/Magpie/assets/34770031/8ba6eb4b-39fe-4d89-9f4b-b42b07b5f890)

这个 bug 一旦连接调试器就不会出现，让我想起了 https://github.com/Blinue/Magpie/pull/771#pullrequestreview-1775229194 ，但大概没有联系。玄学错误就用玄学来修复，我发现不自定义 ListView.ItemsPanel，即使用默认的 ItemsStackPanel 时就没有这个问题。具体原因仍是个谜。