### PR TITLE
修复忘记释放某些 mutex

### DIFF
--- a/src/Magpie.Core/ExclModeHelper.cpp
+++ b/src/Magpie.Core/ExclModeHelper.cpp
@@ -30,7 +30,7 @@ wil::unique_mutex_nothrow ExclModeHelper::EnterExclMode() noexcept {
 		return exclModeMutex;
 	}
 
-	if (!wil::event_is_signaled(exclModeMutex.get())) {
+	if (!wil::handle_wait(exclModeMutex.get(), 0)) {
 		Logger::Get().Error("获取 __DDrawExclMode__ 失败");
 		exclModeMutex.reset();
 		return exclModeMutex;

--- a/src/Magpie.Core/ExclModeHelper.cpp
+++ b/src/Magpie.Core/ExclModeHelper.cpp
@@ -39,11 +39,13 @@ wil::unique_mutex_nothrow ExclModeHelper::EnterExclMode() noexcept {
 	hr = SHQueryUserNotificationState(&state);
 	if (FAILED(hr)) {
 		Logger::Get().ComError("SHQueryUserNotificationState 失败", hr);
+		exclModeMutex.ReleaseMutex();
 		exclModeMutex.reset();
 		return exclModeMutex;
 	}
 	if (state != QUNS_RUNNING_D3D_FULL_SCREEN) {
 		Logger::Get().Error("模拟独占全屏失败");
+		exclModeMutex.ReleaseMutex();
 		exclModeMutex.reset();
 		return exclModeMutex;
 	}

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -412,8 +412,10 @@ LRESULT ScalingWindow::_MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) n
 	}
 	case WM_DESTROY:
 	{
-		_exclModeMutex.ReleaseMutex();
-		_exclModeMutex.reset();
+		if (_exclModeMutex) {
+			_exclModeMutex.ReleaseMutex();
+			_exclModeMutex.reset();
+		}
 
 		_hwndDDF.reset();
 		_isDDFWindowShown = false;

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -412,6 +412,7 @@ LRESULT ScalingWindow::_MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) n
 	}
 	case WM_DESTROY:
 	{
+		_exclModeMutex.ReleaseMutex();
 		_exclModeMutex.reset();
 
 		_hwndDDF.reset();

--- a/src/Updater/main.cpp
+++ b/src/Updater/main.cpp
@@ -37,7 +37,9 @@ static bool WaitForMagpieToExit() noexcept {
 	{
 		wil::unique_mutex_nothrow hSingleInstanceMutex;
 		if (hSingleInstanceMutex.try_create(CommonSharedConstants::SINGLE_INSTANCE_MUTEX_NAME)) {
-			wil::handle_wait(hSingleInstanceMutex.get(), 10000);
+			if (wil::handle_wait(hSingleInstanceMutex.get(), 10000)) {
+				hSingleInstanceMutex.ReleaseMutex();
+			}
 		}
 	}
 


### PR DESCRIPTION
Close #937
Close #928

这个 bug 是 #894 引入的。wil::unique_mutex_nothrow 在析构时不会自动释放，虽然我开发 #894 的过程中注意到了，但一些旧代码忘记调整了。