### PR TITLE
支持长路径

### DIFF
--- a/src/Magpie/app.manifest
+++ b/src/Magpie/app.manifest
@@ -21,8 +21,10 @@
     <windowsSettings>
       <!-- 使程序可以枚举到沉浸式窗口（immersive windows），如很多类名为 “Windows.UI.Core.CoreWindow” 的系统窗口 -->
       <disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</disableWindowFiltering>
-      <!-- 表示程序可以感知 DPI 缩放。PerMonitorV2 在 Win10 v1703 中引入 -->
+      <!-- 使程序可以感知 DPI 缩放。PerMonitorV2 在 Win10 v1703 中引入 -->
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <!-- 表示程序支持长度大于 MAX_PATH 的路径，但用户需要修改注册表才能起作用 -->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
       <!-- 在 Win10 v2004 和更高版本中启用 Segment Heap，这可以有效减少内存占用，但会稍微降低性能 -->
       <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>

--- a/src/TouchHelper/app.manifest
+++ b/src/TouchHelper/app.manifest
@@ -9,8 +9,10 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <!-- 表示程序可以感知 DPI 缩放。PerMonitorV2 在 Win10 v1703 中引入 -->
+      <!-- 使程序可以感知 DPI 缩放。PerMonitorV2 在 Win10 v1703 中引入 -->
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <!-- 表示程序支持长度大于 MAX_PATH 的路径，但用户需要修改注册表才能起作用 -->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
       <!-- 在 Win10 v2004 和更高版本中启用 Segment Heap，这可以有效减少内存占用，但会稍微降低性能 -->
       <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>

--- a/src/Updater/app.manifest
+++ b/src/Updater/app.manifest
@@ -9,8 +9,10 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <!-- 表示程序可以感知 DPI 缩放。PerMonitorV2 在 Win10 v1703 中引入 -->
+      <!-- 使程序可以感知 DPI 缩放。PerMonitorV2 在 Win10 v1703 中引入 -->
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <!-- 表示程序支持长度大于 MAX_PATH 的路径，但用户需要修改注册表才能起作用 -->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
       <!-- 在 Win10 v2004 和更高版本中启用 Segment Heap，这可以有效减少内存占用，但会稍微降低性能 -->
       <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>


### PR DESCRIPTION
#894 消除了大部分 MAX_PATH，然后 https://github.com/Blinue/Magpie/commit/c24c32e0f21930655ccc873c6f88e50e39f67f4c 消除了剩下的，是时候启用长路径支持了。

注意虽然程序支持长路径，用户仍需要修改注册表才能起作用，见 [Maximum Path Length Limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later)。Python 等软件在安装时可以选择自动修改注册表，但我们尊重用户的配置就行，因为 Windows 目前对长路径的支持很差。需要长路径支持的用户应该有能力自己修改注册表，或者已经在安装其他软件时自动修改了。