### PR TITLE
fix: 修复启用“以管理者身份运行该程序”兼容性选项时 TouchHelper 无法获得 UIAccess 权限的问题

### DIFF
--- a/src/Magpie.App/TouchHelper.cpp
+++ b/src/Magpie.App/TouchHelper.cpp
@@ -106,7 +106,9 @@ bool TouchHelper::TryLaunchTouchHelper(bool& isTouchSupportEnabled) noexcept {
 		return false;
 	}
 
-	if (!Win32Utils::ShellOpen(path.c_str(), nullptr, false)) {
+	// GH#992: 必须委托 explorer 启动 ToucherHelper，否则如果启用了“以管理者身份运行该程序”
+	// 兼容性选项，ToucherHelper 将无法获得 UIAccess 权限
+	if (!Win32Utils::ShellOpen(path.c_str(), nullptr, true)) {
 		Logger::Get().Error("启动 TouchHelper.exe 失败");
 		return false;
 	}

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -358,6 +358,15 @@ LRESULT ScalingWindow::_MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) n
 	}
 
 	switch (msg) {
+	case WM_CREATE:
+	{
+		// TouchHelper 的权限可能比我们低
+		if (!ChangeWindowMessageFilterEx(Handle(), WM_MAGPIE_TOUCHHELPER, MSGFLT_ADD, nullptr)) {
+			Logger::Get().Win32Error("ChangeWindowMessageFilter 失败");
+		}
+
+		break;
+	}
 	case WM_LBUTTONDOWN:
 	case WM_RBUTTONDOWN:
 	{

--- a/src/Magpie/XamlApp.cpp
+++ b/src/Magpie/XamlApp.cpp
@@ -19,6 +19,11 @@ static UINT WM_MAGPIE_QUIT;
 static void InitMessages() noexcept {
 	WM_MAGPIE_SHOWME = RegisterWindowMessage(CommonSharedConstants::WM_MAGPIE_SHOWME);
 	WM_MAGPIE_QUIT = RegisterWindowMessage(CommonSharedConstants::WM_MAGPIE_QUIT);
+
+	// 允许被权限更低的实例唤醒
+	if (!ChangeWindowMessageFilter(WM_MAGPIE_SHOWME, MSGFLT_ADD)) {
+		Logger::Get().Win32Error("ChangeWindowMessageFilter 失败");
+	}
 }
 
 // 我们需要尽可能高的时钟分辨率来提高渲染帧率。
@@ -202,11 +207,6 @@ bool XamlApp::_CheckSingleInstance() noexcept {
 			// 通知已有实例显示主窗口
 			PostMessage(HWND_BROADCAST, WM_MAGPIE_SHOWME, 0, 0);
 			return false;
-		}
-
-		// 以管理员身份运行时允许接收 WM_MAGPIE_SHOWME 消息，否则无法被该消息唤醒
-		if (!ChangeWindowMessageFilter(WM_MAGPIE_SHOWME, MSGFLT_ADD)) {
-			Logger::Get().Win32Error("ChangeWindowMessageFilter 失败");
 		}
 	}
 


### PR DESCRIPTION
Close #992 

出于未知原因，启用了“以管理者身份运行该程序”兼容性选项的程序无法获得 UIAccess 权限。这个 PR 委托 explorer 启动 TouchHelper，从而绕过这个限制。