### PR TITLE
为模拟独占全屏选项添加警告

### DIFF
--- a/src/Magpie.App/HomePage.cpp
+++ b/src/Magpie.App/HomePage.cpp
@@ -17,4 +17,25 @@ void HomePage::ComboBox_DropDownOpened(IInspectable const& sender, IInspectable 
 	ComboBoxHelper::DropDownOpened(*this, sender);
 }
 
+void HomePage::SimulateExclusiveFullscreenToggleSwitch_Toggled(IInspectable const& sender, RoutedEventArgs const&) {
+	// 如果没有启用开发者模式，模拟独占全屏选项位于页面底部，用户可能注意不到警告。
+	// 为了解决这个问题，打开模拟独占全屏选项时自动滚动页面。
+	if (_viewModel.IsDeveloperMode() || !sender.as<Controls::ToggleSwitch>().IsOn() || !IsLoaded()) {
+		return;
+	}
+
+	// 这个回调被触发时 UI 还没有更新，需要异步处理
+	Dispatcher().TryRunAsync(CoreDispatcherPriority::Low, [weakThis(get_weak())]() {
+		auto strongThis = weakThis.get();
+		if (!strongThis) {
+			return;
+		}
+
+		auto scrollViewer = strongThis->PageFrame().ScrollViewer();
+		scrollViewer.UpdateLayout();
+		// 滚动到底部
+		scrollViewer.ChangeView(nullptr, scrollViewer.ScrollableHeight(), nullptr);
+	});
+}
+
 }

--- a/src/Magpie.App/HomePage.h
+++ b/src/Magpie.App/HomePage.h
@@ -12,6 +12,8 @@ struct HomePage : HomePageT<HomePage> {
 
 	void ComboBox_DropDownOpened(IInspectable const& sender, IInspectable const&) const;
 
+	void SimulateExclusiveFullscreenToggleSwitch_Toggled(IInspectable const& sender, RoutedEventArgs const&);
+
 private:
 	Magpie::App::HomeViewModel _viewModel;
 };

--- a/src/Magpie.App/HomePage.xaml
+++ b/src/Magpie.App/HomePage.xaml
@@ -6,7 +6,8 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
-	<local:PageFrame x:Uid="Home_PageFrame">
+	<local:PageFrame x:Name="PageFrame"
+	                 x:Uid="Home_PageFrame">
 		<local:SimpleStackPanel Padding="0,4,0,0"
 		                        HorizontalAlignment="Stretch"
 		                        ChildrenTransitions="{StaticResource SettingsCardsAnimations}"
@@ -170,8 +171,13 @@
 						<FontIcon Glyph="&#xec46;" />
 					</local:SettingsCard.HeaderIcon>
 					<ToggleSwitch x:Uid="ToggleSwitch"
-					              IsOn="{x:Bind ViewModel.IsSimulateExclusiveFullscreen, Mode=TwoWay}" />
+					              IsOn="{x:Bind ViewModel.IsSimulateExclusiveFullscreen, Mode=TwoWay}"
+					              Toggled="SimulateExclusiveFullscreenToggleSwitch_Toggled" />
 				</local:SettingsCard>
+				<muxc:InfoBar x:Uid="Home_Advanced_SimulateExclusiveFullscreen_InfoBar"
+				              IsClosable="False"
+				              IsOpen="{x:Bind ViewModel.IsSimulateExclusiveFullscreen, Mode=OneWay}"
+				              Severity="Warning" />
 				<local:SettingsExpander x:Name="DeveloperModeExpander"
 				                        x:Uid="Home_Advanced_DeveloperOptions"
 				                        x:Load="{x:Bind ViewModel.IsDeveloperMode, Mode=OneWay}"

--- a/src/Magpie.App/PageFrame.cpp
+++ b/src/Magpie.App/PageFrame.cpp
@@ -83,7 +83,7 @@ void PageFrame::ScrollViewer_ViewChanging(IInspectable const&, ScrollViewerViewC
 }
 
 void PageFrame::ScrollViewer_KeyDown(IInspectable const& sender, KeyRoutedEventArgs const& args) {
-	ScrollViewer scrollViewer = sender.as<ScrollViewer>();
+	auto scrollViewer = sender.as<Controls::ScrollViewer>();
 	switch (args.Key()) {
 	case VirtualKey::Up:
 		scrollViewer.ChangeView(scrollViewer.HorizontalOffset(), scrollViewer.VerticalOffset() - 100, 1);

--- a/src/Magpie.App/PageFrame.idl
+++ b/src/Magpie.App/PageFrame.idl
@@ -7,5 +7,7 @@ namespace Magpie.App {
 		Windows.UI.Xaml.Controls.IconElement Icon;
 		Windows.UI.Xaml.FrameworkElement HeaderAction;
 		Object MainContent;
+
+		Windows.UI.Xaml.Controls.ScrollViewer ScrollViewer { get; };
 	}
 }

--- a/src/Magpie.App/PageFrame.xaml
+++ b/src/Magpie.App/PageFrame.xaml
@@ -84,7 +84,8 @@
 			</Grid>
 		</local:SimpleStackPanel>
 		<!--  ScrollViewer 可以接受焦点，这使用户可以通过键盘滚动页面  -->
-		<ScrollViewer Grid.Row="1"
+		<ScrollViewer x:Name="ScrollViewer"
+		              Grid.Row="1"
 		              IsTabStop="True"
 		              KeyDown="ScrollViewer_KeyDown"
 		              PointerPressed="ScrollViewer_PointerPressed"

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -836,6 +836,6 @@
     <value>If touch support fails, Magpie may request administrator privileges before scaling to perform repairs.</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen_InfoBar.Title" xml:space="preserve">
-    <value>This option is not compatible with certain older games. Please use it with caution.</value>
+    <value>This option is not compatible with some older games. Please use it with caution.</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-en-US.resw
+++ b/src/Magpie.App/Resources.language-en-US.resw
@@ -835,4 +835,7 @@
   <data name="Home_TouchSupport_InfoBar.Title" xml:space="preserve">
     <value>If touch support fails, Magpie may request administrator privileges before scaling to perform repairs.</value>
   </data>
+  <data name="Home_Advanced_SimulateExclusiveFullscreen_InfoBar.Title" xml:space="preserve">
+    <value>This option is not compatible with certain older games. Please use it with caution.</value>
+  </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -836,6 +836,6 @@
     <value>如果触控支持失效，Magpie 可能会在缩放前请求管理员权限以执行修复。</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen_InfoBar.Title" xml:space="preserve">
-    <value>此选项和某些旧游戏不兼容，请谨慎使用。</value>
+    <value>此选项和一些旧游戏不兼容，请谨慎使用。</value>
   </data>
 </root>

--- a/src/Magpie.App/Resources.language-zh-Hans.resw
+++ b/src/Magpie.App/Resources.language-zh-Hans.resw
@@ -835,4 +835,7 @@
   <data name="Home_TouchSupport_InfoBar.Title" xml:space="preserve">
     <value>如果触控支持失效，Magpie 可能会在缩放前请求管理员权限以执行修复。</value>
   </data>
+  <data name="Home_Advanced_SimulateExclusiveFullscreen_InfoBar.Title" xml:space="preserve">
+    <value>此选项和某些旧游戏不兼容，请谨慎使用。</value>
+  </data>
 </root>


### PR DESCRIPTION
这个选项和 D3D9 不兼容，会使很多旧游戏出错。见 #588