### PR TITLE
fix: 缩放窗口销毁前清理属性，以及更新文档说明清理窗口属性

### DIFF
--- a/docs/Interact with Magpie programally.md
+++ b/docs/Interact with Magpie programally.md
@@ -91,3 +91,7 @@ Magpie stops scaling when the foreground window changes, with some system window
 ```c++
 SetProp(hYourWindow, L"Magpie.ToolWindow", (HANDLE)TRUE);
 ```
+
+### Notes
+
+According to the [documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setpropw), you should use RemoveProp to clear this property before your window is destroyed. However, if you forget to do so, there's no need to worry: [the system will automatically clean it up](https://devblogs.microsoft.com/oldnewthing/20231030-00/?p=108939).

--- a/docs/以编程方式与 Magpie 交互.md
+++ b/docs/以编程方式与 Magpie 交互.md
@@ -91,3 +91,7 @@ destRect.bottom = (LONG)(INT_PTR)GetProp(hwndScaling, L"Magpie.DestBottom");
 ```c++
 SetProp(hYourWindow, L"Magpie.ToolWindow", (HANDLE)TRUE);
 ```
+
+### 注意事项
+
+根据[文档](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setpropw)的要求，你应该在你的窗口被销毁前使用 RemoveProp 清理这个属性。但如果你忘了也不会有问题，[系统会自动清理它](https://devblogs.microsoft.com/oldnewthing/20231030-00/?p=108939)。

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -438,6 +438,8 @@ LRESULT ScalingWindow::_MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) n
 		// 还原时钟精度
 		timeEndPeriod(1);
 
+		_RemoveWindowProps();
+
 		// 广播停止缩放
 		PostMessage(HWND_BROADCAST, WM_MAGPIE_SCALINGCHANGED, 0, 0);
 		break;
@@ -615,6 +617,31 @@ void ScalingWindow::_SetWindowProps() const noexcept {
 	SetProp(_hWnd, L"Magpie.DestTop", (HANDLE)(INT_PTR)destRect.top);
 	SetProp(_hWnd, L"Magpie.DestRight", (HANDLE)(INT_PTR)destRect.right);
 	SetProp(_hWnd, L"Magpie.DestBottom", (HANDLE)(INT_PTR)destRect.bottom);
+}
+
+// 文档要求窗口被销毁前清理所有属性，但实际上这不是必须的，见
+// https://devblogs.microsoft.com/oldnewthing/20231030-00/?p=108939
+void ScalingWindow::_RemoveWindowProps() const noexcept {
+	RemoveProp(_hWnd, L"Magpie.SrcHWND");
+	RemoveProp(_hWnd, L"Magpie.SrcLeft");
+	RemoveProp(_hWnd, L"Magpie.SrcTop");
+	RemoveProp(_hWnd, L"Magpie.SrcRight");
+	RemoveProp(_hWnd, L"Magpie.SrcBottom");
+	RemoveProp(_hWnd, L"Magpie.DestLeft");
+	RemoveProp(_hWnd, L"Magpie.DestTop");
+	RemoveProp(_hWnd, L"Magpie.DestRight");
+	RemoveProp(_hWnd, L"Magpie.DestBottom");
+
+	if (_options.IsTouchSupportEnabled()) {
+		RemoveProp(_hWnd, L"Magpie.SrcTouchLeft");
+		RemoveProp(_hWnd, L"Magpie.SrcTouchTop");
+		RemoveProp(_hWnd, L"Magpie.SrcTouchRight");
+		RemoveProp(_hWnd, L"Magpie.SrcTouchBottom");
+		RemoveProp(_hWnd, L"Magpie.DestTouchLeft");
+		RemoveProp(_hWnd, L"Magpie.DestTouchTop");
+		RemoveProp(_hWnd, L"Magpie.DestTouchRight");
+		RemoveProp(_hWnd, L"Magpie.DestTouchBottom");
+	}
 }
 
 // 在源窗口四周创建辅助窗口拦截黑边上的触控点击。

--- a/src/Magpie.Core/ScalingWindow.h
+++ b/src/Magpie.Core/ScalingWindow.h
@@ -73,6 +73,8 @@ private:
 
 	void _SetWindowProps() const noexcept;
 
+	void _RemoveWindowProps() const noexcept;
+
 	void _CreateTouchHoleWindows() noexcept;
 
 	winrt::DispatcherQueue _dispatcher{ nullptr };


### PR DESCRIPTION
SetProp 文档要求窗口被销毁前清理所有属性，这个 PR 添加了清理的代码。实际上这不是必须的，见 https://devblogs.microsoft.com/oldnewthing/20231030-00/?p=108939