### PR TITLE
适配 TeknoParrot 的窗口类名

### DIFF
--- a/src/Magpie.App/ProfileService.h
+++ b/src/Magpie.App/ProfileService.h
@@ -15,7 +15,7 @@ public:
 	ProfileService(const ProfileService&) = delete;
 	ProfileService(ProfileService&&) = delete;
 
-	bool TestNewProfile(bool isPackaged, std::wstring_view pathOrAumid, std::wstring_view className);
+	bool TestNewProfile(bool isPackaged, std::wstring_view pathOrAumid, std::wstring_view className) noexcept;
 
 	// copyFrom < 0 表示复制默认配置
 	bool AddProfile(bool isPackaged, std::wstring_view pathOrAumid, std::wstring_view className, std::wstring_view name, int copyFrom);
@@ -26,13 +26,13 @@ public:
 
 	bool MoveProfile(uint32_t profileIdx, bool isMoveUp);
 
-	const Profile* GetProfileForWindow(HWND hWnd, bool forAutoScale);
+	const Profile* GetProfileForWindow(HWND hWnd, bool forAutoScale) noexcept;
 
-	Profile& DefaultProfile();
+	Profile& DefaultProfile() noexcept;
 
-	Profile& GetProfile(uint32_t idx);
+	Profile& GetProfile(uint32_t idx) noexcept;
 
-	uint32_t GetProfileCount();
+	uint32_t GetProfileCount() noexcept;
 
 	WinRTUtils::Event<delegate<Profile&>> ProfileAdded;
 	WinRTUtils::Event<delegate<uint32_t>> ProfileRenamed;

--- a/src/Shared/StrUtils.h
+++ b/src/Shared/StrUtils.h
@@ -102,6 +102,14 @@ struct StrUtils {
 		return (bool)std::iswalpha(c);
 	}
 
+	static bool isdigit(char c) noexcept {
+		return (bool)std::isdigit(static_cast<unsigned char>(c));
+	}
+
+	static bool isdigit(wchar_t c) noexcept {
+		return (bool)std::isdigit(c);
+	}
+
 	static bool isalnum(char c) noexcept {
 		return (bool)std::isalnum(static_cast<unsigned char>(c));
 	}


### PR DESCRIPTION
Close #904 

TeknoParrot 中的 BudgieLoader.exe 用于运行 Linux 游戏，每次启动窗口类名都会改变，格式为 XWindow_{一串数字}。这个 PR 还优化了解析窗口类名的性能。