### PR TITLE
实现最小帧率

### DIFF
--- a/src/Magpie.Core/DesktopDuplicationFrameSource.h
+++ b/src/Magpie.Core/DesktopDuplicationFrameSource.h
@@ -12,7 +12,7 @@ public:
 	}
 
 	FrameSourceWaitType WaitType() const noexcept override {
-		return WaitForFrame;
+		return FrameSourceWaitType::WaitForFrame;
 	}
 
 	const char* Name() const noexcept override {
@@ -30,7 +30,7 @@ protected:
 
 	bool _Initialize() noexcept override;
 
-	UpdateState _Update() noexcept override;
+	FrameSourceState _Update() noexcept override;
 
 private:
 	winrt::com_ptr<IDXGIOutputDuplication> _outputDup;

--- a/src/Magpie.Core/DwmSharedSurfaceFrameSource.cpp
+++ b/src/Magpie.Core/DwmSharedSurfaceFrameSource.cpp
@@ -87,14 +87,14 @@ bool DwmSharedSurfaceFrameSource::_Initialize() noexcept {
 	return true;
 }
 
-FrameSourceBase::UpdateState DwmSharedSurfaceFrameSource::_Update() noexcept {
+FrameSourceState DwmSharedSurfaceFrameSource::_Update() noexcept {
 	HANDLE sharedTextureHandle = NULL;
 	if (!dwmGetDxSharedSurface(ScalingWindow::Get().HwndSrc(),
 		&sharedTextureHandle, nullptr, nullptr, nullptr, nullptr)
 		|| !sharedTextureHandle
 	) {
 		Logger::Get().Win32Error("DwmGetDxSharedSurface 失败");
-		return UpdateState::Error;
+		return FrameSourceState::Error;
 	}
 
 	winrt::com_ptr<ID3D11Texture2D> sharedTexture;
@@ -102,13 +102,13 @@ FrameSourceBase::UpdateState DwmSharedSurfaceFrameSource::_Update() noexcept {
 		->OpenSharedResource(sharedTextureHandle, IID_PPV_ARGS(&sharedTexture));
 	if (FAILED(hr)) {
 		Logger::Get().ComError("OpenSharedResource 失败", hr);
-		return UpdateState::Error;
+		return FrameSourceState::Error;
 	}
 
 	_deviceResources->GetD3DDC()->CopySubresourceRegion(
 		_output.get(), 0, 0, 0, 0, sharedTexture.get(), 0, &_frameInWnd);
 
-	return UpdateState::NewFrame;
+	return FrameSourceState::NewFrame;
 }
 
 }

--- a/src/Magpie.Core/DwmSharedSurfaceFrameSource.h
+++ b/src/Magpie.Core/DwmSharedSurfaceFrameSource.h
@@ -12,7 +12,7 @@ public:
 	}
 
 	FrameSourceWaitType WaitType() const noexcept override {
-		return NoWait;
+		return FrameSourceWaitType::NoWait;
 	}
 
 	const char* Name() const noexcept override {
@@ -22,7 +22,7 @@ public:
 protected:
 	bool _Initialize() noexcept override;
 
-	UpdateState _Update() noexcept override;
+	FrameSourceState _Update() noexcept override;
 
 	bool _HasRoundCornerInWin11() noexcept override {
 		return false;

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -110,12 +110,8 @@ bool FrameSourceBase::Initialize(DeviceResources& deviceResources, BackendDescri
 	return true;
 }
 
-FrameSourceState FrameSourceBase::Update(bool forceNewFrame) noexcept {
+FrameSourceState FrameSourceBase::Update() noexcept {
 	const FrameSourceState state = _Update();
-
-	if (forceNewFrame) {
-		return FrameSourceState::NewFrame;
-	}
 
 	const ScalingOptions& options = ScalingWindow::Get().Options();
 	const auto duplicateFrameDetectionMode = options.duplicateFrameDetectionMode;

--- a/src/Magpie.Core/FrameSourceBase.cpp
+++ b/src/Magpie.Core/FrameSourceBase.cpp
@@ -110,12 +110,16 @@ bool FrameSourceBase::Initialize(DeviceResources& deviceResources, BackendDescri
 	return true;
 }
 
-FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
-	const UpdateState state = _Update();
+FrameSourceState FrameSourceBase::Update(bool forceNewFrame) noexcept {
+	const FrameSourceState state = _Update();
+
+	if (forceNewFrame) {
+		return FrameSourceState::NewFrame;
+	}
 
 	const ScalingOptions& options = ScalingWindow::Get().Options();
 	const auto duplicateFrameDetectionMode = options.duplicateFrameDetectionMode;
-	if (state != UpdateState::NewFrame || options.Is3DGameMode() ||
+	if (state != FrameSourceState::NewFrame || options.Is3DGameMode() ||
 		duplicateFrameDetectionMode == DuplicateFrameDetectionMode::Never) {
 		return state;
 	}
@@ -131,16 +135,16 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 			_prevFrameSrv = nullptr;
 		}
 
-		return UpdateState::NewFrame;
+		return FrameSourceState::NewFrame;
 	}
 
 	if (duplicateFrameDetectionMode == DuplicateFrameDetectionMode::Always) {
 		// 总是检查重复帧
 		if (_IsDuplicateFrame()) {
-			return UpdateState::Waiting;
+			return FrameSourceState::Waiting;
 		} else {
 			d3dDC->CopyResource(_prevFrame.get(), _output.get());
-			return UpdateState::NewFrame;
+			return FrameSourceState::NewFrame;
 		}
 	}
 
@@ -166,12 +170,12 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 			_isCheckingForDuplicateFrame = true;
 			_framesLeft = INITIAL_CHECK_COUNT;
 			_nextSkipCount = INITIAL_SKIP_COUNT;
-			return UpdateState::Waiting;
+			return FrameSourceState::Waiting;
 		} else {
 			if (_isCheckingForDuplicateFrame || isStatisticsEnabled) {
 				d3dDC->CopyResource(_prevFrame.get(), _output.get());
 			}
-			return UpdateState::NewFrame;
+			return FrameSourceState::NewFrame;
 		}
 	} else {
 		if (--_framesLeft == 0) {
@@ -201,7 +205,7 @@ FrameSourceBase::UpdateState FrameSourceBase::Update() noexcept {
 			_statistics.store(statistics, std::memory_order_relaxed);
 		}
 
-		return UpdateState::NewFrame;
+		return FrameSourceState::NewFrame;
 	}
 }
 

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -5,6 +5,18 @@ namespace Magpie {
 class DeviceResources;
 class BackendDescriptorStore;
 
+enum class FrameSourceWaitType {
+	NoWait,
+	WaitForMessage,
+	WaitForFrame
+};
+
+enum class FrameSourceState {
+	NewFrame,
+	Waiting,
+	Error
+};
+
 class FrameSourceBase {
 public:
 	FrameSourceBase() noexcept;
@@ -17,13 +29,7 @@ public:
 
 	bool Initialize(DeviceResources& deviceResources, BackendDescriptorStore& descriptorStore) noexcept;
 
-	enum class UpdateState {
-		NewFrame,
-		Waiting,
-		Error
-	};
-
-	UpdateState Update() noexcept;
+	FrameSourceState Update(bool forceNewFrame) noexcept;
 
 	ID3D11Texture2D* GetOutput() noexcept {
 		return _output.get();
@@ -39,12 +45,6 @@ public:
 
 	virtual bool IsScreenCapture() const noexcept = 0;
 
-	enum FrameSourceWaitType {
-		NoWait,
-		WaitForMessage,
-		WaitForFrame
-	};
-
 	virtual FrameSourceWaitType WaitType() const noexcept = 0;
 	
 	virtual void OnCursorVisibilityChanged(bool /*isVisible*/, bool /*onDestory*/) noexcept {};
@@ -52,7 +52,7 @@ public:
 protected:
 	virtual bool _Initialize() noexcept = 0;
 
-	virtual UpdateState _Update() noexcept = 0;
+	virtual FrameSourceState _Update() noexcept = 0;
 
 	virtual bool _HasRoundCornerInWin11() noexcept = 0;
 

--- a/src/Magpie.Core/FrameSourceBase.h
+++ b/src/Magpie.Core/FrameSourceBase.h
@@ -29,7 +29,7 @@ public:
 
 	bool Initialize(DeviceResources& deviceResources, BackendDescriptorStore& descriptorStore) noexcept;
 
-	FrameSourceState Update(bool forceNewFrame) noexcept;
+	FrameSourceState Update() noexcept;
 
 	ID3D11Texture2D* GetOutput() noexcept {
 		return _output.get();
@@ -76,7 +76,7 @@ protected:
 	DeviceResources* _deviceResources = nullptr;
 	BackendDescriptorStore* _descriptorStore = nullptr;
 	winrt::com_ptr<ID3D11Texture2D> _output;
-	ID3D11ShaderResourceView* _outputSrv;
+	ID3D11ShaderResourceView* _outputSrv = nullptr;
 
 	winrt::com_ptr<ID3D11Buffer> _resultBuffer;
 	ID3D11UnorderedAccessView* _resultBufferUav = nullptr;

--- a/src/Magpie.Core/GDIFrameSource.cpp
+++ b/src/Magpie.Core/GDIFrameSource.cpp
@@ -63,12 +63,12 @@ bool GDIFrameSource::_Initialize() noexcept {
 	return true;
 }
 
-FrameSourceBase::UpdateState GDIFrameSource::_Update() noexcept {
+FrameSourceState GDIFrameSource::_Update() noexcept {
 	HDC hdcDest;
 	HRESULT hr = _dxgiSurface->GetDC(TRUE, &hdcDest);
 	if (FAILED(hr)) {
 		Logger::Get().ComError("从 Texture2D 获取 IDXGISurface1 失败", hr);
-		return UpdateState::Error;
+		return FrameSourceState::Error;
 	}
 
 	auto se = wil::scope_exit([&]() {
@@ -79,17 +79,17 @@ FrameSourceBase::UpdateState GDIFrameSource::_Update() noexcept {
 	wil::unique_hdc_window hdcSrc(wil::window_dc(GetDCEx(hwndSrc, NULL, DCX_WINDOW), hwndSrc));
 	if (!hdcSrc) {
 		Logger::Get().Win32Error("GetDC 失败");
-		return UpdateState::Error;
+		return FrameSourceState::Error;
 	}
 
 	if (!BitBlt(hdcDest, 0, 0, _frameRect.right - _frameRect.left, _frameRect.bottom - _frameRect.top,
 		hdcSrc.get(), _frameRect.left, _frameRect.top, SRCCOPY)
 	) {
 		Logger::Get().Win32Error("BitBlt 失败");
-		return UpdateState::Error;
+		return FrameSourceState::Error;
 	}
 
-	return UpdateState::NewFrame;
+	return FrameSourceState::NewFrame;
 }
 
 }

--- a/src/Magpie.Core/GDIFrameSource.h
+++ b/src/Magpie.Core/GDIFrameSource.h
@@ -12,7 +12,7 @@ public:
 	}
 
 	FrameSourceWaitType WaitType() const noexcept override {
-		return NoWait;
+		return FrameSourceWaitType::NoWait;
 	}
 
 	const char* Name() const noexcept override {
@@ -22,7 +22,7 @@ public:
 protected:
 	bool _Initialize() noexcept override;
 
-	UpdateState _Update() noexcept override;
+	FrameSourceState _Update() noexcept override;
 
 	bool _HasRoundCornerInWin11() noexcept override {
 		return false;

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
@@ -91,15 +91,15 @@ bool GraphicsCaptureFrameSource::_Initialize() noexcept {
 	return true;
 }
 
-FrameSourceBase::UpdateState GraphicsCaptureFrameSource::_Update() noexcept {
+FrameSourceState GraphicsCaptureFrameSource::_Update() noexcept {
 	if (!_captureSession) {
-		return UpdateState::Waiting;
+		return FrameSourceState::Waiting;
 	}
 
 	winrt::Direct3D11CaptureFrame frame = _captureFramePool.TryGetNextFrame();
 	if (!frame) {
 		// 因为已通过 FrameArrived 注册回调，所以每当有新帧时会有新消息到达
-		return UpdateState::Waiting;
+		return FrameSourceState::Waiting;
 	}
 
 	// 从帧获取 IDXGISurface
@@ -113,12 +113,12 @@ FrameSourceBase::UpdateState GraphicsCaptureFrameSource::_Update() noexcept {
 	HRESULT hr = dxgiInterfaceAccess->GetInterface(IID_PPV_ARGS(&withFrame));
 	if (FAILED(hr)) {
 		Logger::Get().ComError("从获取 IDirect3DSurface 获取 ID3D11Texture2D 失败", hr);
-		return UpdateState::Error;
+		return FrameSourceState::Error;
 	}
 
 	_deviceResources->GetD3DDC()->CopySubresourceRegion(_output.get(), 0, 0, 0, 0, withFrame.get(), 0, &_frameBox);
 
-	return UpdateState::NewFrame;
+	return FrameSourceState::NewFrame;
 }
 
 void GraphicsCaptureFrameSource::OnCursorVisibilityChanged(bool isVisible, bool onDestory) noexcept {

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.h
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.h
@@ -17,7 +17,7 @@ public:
 	}
 
 	FrameSourceWaitType WaitType() const noexcept override {
-		return WaitForMessage;
+		return FrameSourceWaitType::WaitForMessage;
 	}
 
 	const char* Name() const noexcept override {
@@ -37,7 +37,7 @@ protected:
 
 	bool _Initialize() noexcept override;
 
-	UpdateState _Update() noexcept override;
+	FrameSourceState _Update() noexcept override;
 
 private:
 	bool _StartCapture() noexcept;

--- a/src/Magpie.Core/Logger.cpp
+++ b/src/Magpie.Core/Logger.cpp
@@ -57,7 +57,7 @@ void Logger::_Log(spdlog::level::level_enum logLevel, std::string_view msg, cons
 	assert(!msg.empty());
 
 	if (logLevel >= spdlog::level::warn && IsDebuggerPresent()) {
-		// 警告或更高等级的日志也记录到调试器（VS 中的“即时窗口”）
+		// 警告或更高等级的日志也记录到调试器（VS 中的输出窗口）
 		if (msg.back() == '\n') {
 			OutputDebugString(StrHelper::Concat(L"[LOG] ", StrHelper::UTF8ToUTF16(msg)).c_str());
 		} else {

--- a/src/Magpie.Core/Logger.cpp
+++ b/src/Magpie.Core/Logger.cpp
@@ -57,7 +57,7 @@ void Logger::_Log(spdlog::level::level_enum logLevel, std::string_view msg, cons
 	assert(!msg.empty());
 
 	if (logLevel >= spdlog::level::warn && IsDebuggerPresent()) {
-		// 警告或更高等级的日志也记录到调试器（VS 中的输出窗口）
+		// 警告或更高等级的日志也记录到调试器
 		if (msg.back() == '\n') {
 			OutputDebugString(StrHelper::Concat(L"[LOG] ", StrHelper::UTF8ToUTF16(msg)).c_str());
 		} else {

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -667,7 +667,7 @@ void Renderer::_BackendThreadProc() noexcept {
 	}
 
 	bool exiting = false;
-	bool waitMsgForNewFrame = false;
+	bool waitMsgForNewFrame = _frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
 
 	MSG msg;
 	while (true) {
@@ -695,11 +695,11 @@ void Renderer::_BackendThreadProc() noexcept {
 		}
 
 		FrameSourceState state = _frameSource->Update(stepTimerStatus == StepTimerStatus::ForceNewFrame);
-		_stepTimer.UpdateFPS(state == FrameSourceState::NewFrame);
 
 		switch (state) {
 		case FrameSourceState::NewFrame:
 		{
+			_stepTimer.PrepareForNewFrame();
 			_BackendRender(outputTexture);
 			break;
 		}
@@ -783,7 +783,7 @@ ID3D11Texture2D* Renderer::_InitBackend() noexcept {
 			}
 		}
 
-		_stepTimer.Initialize(10.0f, frameRateLimit);
+		_stepTimer.Initialize(5.0f, frameRateLimit);
 	}
 
 	ID3D11Texture2D* outputTexture = _BuildEffects();

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -666,11 +666,20 @@ void Renderer::_BackendThreadProc() noexcept {
 		return;
 	}
 
-	bool waitingForStepTimer = true;
 	bool exiting = false;
+	bool waitMsgForNewFrame = false;
 
 	MSG msg;
 	while (true) {
+		StepTimerStatus stepTimerStatus = StepTimerStatus::WaitForNewFrame;
+
+		if (exiting) {
+			WaitMessage();
+		} else {
+			stepTimerStatus = _stepTimer.WaitForNextFrame(waitMsgForNewFrame);
+			waitMsgForNewFrame = false;
+		}
+
 		while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
 			if (msg.message == WM_QUIT) {
 				// 不能在前端线程释放
@@ -682,38 +691,29 @@ void Renderer::_BackendThreadProc() noexcept {
 		}
 
 		if (exiting) {
-			// 准备退出，不再捕获
-			WaitMessage();
+			continue;
+		}
+		
+		if (stepTimerStatus == StepTimerStatus::WaitForFPSLimiter) {
+			_stepTimer.UpdateFPS(false);
 			continue;
 		}
 
-		if (waitingForStepTimer) {
-			if (!_stepTimer.WaitForNextFrame()) {
-				_stepTimer.UpdateFPS(false);
-				continue;
-			}
-			waitingForStepTimer = false;
-		}
-
-		const FrameSourceBase::UpdateState state = _frameSource->Update();
-		_stepTimer.UpdateFPS(state == FrameSourceBase::UpdateState::NewFrame);
+		FrameSourceState state = _frameSource->Update(stepTimerStatus == StepTimerStatus::ForceNewFrame);
+		_stepTimer.UpdateFPS(state == FrameSourceState::NewFrame);
 
 		switch (state) {
-		case FrameSourceBase::UpdateState::NewFrame:
+		case FrameSourceState::NewFrame:
 		{
 			_BackendRender(outputTexture);
-			waitingForStepTimer = true;
 			break;
 		}
-		case FrameSourceBase::UpdateState::Waiting:
+		case FrameSourceState::Waiting:
 		{
-			if (_frameSource->WaitType() == FrameSourceBase::WaitForMessage) {
-				// 等待新消息
-				WaitMessage();
-			}
+			waitMsgForNewFrame = _frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
 			break;
 		}
-		case FrameSourceBase::UpdateState::Error:
+		case FrameSourceState::Error:
 		{
 			// 捕获出错，退出缩放
 			ScalingWindow::Get().Dispatcher().TryEnqueue([]() {
@@ -726,7 +726,6 @@ void Renderer::_BackendThreadProc() noexcept {
 		}
 		default:
 		{
-			waitingForStepTimer = true;
 			break;
 		}
 		}
@@ -765,7 +764,7 @@ ID3D11Texture2D* Renderer::_InitBackend() noexcept {
 
 	{
 		std::optional<float> frameRateLimit;
-		if (_frameSource->WaitType() == FrameSourceBase::NoWait) {
+		if (_frameSource->WaitType() == FrameSourceWaitType::NoWait) {
 			// 某些捕获方式不会限制捕获帧率，因此将捕获帧率限制为屏幕刷新率
 			const HWND hwndSrc = ScalingWindow::Get().HwndSrc();
 			if (HMONITOR hMon = MonitorFromWindow(hwndSrc, MONITOR_DEFAULTTONEAREST)) {
@@ -789,7 +788,7 @@ ID3D11Texture2D* Renderer::_InitBackend() noexcept {
 			}
 		}
 
-		_stepTimer.Initialize(frameRateLimit);
+		_stepTimer.Initialize(10.0f, frameRateLimit);
 	}
 
 	ID3D11Texture2D* outputTexture = _BuildEffects();

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -699,7 +699,7 @@ void Renderer::_BackendThreadProc() noexcept {
 		switch (state) {
 		case FrameSourceState::NewFrame:
 		{
-			_stepTimer.PrepareForNewFrame();
+			_stepTimer.PrepareForRender();
 			_BackendRender(outputTexture);
 			break;
 		}

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -690,12 +690,7 @@ void Renderer::_BackendThreadProc() noexcept {
 			DispatchMessage(&msg);
 		}
 
-		if (exiting) {
-			continue;
-		}
-		
-		if (stepTimerStatus == StepTimerStatus::WaitForFPSLimiter) {
-			_stepTimer.UpdateFPS(false);
+		if (exiting || stepTimerStatus == StepTimerStatus::WaitForFPSLimiter) {
 			continue;
 		}
 

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -666,7 +666,8 @@ void Renderer::_BackendThreadProc() noexcept {
 		return;
 	}
 
-	bool waitMsgForNewFrame = _frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
+	const bool waitMsgForNewFrame =
+		_frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
 
 	MSG msg;
 	while (true) {
@@ -691,11 +692,7 @@ void Renderer::_BackendThreadProc() noexcept {
 		if (state == FrameSourceState::NewFrame) {
 			_stepTimer.PrepareForRender();
 			_BackendRender(outputTexture);
-
-			waitMsgForNewFrame = false;
-		} else if (state == FrameSourceState::Waiting) {
-			waitMsgForNewFrame = _frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
-		} else {
+		} else if (state == FrameSourceState::Error) [[unlikely]] {
 			// 捕获出错，退出缩放
 			ScalingWindow::Get().Dispatcher().TryEnqueue([]() {
 				ScalingWindow::Get().RuntimeError(ScalingError::CaptureFailed);

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -783,7 +783,7 @@ ID3D11Texture2D* Renderer::_InitBackend() noexcept {
 			}
 		}
 
-		_stepTimer.Initialize(5.0f, frameRateLimit);
+		_stepTimer.Initialize(options.minFrameRate, frameRateLimit);
 	}
 
 	ID3D11Texture2D* outputTexture = _BuildEffects();

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -666,7 +666,7 @@ void Renderer::_BackendThreadProc() noexcept {
 		return;
 	}
 
-	const bool waitMsgForNewFrame =
+	bool waitMsgForNewFrame =
 		_frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
 
 	MSG msg;
@@ -689,12 +689,16 @@ void Renderer::_BackendThreadProc() noexcept {
 
 		switch (_frameSource->Update()) {
 		case FrameSourceState::Waiting:
+			waitMsgForNewFrame = _frameSource->WaitType() == FrameSourceWaitType::WaitForMessage;
+
 			if (stepTimerStatus != StepTimerStatus::ForceNewFrame) {
 				break;
 			}
+
 			// 强制帧
 			[[fallthrough]];
 		case FrameSourceState::NewFrame:
+			waitMsgForNewFrame = false;
 			_stepTimer.PrepareForRender();
 			_BackendRender(outputTexture);
 			break;

--- a/src/Magpie.Core/ScalingOptions.cpp
+++ b/src/Magpie.Core/ScalingOptions.cpp
@@ -59,6 +59,7 @@ void ScalingOptions::Log() const noexcept {
 		idx: {}
 		venderId: {}
 		deviceId: {}
+	minFrameRate: {}
 	maxFrameRate: {}
 	cursorScaling: {}
 	captureMethod: {}
@@ -86,6 +87,7 @@ void ScalingOptions::Log() const noexcept {
 		graphicsCardId.idx,
 		graphicsCardId.vendorId,
 		graphicsCardId.deviceId,
+		minFrameRate,
 		maxFrameRate.has_value() ? *maxFrameRate : 0.0f,
 		cursorScaling,
 		(int)captureMethod,

--- a/src/Magpie.Core/StepTimer.cpp
+++ b/src/Magpie.Core/StepTimer.cpp
@@ -5,46 +5,64 @@ using namespace std::chrono;
 
 namespace Magpie {
 
-void StepTimer::Initialize(std::optional<float> maxFrameRate) noexcept {
+void StepTimer::Initialize(float minFrameRate, std::optional<float> maxFrameRate) noexcept {
+	if (minFrameRate > 1e-6) {
+		_maxInterval = duration_cast<nanoseconds>(duration<float>(1 / minFrameRate));
+	} else {
+		_maxInterval = nanoseconds(std::numeric_limits<nanoseconds::rep>::max());
+	}
+
 	if (maxFrameRate) {
 		_minInterval = duration_cast<nanoseconds>(duration<float>(1 / *maxFrameRate));
-		_hTimer.reset(CreateWaitableTimerEx(nullptr, nullptr,
-			CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS));
 	}
+
+	_hTimer.reset(CreateWaitableTimerEx(nullptr, nullptr,
+		CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS));
 }
 
-bool StepTimer::WaitForNextFrame() noexcept {
-	if (!_minInterval) {
-		return true;
-	}
-
+StepTimerStatus StepTimer::WaitForNextFrame(bool waitMsgForNewFrame) noexcept {
 	const time_point<steady_clock> now = steady_clock::now();
+
+	if (_lastFrameTime == time_point<steady_clock>{}) {
+		_lastFrameTime = now;
+		return StepTimerStatus::WaitForNewFrame;
+	}
+
 	const nanoseconds delta = now - _lastFrameTime;
-	if (delta >= *_minInterval) {
-		_lastFrameTime = now - delta % *_minInterval;
-		return true;
+
+	if (delta >= _maxInterval) {
+		_lastFrameTime = now - delta % _maxInterval;
+		return StepTimerStatus::ForceNewFrame;
 	}
 
-	const nanoseconds rest = *_minInterval - delta;
-	if (rest > 1ms) {
-		// Sleep 精度太低，我们使用 WaitableTimer 睡眠。负值表示相对时间
-		LARGE_INTEGER liDueTime{
-			.QuadPart = (rest - 1ms).count() / -100
-		};
-		SetWaitableTimerEx(_hTimer.get(), &liDueTime, 0, NULL, NULL, 0, 0);
+	if (_minInterval) {
+		if (delta < *_minInterval) {
+			_WaitForMsgAndTimer(*_minInterval - delta);
+			return StepTimerStatus::WaitForFPSLimiter;
+		}
 
-		// 新消息到达则中止等待
-		HANDLE hTimer = _hTimer.get();
-		MsgWaitForMultipleObjectsEx(1, &hTimer, INFINITE, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
-	} else {
-		// 剩余时间在 1ms 以内则“忙等待”
-		Sleep(0);
+		if (!_isWaitingForNewFrame) {
+			_isWaitingForNewFrame = true;
+			_lastFrameTime = now - delta % *_minInterval;
+		}
 	}
 
-	return false;
+	if (waitMsgForNewFrame) {
+		if (_maxInterval == nanoseconds(std::numeric_limits<nanoseconds::rep>::max())) {
+			WaitMessage();
+		} else {
+			_WaitForMsgAndTimer(_maxInterval - delta);
+		}
+	}
+
+	return StepTimerStatus::WaitForNewFrame;
 }
 
 void StepTimer::UpdateFPS(bool newFrame) noexcept {
+	if (newFrame) {
+		_isWaitingForNewFrame = false;
+	}
+
 	if (_lastSecondTime == time_point<steady_clock>{}) {
 		// 第一帧
 		if (!newFrame) {
@@ -70,6 +88,23 @@ void StepTimer::UpdateFPS(bool newFrame) noexcept {
 
 		_framesPerSecond.store(_framesThisSecond, std::memory_order_relaxed);
 		_framesThisSecond = 0;
+	}
+}
+
+void StepTimer::_WaitForMsgAndTimer(std::chrono::nanoseconds time) noexcept {
+	if (time > 1ms) {
+		// Sleep 精度太低，我们使用 WaitableTimer 睡眠。负值表示相对时间
+		LARGE_INTEGER liDueTime{
+			.QuadPart = (time - 1ms).count() / -100
+		};
+		SetWaitableTimerEx(_hTimer.get(), &liDueTime, 0, NULL, NULL, 0, 0);
+
+		// 新消息到达则中止等待
+		HANDLE hTimer = _hTimer.get();
+		MsgWaitForMultipleObjectsEx(1, &hTimer, INFINITE, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
+	} else {
+		// 剩余时间在 1ms 以内则“忙等待”
+		Sleep(0);
 	}
 }
 

--- a/src/Magpie.Core/StepTimer.h
+++ b/src/Magpie.Core/StepTimer.h
@@ -20,7 +20,7 @@ public:
 
 	StepTimerStatus WaitForNextFrame(bool waitMsgForNewFrame) noexcept;
 
-	void PrepareForNewFrame() noexcept;
+	void PrepareForRender() noexcept;
 
 	uint32_t FrameCount() const noexcept {
 		return _frameCount;
@@ -43,14 +43,13 @@ private:
 	std::chrono::nanoseconds _maxInterval{ std::numeric_limits<std::chrono::nanoseconds::rep>::max() };
 	wil::unique_event_nothrow _hTimer;
 
-	std::chrono::time_point<std::chrono::steady_clock> _lastFrameTime;
+	std::chrono::time_point<std::chrono::steady_clock> _thisFrameStartTime;
+	std::chrono::time_point<std::chrono::steady_clock> _nextFrameStartTime;
 	std::chrono::time_point<std::chrono::steady_clock> _lastSecondTime;
 
 	uint32_t _frameCount = 0;
 	std::atomic<uint32_t> _framesPerSecond = 0;
 	uint32_t _framesThisSecond = 0;
-
-	std::chrono::time_point<std::chrono::steady_clock> _frameStartTime;
 };
 
 }

--- a/src/Magpie.Core/StepTimer.h
+++ b/src/Magpie.Core/StepTimer.h
@@ -16,11 +16,11 @@ public:
 	StepTimer(const StepTimer&) = delete;
 	StepTimer(StepTimer&&) = delete;
 
-	void Initialize(float minFrameRate, std::optional<float> maxFrameRate) noexcept;
+	void Initialize(std::optional<float> minFrameRate, std::optional<float> maxFrameRate) noexcept;
 
 	StepTimerStatus WaitForNextFrame(bool waitMsgForNewFrame) noexcept;
 
-	void UpdateFPS(bool newFrame) noexcept;
+	void PrepareForNewFrame() noexcept;
 
 	uint32_t FrameCount() const noexcept {
 		return _frameCount;
@@ -32,12 +32,15 @@ public:
 	}
 
 private:
+	bool _HasMinInterval() const noexcept;
+	bool _HasMaxInterval() const noexcept;
+
 	void _WaitForMsgAndTimer(std::chrono::nanoseconds time) noexcept;
 
-	bool _HasMinFrameRate() const noexcept;
+	void _UpdateFPS() noexcept;
 
-	std::optional<std::chrono::nanoseconds> _minInterval;
-	std::chrono::nanoseconds _maxInterval{};
+	std::chrono::nanoseconds _minInterval{};
+	std::chrono::nanoseconds _maxInterval{ std::numeric_limits<std::chrono::nanoseconds::rep>::max() };
 	wil::unique_event_nothrow _hTimer;
 
 	std::chrono::time_point<std::chrono::steady_clock> _lastFrameTime;

--- a/src/Magpie.Core/StepTimer.h
+++ b/src/Magpie.Core/StepTimer.h
@@ -50,7 +50,7 @@ private:
 	std::atomic<uint32_t> _framesPerSecond = 0;
 	uint32_t _framesThisSecond = 0;
 
-	bool _isNewFrame = false;
+	std::chrono::time_point<std::chrono::steady_clock> _frameStartTime;
 };
 
 }

--- a/src/Magpie.Core/StepTimer.h
+++ b/src/Magpie.Core/StepTimer.h
@@ -16,7 +16,7 @@ public:
 	StepTimer(const StepTimer&) = delete;
 	StepTimer(StepTimer&&) = delete;
 
-	void Initialize(std::optional<float> minFrameRate, std::optional<float> maxFrameRate) noexcept;
+	void Initialize(float minFrameRate, std::optional<float> maxFrameRate) noexcept;
 
 	StepTimerStatus WaitForNextFrame(bool waitMsgForNewFrame) noexcept;
 
@@ -37,7 +37,7 @@ private:
 
 	void _WaitForMsgAndTimer(std::chrono::nanoseconds time) noexcept;
 
-	void _UpdateFPS() noexcept;
+	void _UpdateFPS(std::chrono::time_point<std::chrono::steady_clock> now) noexcept;
 
 	std::chrono::nanoseconds _minInterval{};
 	std::chrono::nanoseconds _maxInterval{ std::numeric_limits<std::chrono::nanoseconds::rep>::max() };
@@ -49,6 +49,8 @@ private:
 	uint32_t _frameCount = 0;
 	std::atomic<uint32_t> _framesPerSecond = 0;
 	uint32_t _framesThisSecond = 0;
+
+	bool _isNewFrame = false;
 };
 
 }

--- a/src/Magpie.Core/StepTimer.h
+++ b/src/Magpie.Core/StepTimer.h
@@ -34,6 +34,8 @@ public:
 private:
 	void _WaitForMsgAndTimer(std::chrono::nanoseconds time) noexcept;
 
+	bool _HasMinFrameRate() const noexcept;
+
 	std::optional<std::chrono::nanoseconds> _minInterval;
 	std::chrono::nanoseconds _maxInterval{};
 	wil::unique_event_nothrow _hTimer;
@@ -44,8 +46,6 @@ private:
 	uint32_t _frameCount = 0;
 	std::atomic<uint32_t> _framesPerSecond = 0;
 	uint32_t _framesThisSecond = 0;
-
-	bool _isWaitingForNewFrame = false;
 };
 
 }

--- a/src/Magpie.Core/StepTimer.h
+++ b/src/Magpie.Core/StepTimer.h
@@ -3,6 +3,12 @@
 
 namespace Magpie {
 
+enum class StepTimerStatus {
+	WaitForNewFrame,
+	WaitForFPSLimiter,
+	ForceNewFrame
+};
+
 class StepTimer {
 public:
 	StepTimer() = default;
@@ -10,9 +16,9 @@ public:
 	StepTimer(const StepTimer&) = delete;
 	StepTimer(StepTimer&&) = delete;
 
-	void Initialize(std::optional<float> maxFrameRate) noexcept;
+	void Initialize(float minFrameRate, std::optional<float> maxFrameRate) noexcept;
 
-	bool WaitForNextFrame() noexcept;
+	StepTimerStatus WaitForNextFrame(bool waitMsgForNewFrame) noexcept;
 
 	void UpdateFPS(bool newFrame) noexcept;
 
@@ -26,7 +32,10 @@ public:
 	}
 
 private:
+	void _WaitForMsgAndTimer(std::chrono::nanoseconds time) noexcept;
+
 	std::optional<std::chrono::nanoseconds> _minInterval;
+	std::chrono::nanoseconds _maxInterval{};
 	wil::unique_event_nothrow _hTimer;
 
 	std::chrono::time_point<std::chrono::steady_clock> _lastFrameTime;
@@ -35,6 +44,8 @@ private:
 	uint32_t _frameCount = 0;
 	std::atomic<uint32_t> _framesPerSecond = 0;
 	uint32_t _framesThisSecond = 0;
+
+	bool _isWaitingForNewFrame = false;
 };
 
 }

--- a/src/Magpie.Core/include/ScalingOptions.h
+++ b/src/Magpie.Core/include/ScalingOptions.h
@@ -112,6 +112,7 @@ struct ScalingOptions {
 	Cropping cropping{};
 	uint32_t flags = ScalingFlags::AdjustCursorSpeed | ScalingFlags::DrawCursor;	// ScalingFlags
 	GraphicsCardId graphicsCardId;
+	float minFrameRate = 0.0f;
 	std::optional<float> maxFrameRate;
 	float cursorScaling = 1.0f;
 	CaptureMethod captureMethod = CaptureMethod::GraphicsCapture;

--- a/src/Magpie/AboutPage.h
+++ b/src/Magpie/AboutPage.h
@@ -23,7 +23,6 @@ private:
 
 namespace winrt::Magpie::factory_implementation {
 
-struct AboutPage : AboutPageT<AboutPage, implementation::AboutPage> {
-};
+struct AboutPage : AboutPageT<AboutPage, implementation::AboutPage> {};
 
 }

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -42,6 +42,7 @@
 
 using namespace ::Magpie;
 using namespace winrt;
+using namespace Windows::Globalization::NumberFormatting;
 using namespace Windows::UI::ViewManagement;
 
 namespace winrt::Magpie::implementation {
@@ -261,6 +262,20 @@ void App::Restart(bool asElevated, const wchar_t* arguments) noexcept {
 const com_ptr<RootPage>& App::RootPage() const noexcept {
 	assert(_mainWindow && *_mainWindow);
 	return _mainWindow->Content();
+}
+
+INumberFormatter2 App::DoubleFormatter() {
+	static DecimalFormatter numberFormatter = []() {
+		DecimalFormatter result;
+		IncrementNumberRounder rounder;
+		// 保留五位小数
+		rounder.Increment(0.00001);
+		result.NumberRounder(rounder);
+		result.FractionDigits(0);
+		return result;
+	}();
+
+	return numberFormatter;
 }
 
 void App::_Uninitialize() {

--- a/src/Magpie/App.h
+++ b/src/Magpie/App.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "App.g.h"
 #include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Windows.Globalization.NumberFormatting.h>
 #include "AppSettings.h"
 #include "Event.h"
 
@@ -47,6 +48,8 @@ public:
 	bool IsLightTheme() const noexcept {
 		return _isLightTheme.load(std::memory_order_relaxed);
 	}
+
+	static Windows::Globalization::NumberFormatting::INumberFormatter2 DoubleFormatter();
 
 	::Magpie::MultithreadEvent<bool> ThemeChanged;
 
@@ -108,5 +111,11 @@ private:
 
 	com_ptr<XamlMetaDataProvider> _appProvider;
 };
+
+}
+
+namespace winrt::Magpie::factory_implementation {
+
+struct App : AppT<App, implementation::App> {};
 
 }

--- a/src/Magpie/App.idl
+++ b/src/Magpie/App.idl
@@ -41,5 +41,6 @@ namespace Magpie {
 namespace Magpie {
 	[default_interface]
 	runtimeclass App : Windows.UI.Xaml.Application {
+		static Windows.Globalization.NumberFormatting.INumberFormatter2 DoubleFormatter { get; };
 	}
 }

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -516,6 +516,8 @@ bool AppSettings::_Save(const _AppSettingsData& data) noexcept {
 	writer.Uint((uint32_t)data._duplicateFrameDetectionMode);
 	writer.Key("enableStatisticsForDynamicDetection");
 	writer.Bool(data._isStatisticsForDynamicDetectionEnabled);
+	writer.Key("minFrameRate");
+	writer.Double(data._minFrameRate);
 
 	ScalingModesService::Get().Export(writer);
 
@@ -678,6 +680,7 @@ void AppSettings::_LoadSettings(const rapidjson::GenericObject<true, rapidjson::
 		_duplicateFrameDetectionMode = (::Magpie::DuplicateFrameDetectionMode)duplicateFrameDetectionMode;
 	}
 	JsonHelper::ReadBool(root, "enableStatisticsForDynamicDetection", _isStatisticsForDynamicDetectionEnabled);
+	JsonHelper::ReadFloat(root, "minFrameRate", _minFrameRate);
 
 	[[maybe_unused]] bool result = ScalingModesService::Get().Import(root, true);
 	assert(result);

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -49,7 +49,7 @@ struct _AppSettingsData {
 	DuplicateFrameDetectionMode _duplicateFrameDetectionMode =
 		DuplicateFrameDetectionMode::Dynamic;
 
-	float _minFrameRate = 5.0f;
+	float _minFrameRate = 10.0f;
 	
 	bool _isPortableMode = false;
 	bool _isAlwaysRunAsAdmin = false;

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -48,6 +48,8 @@ struct _AppSettingsData {
 
 	DuplicateFrameDetectionMode _duplicateFrameDetectionMode =
 		DuplicateFrameDetectionMode::Dynamic;
+
+	float _minFrameRate = 5.0f;
 	
 	bool _isPortableMode = false;
 	bool _isAlwaysRunAsAdmin = false;
@@ -278,6 +280,15 @@ public:
 
 	void IsStatisticsForDynamicDetectionEnabled(bool value) noexcept {
 		_isStatisticsForDynamicDetectionEnabled = value;
+		SaveAsync();
+	}
+
+	float MinFrameRate() const noexcept {
+		return _minFrameRate;
+	}
+
+	void MinFrameRate(float value) noexcept {
+		_minFrameRate = value;
 		SaveAsync();
 	}
 

--- a/src/Magpie/AppXReader.cpp
+++ b/src/Magpie/AppXReader.cpp
@@ -10,6 +10,7 @@
 #include <parallel_hashmap/phmap.h>
 #include <AppxPackaging.h>
 #include <propsys.h>
+#include <winrt/Windows.Graphics.Imaging.h>
 
 using namespace winrt;
 using namespace Windows::Graphics::Imaging;

--- a/src/Magpie/EffectParametersViewModel.cpp
+++ b/src/Magpie/EffectParametersViewModel.cpp
@@ -158,4 +158,8 @@ phmap::flat_hash_map<std::wstring, float>& EffectParametersViewModel::_Data() {
 	return scalingMode.effects[_effectIdx].parameters;
 }
 
+inline hstring ScalingModeFloatParameter::ValueText() const noexcept {
+	return App::DoubleFormatter().FormatDouble(_value);
+}
+
 }

--- a/src/Magpie/EffectParametersViewModel.h
+++ b/src/Magpie/EffectParametersViewModel.h
@@ -58,9 +58,7 @@ struct ScalingModeFloatParameter : ScalingModeFloatParameterT<ScalingModeFloatPa
 		RaisePropertyChanged(L"ValueText");
 	}
 
-	hstring ValueText() const noexcept {
-		return ScalingModesPage::NumberFormatter().FormatDouble(_value);
-	}
+	hstring ValueText() const noexcept;
 
 	hstring Label() const noexcept {
 		return _label;

--- a/src/Magpie/HomePage.cpp
+++ b/src/Magpie/HomePage.cpp
@@ -41,9 +41,4 @@ void HomePage::SimulateExclusiveFullscreenToggleSwitch_Toggled(IInspectable cons
 	});
 }
 
-void HomePage::MinFrameRateNumberBox_Loading(FrameworkElement const& sender, IInspectable const&) {
-	// 不知为何在 XAML 中设置会导致加载失败
-	sender.as<MUXC::NumberBox>().NumberFormatter(App::Get().DoubleFormatter());
-}
-
 }

--- a/src/Magpie/HomePage.cpp
+++ b/src/Magpie/HomePage.cpp
@@ -41,4 +41,9 @@ void HomePage::SimulateExclusiveFullscreenToggleSwitch_Toggled(IInspectable cons
 	});
 }
 
+void HomePage::MinFrameRateNumberBox_Loading(FrameworkElement const& sender, IInspectable const&) {
+	// 不知为何在 XAML 中设置会导致加载失败
+	sender.as<MUXC::NumberBox>().NumberFormatter(App::Get().DoubleFormatter());
+}
+
 }

--- a/src/Magpie/HomePage.h
+++ b/src/Magpie/HomePage.h
@@ -15,6 +15,8 @@ struct HomePage : HomePageT<HomePage> {
 
 	void SimulateExclusiveFullscreenToggleSwitch_Toggled(IInspectable const& sender, RoutedEventArgs const&);
 
+	void MinFrameRateNumberBox_Loading(FrameworkElement const& sender, IInspectable const&);
+
 private:
 	com_ptr<HomeViewModel> _viewModel = make_self<HomeViewModel>();
 };

--- a/src/Magpie/HomePage.h
+++ b/src/Magpie/HomePage.h
@@ -15,8 +15,6 @@ struct HomePage : HomePageT<HomePage> {
 
 	void SimulateExclusiveFullscreenToggleSwitch_Toggled(IInspectable const& sender, RoutedEventArgs const&);
 
-	void MinFrameRateNumberBox_Loading(FrameworkElement const& sender, IInspectable const&);
-
 private:
 	com_ptr<HomeViewModel> _viewModel = make_self<HomeViewModel>();
 };

--- a/src/Magpie/HomePage.h
+++ b/src/Magpie/HomePage.h
@@ -23,7 +23,6 @@ private:
 
 namespace winrt::Magpie::factory_implementation {
 
-struct HomePage : HomePageT<HomePage, implementation::HomePage> {
-};
+struct HomePage : HomePageT<HomePage, implementation::HomePage> {};
 
 }

--- a/src/Magpie/HomePage.xaml
+++ b/src/Magpie/HomePage.xaml
@@ -168,11 +168,33 @@
 				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Home_Advanced_SimulateExclusiveFullscreen">
 					<local:SettingsCard.HeaderIcon>
-						<FontIcon Glyph="&#xec46;" />
+						<FontIcon Glyph="&#xEC46;" />
 					</local:SettingsCard.HeaderIcon>
 					<ToggleSwitch x:Uid="ToggleSwitch"
 					              IsOn="{x:Bind ViewModel.IsSimulateExclusiveFullscreen, Mode=TwoWay}"
 					              Toggled="SimulateExclusiveFullscreenToggleSwitch_Toggled" />
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_MinFrameRate"
+				                    IsWrapEnabled="True">
+					<local:SettingsCard.HeaderIcon>
+						<FontIcon Glyph="&#xECAD;" />
+					</local:SettingsCard.HeaderIcon>
+					<Grid MinWidth="{StaticResource SettingsCardContentMinWidth}">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+						<ComboBox Grid.Column="0"
+						          MinWidth="0"
+						          Margin="0,0,8,0"
+						          HorizontalAlignment="Stretch"
+						          DropDownOpened="ComboBox_DropDownOpened"
+						          ItemsSource="{x:Bind ViewModel.MinFrameRateOptions, Mode=OneTime}"
+						          SelectedIndex="{x:Bind ViewModel.MinFrameRateIndex, Mode=TwoWay}" />
+						<TextBlock Grid.Column="1"
+						           VerticalAlignment="Center"
+						           Text="FPS" />
+					</Grid>
 				</local:SettingsCard>
 				<muxc:InfoBar x:Uid="Home_Advanced_SimulateExclusiveFullscreen_InfoBar"
 				              IsClosable="False"
@@ -223,23 +245,6 @@
 						                    IsEnabled="{x:Bind ViewModel.IsDynamicDection, Mode=OneWay}">
 							<ToggleSwitch x:Uid="ToggleSwitch"
 							              IsOn="{x:Bind ViewModel.IsStatisticsForDynamicDetectionEnabled, Mode=TwoWay}" />
-						</local:SettingsCard>
-						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_MinFrameRate"
-						                    IsWrapEnabled="True">
-							<local:SimpleStackPanel Orientation="Horizontal"
-							                        Spacing="8">
-								<!--  不知为何在 XAML 中设置 NumberFormatter 会导致加载失败，改为在 Loading 事件中设置  -->
-								<muxc:NumberBox VerticalAlignment="Center"
-								                LargeChange="10"
-								                Loading="MinFrameRateNumberBox_Loading"
-								                Maximum="1000"
-								                Minimum="0"
-								                SmallChange="1"
-								                SpinButtonPlacementMode="Inline"
-								                Value="{x:Bind ViewModel.MinFrameRate, Mode=TwoWay}" />
-								<TextBlock VerticalAlignment="Center"
-								           Text="FPS" />
-							</local:SimpleStackPanel>
 						</local:SettingsCard>
 					</local:SettingsExpander.Items>
 				</local:SettingsExpander>

--- a/src/Magpie/HomePage.xaml
+++ b/src/Magpie/HomePage.xaml
@@ -189,7 +189,7 @@
 						          Margin="0,0,8,0"
 						          HorizontalAlignment="Stretch"
 						          DropDownOpened="ComboBox_DropDownOpened"
-						          ItemsSource="{x:Bind ViewModel.MinFrameRateOptions, Mode=OneTime}"
+						          ItemsSource="{x:Bind local:HomeViewModel.MinFrameRateOptions, Mode=OneTime}"
 						          SelectedIndex="{x:Bind ViewModel.MinFrameRateIndex, Mode=TwoWay}" />
 						<TextBlock Grid.Column="1"
 						           VerticalAlignment="Center"

--- a/src/Magpie/HomePage.xaml
+++ b/src/Magpie/HomePage.xaml
@@ -190,25 +190,25 @@
 						              IsOn="{x:Bind ViewModel.IsDeveloperMode, Mode=TwoWay}" />
 					</local:SettingsExpander.Content>
 					<local:SettingsExpander.Items>
-						<local:SettingsCard ContentAlignment="Left">
-							<CheckBox x:Uid="Home_Advanced_DeveloperOptions_DebugMode"
-							          IsChecked="{x:Bind ViewModel.IsDebugMode, Mode=TwoWay}" />
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_DebugMode">
+							<ToggleSwitch x:Uid="ToggleSwitch"
+							              IsOn="{x:Bind ViewModel.IsDebugMode, Mode=TwoWay}" />
 						</local:SettingsCard>
-						<local:SettingsCard ContentAlignment="Left">
-							<CheckBox x:Uid="Home_Advanced_DeveloperOptions_DisableEffectCache"
-							          IsChecked="{x:Bind ViewModel.IsEffectCacheDisabled, Mode=TwoWay}" />
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_DisableEffectCache">
+							<ToggleSwitch x:Uid="ToggleSwitch"
+							              IsOn="{x:Bind ViewModel.IsEffectCacheDisabled, Mode=TwoWay}" />
 						</local:SettingsCard>
-						<local:SettingsCard ContentAlignment="Left">
-							<CheckBox x:Uid="Home_Advanced_DeveloperOptions_DisableFontCache"
-							          IsChecked="{x:Bind ViewModel.IsFontCacheDisabled, Mode=TwoWay}" />
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_DisableFontCache">
+							<ToggleSwitch x:Uid="ToggleSwitch"
+							              IsOn="{x:Bind ViewModel.IsFontCacheDisabled, Mode=TwoWay}" />
 						</local:SettingsCard>
-						<local:SettingsCard ContentAlignment="Left">
-							<CheckBox x:Uid="Home_Advanced_DeveloperOptions_SaveEffectSources"
-							          IsChecked="{x:Bind ViewModel.IsSaveEffectSources, Mode=TwoWay}" />
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_SaveEffectSources">
+							<ToggleSwitch x:Uid="ToggleSwitch"
+							              IsOn="{x:Bind ViewModel.IsSaveEffectSources, Mode=TwoWay}" />
 						</local:SettingsCard>
-						<local:SettingsCard ContentAlignment="Left">
-							<CheckBox x:Uid="Home_Advanced_DeveloperOptions_WarningsAreErrors"
-							          IsChecked="{x:Bind ViewModel.IsWarningsAreErrors, Mode=TwoWay}" />
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_WarningsAreErrors">
+							<ToggleSwitch x:Uid="ToggleSwitch"
+							              IsOn="{x:Bind ViewModel.IsWarningsAreErrors, Mode=TwoWay}" />
 						</local:SettingsCard>
 						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_DuplicateFrameDetection"
 						                    IsWrapEnabled="True">
@@ -219,10 +219,27 @@
 								<ComboBoxItem x:Uid="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never" />
 							</ComboBox>
 						</local:SettingsCard>
-						<local:SettingsCard ContentAlignment="Left"
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection"
 						                    IsEnabled="{x:Bind ViewModel.IsDynamicDection, Mode=OneWay}">
-							<CheckBox x:Uid="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection"
-							          IsChecked="{x:Bind ViewModel.IsStatisticsForDynamicDetectionEnabled, Mode=TwoWay}" />
+							<ToggleSwitch x:Uid="ToggleSwitch"
+							              IsOn="{x:Bind ViewModel.IsStatisticsForDynamicDetectionEnabled, Mode=TwoWay}" />
+						</local:SettingsCard>
+						<local:SettingsCard x:Uid="Home_Advanced_DeveloperOptions_MinFrameRate"
+						                    IsWrapEnabled="True">
+							<local:SimpleStackPanel Orientation="Horizontal"
+							                        Spacing="8">
+								<!--  不知为何在 XAML 中设置 NumberFormatter 会导致加载失败，改为在 Loading 事件中设置  -->
+								<muxc:NumberBox VerticalAlignment="Center"
+								                LargeChange="10"
+								                Loading="MinFrameRateNumberBox_Loading"
+								                Maximum="1000"
+								                Minimum="0"
+								                SmallChange="1"
+								                SpinButtonPlacementMode="Inline"
+								                Value="{x:Bind ViewModel.MinFrameRate, Mode=TwoWay}" />
+								<TextBlock VerticalAlignment="Center"
+								           Text="FPS" />
+							</local:SimpleStackPanel>
 						</local:SettingsCard>
 					</local:SettingsExpander.Items>
 				</local:SettingsExpander>

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -271,6 +271,37 @@ void HomeViewModel::IsSimulateExclusiveFullscreen(bool value) {
 	RaisePropertyChanged(L"IsSimulateExclusiveFullscreen");
 }
 
+static constexpr std::array MIN_FRAME_RATE_OPTIONS{ 0,5,10,20,30 };
+
+IVector<IInspectable> HomeViewModel::MinFrameRateOptions() const {
+	std::vector<IInspectable> options;
+	options.reserve(MIN_FRAME_RATE_OPTIONS.size());
+	for (int option : MIN_FRAME_RATE_OPTIONS) {
+		options.push_back(box_value(std::to_wstring(option)));
+	}
+
+	return single_threaded_vector(std::move(options));
+}
+
+int HomeViewModel::MinFrameRateIndex() const noexcept {
+	float minFrameRate = AppSettings::Get().MinFrameRate();
+	auto it = std::find(
+		MIN_FRAME_RATE_OPTIONS.begin(), MIN_FRAME_RATE_OPTIONS.end(), minFrameRate);
+	if (it == MIN_FRAME_RATE_OPTIONS.end()) {
+		return -1;
+	} else {
+		return int(it - MIN_FRAME_RATE_OPTIONS.begin());
+	}
+}
+
+void HomeViewModel::MinFrameRateIndex(int value) {
+	if (value < 0 || value >= MIN_FRAME_RATE_OPTIONS.size()) {
+		return;
+	}
+
+	AppSettings::Get().MinFrameRate(MIN_FRAME_RATE_OPTIONS[value]);
+}
+
 bool HomeViewModel::IsDeveloperMode() const noexcept {
 	return AppSettings::Get().IsDeveloperMode();
 }
@@ -405,16 +436,6 @@ void HomeViewModel::IsStatisticsForDynamicDetectionEnabled(bool value) {
 
 	settings.IsStatisticsForDynamicDetectionEnabled(value);
 	RaisePropertyChanged(L"IsStatisticsForDynamicDetectionEnabled");
-}
-
-double HomeViewModel::MinFrameRate() const noexcept {
-	return AppSettings::Get().MinFrameRate();
-}
-
-void HomeViewModel::MinFrameRate(double value) {
-	// 清空数字框则重置为 5
-	AppSettings::Get().MinFrameRate(std::isnan(value) ? 5.0f : (float)value);
-	RaisePropertyChanged(L"MinFrameRate");
 }
 
 void HomeViewModel::_ScalingService_IsTimerOnChanged(bool value) {

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -303,6 +303,7 @@ void HomeViewModel::MinFrameRateIndex(int value) {
 	}
 
 	AppSettings::Get().MinFrameRate((float)MIN_FRAME_RATE_OPTIONS[value]);
+	RaisePropertyChanged(L"MinFrameRateIndex");
 }
 
 bool HomeViewModel::IsDeveloperMode() const noexcept {

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -285,8 +285,11 @@ IVector<IInspectable> HomeViewModel::MinFrameRateOptions() const {
 
 int HomeViewModel::MinFrameRateIndex() const noexcept {
 	float minFrameRate = AppSettings::Get().MinFrameRate();
-	auto it = std::find(
-		MIN_FRAME_RATE_OPTIONS.begin(), MIN_FRAME_RATE_OPTIONS.end(), minFrameRate);
+	auto it = std::find_if(
+		MIN_FRAME_RATE_OPTIONS.begin(),
+		MIN_FRAME_RATE_OPTIONS.end(),
+		[&](int value) { return std::abs(minFrameRate - value) < 1e-5f; }
+	);
 	if (it == MIN_FRAME_RATE_OPTIONS.end()) {
 		return -1;
 	} else {
@@ -299,7 +302,7 @@ void HomeViewModel::MinFrameRateIndex(int value) {
 		return;
 	}
 
-	AppSettings::Get().MinFrameRate(MIN_FRAME_RATE_OPTIONS[value]);
+	AppSettings::Get().MinFrameRate((float)MIN_FRAME_RATE_OPTIONS[value]);
 }
 
 bool HomeViewModel::IsDeveloperMode() const noexcept {

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -273,14 +273,17 @@ void HomeViewModel::IsSimulateExclusiveFullscreen(bool value) {
 
 static constexpr std::array MIN_FRAME_RATE_OPTIONS{ 0,5,10,20,30 };
 
-IVector<IInspectable> HomeViewModel::MinFrameRateOptions() const {
-	std::vector<IInspectable> options;
-	options.reserve(MIN_FRAME_RATE_OPTIONS.size());
-	for (int option : MIN_FRAME_RATE_OPTIONS) {
-		options.push_back(box_value(std::to_wstring(option)));
-	}
+IVector<IInspectable> HomeViewModel::MinFrameRateOptions() {
+	static IVector<IInspectable> result = [] {
+		std::vector<IInspectable> options;
+		options.reserve(MIN_FRAME_RATE_OPTIONS.size());
+		for (int option : MIN_FRAME_RATE_OPTIONS) {
+			options.push_back(box_value(std::to_wstring(option)));
+		}
 
-	return single_threaded_vector(std::move(options));
+		return single_threaded_vector(std::move(options));
+	}();
+	return result;
 }
 
 int HomeViewModel::MinFrameRateIndex() const noexcept {

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -407,6 +407,16 @@ void HomeViewModel::IsStatisticsForDynamicDetectionEnabled(bool value) {
 	RaisePropertyChanged(L"IsStatisticsForDynamicDetectionEnabled");
 }
 
+double HomeViewModel::MinFrameRate() const noexcept {
+	return AppSettings::Get().MinFrameRate();
+}
+
+void HomeViewModel::MinFrameRate(double value) {
+	// 清空数字框则重置为 5
+	AppSettings::Get().MinFrameRate(std::isnan(value) ? 5.0f : (float)value);
+	RaisePropertyChanged(L"MinFrameRate");
+}
+
 void HomeViewModel::_ScalingService_IsTimerOnChanged(bool value) {
 	if (!value) {
 		RaisePropertyChanged(L"TimerProgressRingValue");

--- a/src/Magpie/HomeViewModel.h
+++ b/src/Magpie/HomeViewModel.h
@@ -91,6 +91,10 @@ struct HomeViewModel : HomeViewModelT<HomeViewModel>, wil::notify_property_chang
 
 	bool IsStatisticsForDynamicDetectionEnabled() const noexcept;
 	void IsStatisticsForDynamicDetectionEnabled(bool value);
+
+	double MinFrameRate() const noexcept;
+	void MinFrameRate(double value);
+
 private:
 	void _ScalingService_IsTimerOnChanged(bool value);
 

--- a/src/Magpie/HomeViewModel.h
+++ b/src/Magpie/HomeViewModel.h
@@ -66,7 +66,7 @@ struct HomeViewModel : HomeViewModelT<HomeViewModel>, wil::notify_property_chang
 	bool IsSimulateExclusiveFullscreen() const noexcept;
 	void IsSimulateExclusiveFullscreen(bool value);
 
-	IVector<IInspectable> MinFrameRateOptions() const;
+	static IVector<IInspectable> MinFrameRateOptions();
 
 	int MinFrameRateIndex() const noexcept;
 	void MinFrameRateIndex(int value);
@@ -114,5 +114,11 @@ private:
 
 	bool _showUpdateCard = false;
 };
+
+}
+
+namespace winrt::Magpie::factory_implementation {
+
+struct HomeViewModel : HomeViewModelT<HomeViewModel, implementation::HomeViewModel> {};
 
 }

--- a/src/Magpie/HomeViewModel.h
+++ b/src/Magpie/HomeViewModel.h
@@ -66,6 +66,11 @@ struct HomeViewModel : HomeViewModelT<HomeViewModel>, wil::notify_property_chang
 	bool IsSimulateExclusiveFullscreen() const noexcept;
 	void IsSimulateExclusiveFullscreen(bool value);
 
+	IVector<IInspectable> MinFrameRateOptions() const;
+
+	int MinFrameRateIndex() const noexcept;
+	void MinFrameRateIndex(int value);
+
 	bool IsDeveloperMode() const noexcept;
 	void IsDeveloperMode(bool value);
 
@@ -91,9 +96,6 @@ struct HomeViewModel : HomeViewModelT<HomeViewModel>, wil::notify_property_chang
 
 	bool IsStatisticsForDynamicDetectionEnabled() const noexcept;
 	void IsStatisticsForDynamicDetectionEnabled(bool value);
-
-	double MinFrameRate() const noexcept;
-	void MinFrameRate(double value);
 
 private:
 	void _ScalingService_IsTimerOnChanged(bool value);

--- a/src/Magpie/HomeViewModel.idl
+++ b/src/Magpie/HomeViewModel.idl
@@ -30,7 +30,7 @@ namespace Magpie {
 		Boolean IsAllowScalingMaximized;
 		Boolean IsInlineParams;
 		Boolean IsSimulateExclusiveFullscreen;
-		IVector<IInspectable> MinFrameRateOptions { get; };
+		static IVector<IInspectable> MinFrameRateOptions { get; };
 		Int32 MinFrameRateIndex;
 
 		Boolean IsDeveloperMode;

--- a/src/Magpie/HomeViewModel.idl
+++ b/src/Magpie/HomeViewModel.idl
@@ -40,5 +40,6 @@ namespace Magpie {
 		Int32 DuplicateFrameDetectionMode;
 		Boolean IsDynamicDection { get; };
 		Boolean IsStatisticsForDynamicDetectionEnabled;
+		Double MinFrameRate;
 	}
 }

--- a/src/Magpie/HomeViewModel.idl
+++ b/src/Magpie/HomeViewModel.idl
@@ -30,6 +30,8 @@ namespace Magpie {
 		Boolean IsAllowScalingMaximized;
 		Boolean IsInlineParams;
 		Boolean IsSimulateExclusiveFullscreen;
+		IVector<IInspectable> MinFrameRateOptions { get; };
+		Int32 MinFrameRateIndex;
 
 		Boolean IsDeveloperMode;
 		Boolean IsDebugMode;
@@ -40,6 +42,5 @@ namespace Magpie {
 		Int32 DuplicateFrameDetectionMode;
 		Boolean IsDynamicDection { get; };
 		Boolean IsStatisticsForDynamicDetectionEnabled;
-		Double MinFrameRate;
 	}
 }

--- a/src/Magpie/IconHelper.cpp
+++ b/src/Magpie/IconHelper.cpp
@@ -5,6 +5,7 @@
 #include "StrHelper.h"
 #include "resource.h"
 #include <Shlobj.h>
+#include <winrt/Windows.Graphics.Imaging.h>
 
 using namespace winrt;
 using namespace Windows::Graphics::Imaging;

--- a/src/Magpie/Profile.h
+++ b/src/Magpie/Profile.h
@@ -64,6 +64,8 @@ struct Profile {
 
 	// 10~1000
 	float maxFrameRate = 60.0f;
+	// 0~1000
+	float minFrameRate = 0.0f;
 
 	std::wstring launchParameters;
 

--- a/src/Magpie/Profile.h
+++ b/src/Magpie/Profile.h
@@ -64,8 +64,6 @@ struct Profile {
 
 	// 10~1000
 	float maxFrameRate = 60.0f;
-	// 0~1000
-	float minFrameRate = 0.0f;
 
 	std::wstring launchParameters;
 

--- a/src/Magpie/ProfilePage.cpp
+++ b/src/Magpie/ProfilePage.cpp
@@ -8,9 +8,8 @@
 #include "ProfileService.h"
 #include "Profile.h"
 
-using namespace Magpie;
+using namespace ::Magpie;
 using namespace winrt;
-using namespace Windows::Globalization::NumberFormatting;
 using namespace Windows::UI::Xaml::Controls::Primitives;
 using namespace Windows::UI::Xaml::Input;
 
@@ -47,20 +46,6 @@ void ProfilePage::CursorScalingComboBox_SelectionChanged(IInspectable const&, Se
 		CustomCursorScalingNumberBox().Visibility(Visibility::Collapsed);
 		CustomCursorScalingLabel().Visibility(Visibility::Collapsed);
 	}
-}
-
-INumberFormatter2 ProfilePage::NumberFormatter() noexcept {
-	static DecimalFormatter numberFormatter = []() {
-		DecimalFormatter result;
-		IncrementNumberRounder rounder;
-		// 保留五位小数
-		rounder.Increment(0.00001);
-		result.NumberRounder(rounder);
-		result.FractionDigits(0);
-		return result;
-	}();
-	
-	return numberFormatter;
 }
 
 void ProfilePage::RenameMenuItem_Click(IInspectable const&, RoutedEventArgs const&) {

--- a/src/Magpie/ProfilePage.h
+++ b/src/Magpie/ProfilePage.h
@@ -17,8 +17,6 @@ struct ProfilePage : ProfilePageT<ProfilePage> {
 
 	void CursorScalingComboBox_SelectionChanged(IInspectable const&, SelectionChangedEventArgs const&);
 
-	static Windows::Globalization::NumberFormatting::INumberFormatter2 NumberFormatter() noexcept;
-
 	void RenameMenuItem_Click(IInspectable const&, RoutedEventArgs const&);
 
 	void RenameFlyout_Opening(IInspectable const&, IInspectable const&);
@@ -43,7 +41,6 @@ private:
 
 namespace winrt::Magpie::factory_implementation {
 
-struct ProfilePage : ProfilePageT<ProfilePage, implementation::ProfilePage> {
-};
+struct ProfilePage : ProfilePageT<ProfilePage, implementation::ProfilePage> {};
 
 }

--- a/src/Magpie/ProfilePage.idl
+++ b/src/Magpie/ProfilePage.idl
@@ -4,8 +4,6 @@ namespace Magpie {
 
 		ProfileViewModel ViewModel { get; };
 
-		static Windows.Globalization.NumberFormatting.INumberFormatter2 NumberFormatter { get; };
-
 		// https://github.com/microsoft/microsoft-ui-xaml/issues/7579
 		void UnloadObject(Windows.UI.Xaml.DependencyObject object);
 	}

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -252,7 +252,7 @@
 								                LargeChange="10"
 								                Maximum="1000"
 								                Minimum="10"
-								                NumberFormatter="{x:Bind local:ProfilePage.NumberFormatter, Mode=OneTime}"
+								                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 								                SmallChange="1"
 								                SpinButtonPlacementMode="Inline"
 								                Value="{x:Bind ViewModel.MaxFrameRate, Mode=TwoWay}" />
@@ -296,7 +296,7 @@
 								<muxc:NumberBox Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 								                LargeChange="10"
 								                Minimum="0"
-								                NumberFormatter="{x:Bind local:ProfilePage.NumberFormatter, Mode=OneTime}"
+								                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 								                SmallChange="1"
 								                SpinButtonPlacementMode="Inline"
 								                Value="{x:Bind ViewModel.CroppingLeft, Mode=TwoWay}" />
@@ -311,7 +311,7 @@
 								<muxc:NumberBox Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 								                LargeChange="10"
 								                Minimum="0"
-								                NumberFormatter="{x:Bind local:ProfilePage.NumberFormatter, Mode=OneTime}"
+								                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 								                SmallChange="1"
 								                SpinButtonPlacementMode="Inline"
 								                Value="{x:Bind ViewModel.CroppingRight, Mode=TwoWay}" />
@@ -326,7 +326,7 @@
 								<muxc:NumberBox Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 								                LargeChange="10"
 								                Minimum="0"
-								                NumberFormatter="{x:Bind local:ProfilePage.NumberFormatter, Mode=OneTime}"
+								                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 								                SmallChange="1"
 								                SpinButtonPlacementMode="Inline"
 								                Value="{x:Bind ViewModel.CroppingTop, Mode=TwoWay}" />
@@ -341,7 +341,7 @@
 								<muxc:NumberBox Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 								                LargeChange="10"
 								                Minimum="0"
-								                NumberFormatter="{x:Bind local:ProfilePage.NumberFormatter, Mode=OneTime}"
+								                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 								                SmallChange="1"
 								                SpinButtonPlacementMode="Inline"
 								                Value="{x:Bind ViewModel.CroppingBottom, Mode=TwoWay}" />
@@ -398,7 +398,7 @@
 								                VerticalAlignment="Stretch"
 								                Maximum="10"
 								                Minimum="0.1"
-								                NumberFormatter="{x:Bind local:ProfilePage.NumberFormatter, Mode=OneTime}"
+								                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 								                SmallChange="0.1"
 								                Value="{x:Bind ViewModel.CustomCursorScaling, Mode=TwoWay}" />
 								<TextBlock x:Name="CustomCursorScalingLabel"

--- a/src/Magpie/ProfileViewModel.h
+++ b/src/Magpie/ProfileViewModel.h
@@ -56,16 +56,12 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel>,
 
 	void Delete();
 
-	IVector<IInspectable> ScalingModes() const noexcept {
-		return _scalingModes;
-	}
+	IVector<IInspectable> ScalingModes() const noexcept;
 
 	int ScalingMode() const noexcept;
 	void ScalingMode(int value);
 
-	IVector<IInspectable> CaptureMethods() const noexcept {
-		return _captureMethods;
-	}
+	IVector<IInspectable> CaptureMethods() const noexcept;
 
 	int CaptureMethod() const noexcept;
 	void CaptureMethod(int value);
@@ -152,9 +148,6 @@ private:
 
 	hstring _renameText;
 	std::wstring_view _trimedRenameText;
-
-	IVector<IInspectable> _scalingModes{ nullptr };
-	IVector<IInspectable> _captureMethods{ nullptr };
 
 	uint32_t _index = 0;
 	// 可以保存此指针的原因是: 用户停留在此页面时不会有缩放配置被创建或删除

--- a/src/Magpie/Resources.language-de.resw
+++ b/src/Magpie/Resources.language-de.resw
@@ -627,10 +627,10 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Entwickleroptionen</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Debug Modus</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Effektcache deaktivieren</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -678,7 +678,7 @@
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
     <value>Gesamt</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Schrift-Cache deaktivieren</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -705,10 +705,10 @@
   <data name="Home_Activation_AutoRestore_EmptyTitle" xml:space="preserve">
     <value>Titel ist leer</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Quellcode beim Parsen von Effekten speichern</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Warnungen beim Kompilieren von Effekten als Fehler betrachten</value>
   </data>
   <data name="AppSettings_ErrorDialog_ConfigLocation" xml:space="preserve">
@@ -802,7 +802,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Dynamic.Content" xml:space="preserve">
     <value>Dynamisch</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Statistik für die dynamische Erkennung aktivieren</value>
   </data>
   <data name="Home_TouchSupport_EnableTouchSupport_Description.Text" xml:space="preserve">

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -868,4 +868,7 @@
   <data name="Home_Advanced_DeveloperOptions_MinFrameRate.Header" xml:space="preserve">
     <value>Minimum frame rate</value>
   </data>
+  <data name="Home_Advanced_DeveloperOptions_MinFrameRate.Description" xml:space="preserve">
+    <value>Stabilizes GPU frequency to reduce stuttering, but may lead to higher power consumption</value>
+  </data>
 </root>

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -669,16 +669,16 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Developer options</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Debug mode</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Disable effect cache</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Save source code when parsing effects</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Treat warnings as errors when compiling effects</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
     <value>Total</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Disable font cache</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -808,7 +808,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>Never</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Enable statistics for dynamic detection</value>
   </data>
   <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">
@@ -864,5 +864,8 @@
   </data>
   <data name="Profile_Performance_NoGraphicsCard.Title" xml:space="preserve">
     <value>No compatible graphics card was found, so CPU rendering will be used instead. Performance may not meet expectations.</value>
+  </data>
+  <data name="Home_Advanced_DeveloperOptions_MinFrameRate.Header" xml:space="preserve">
+    <value>Minimum frame rate</value>
   </data>
 </root>

--- a/src/Magpie/Resources.language-es.resw
+++ b/src/Magpie/Resources.language-es.resw
@@ -489,13 +489,13 @@
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Error</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Modo de depuración</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Guarde el código fuente al analizar los efectos</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Tratar las advertencias como errores al compilar efectos</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -717,7 +717,7 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Opciones de desarrollador</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Desactivar caché de los efectos</value>
   </data>
   <data name="AppSettings_ErrorDialog_ConfigLocation" xml:space="preserve">
@@ -757,7 +757,7 @@
   <data name="Overlay_Profiler_Timings_SwitchToPasses" xml:space="preserve">
     <value>Cambiar a pases</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Desactivar la caché de fuentes</value>
   </data>
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
@@ -808,7 +808,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>Nunca</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Activar estadísticas para detección dinámica</value>
   </data>
   <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">

--- a/src/Magpie/Resources.language-fr.resw
+++ b/src/Magpie/Resources.language-fr.resw
@@ -207,7 +207,7 @@
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
     <value>Total</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Désactiver le cache des polices</value>
   </data>
   <data name="About_PageFrame.Title" xml:space="preserve">
@@ -427,7 +427,7 @@
   <data name="Home_UpdateCard_ReleaseNotes.Content" xml:space="preserve">
     <value>Notes de mise à jour</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Désactiver le cache d'effet</value>
   </data>
   <data name="About_Feedback_ReportBug.Header" xml:space="preserve">
@@ -460,7 +460,7 @@
   <data name="Profile_Cursor_DrawCursor_ScalingFactor_NoScaling.Content" xml:space="preserve">
     <value>Pas de mise à l'échelle</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Sauvegarde du code source lors de l'analyse des effets</value>
   </data>
   <data name="ScalingModes_ScaleFlyout_Type_Factor" xml:space="preserve">
@@ -535,7 +535,7 @@
   <data name="Profile_MoreOptions_RenameFlyout_OK.Content" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Mode debug</value>
   </data>
   <data name="Profile_General_CaptureMethod_Default" xml:space="preserve">
@@ -634,7 +634,7 @@
   <data name="About_Version_CheckingForUpdates.Text" xml:space="preserve">
     <value>Recherche de mises à jour</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Traiter les avertissements comme des erreurs lors de la compilation des effets</value>
   </data>
   <data name="About_Version_UpdateToDate_Installing.Text" xml:space="preserve">
@@ -793,7 +793,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Always.Content" xml:space="preserve">
     <value>Toujours</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Activer les statistiques pour la détection dynamique</value>
   </data>
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Dynamic.Content" xml:space="preserve">

--- a/src/Magpie/Resources.language-id.resw
+++ b/src/Magpie/Resources.language-id.resw
@@ -666,19 +666,19 @@
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
     <value>Keluar</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Nonaktifkan cache efek</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Simpan kode sumber ketika efek parsing</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Mode debug</value>
   </data>
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Pilihan pengembang</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Perlakukan peringatan sebagai eror saat menyusun efek</value>
   </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">

--- a/src/Magpie/Resources.language-it.resw
+++ b/src/Magpie/Resources.language-it.resw
@@ -498,10 +498,10 @@
   <data name="Home_Advanced_DeveloperOptions.Description" xml:space="preserve">
     <value>Queste impostazioni sono solo per gli sviluppatori</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Disabilita la cache degli effetti</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Salva il codice sorgente durante l'analisi degli effetti</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -565,7 +565,7 @@
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
     <value>Totale</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Disabilita la cache dei caratteri</value>
   </data>
   <data name="Overlay_Profiler_Timings_SwitchToPasses" xml:space="preserve">
@@ -757,10 +757,10 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Impostazioni sviluppatore</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Modalità di debug</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Considera gli avvisi come errori durante la compilazione degli effetti</value>
   </data>
   <data name="Settings_General_RequireRestart_ActionButton.Content" xml:space="preserve">

--- a/src/Magpie/Resources.language-ja.resw
+++ b/src/Magpie/Resources.language-ja.resw
@@ -522,13 +522,13 @@
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>エラー</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>エフェクトのコンパイル時に警告をエラーとして扱う</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>エフェクトの解析時にソースコードを保存する</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>エフェクトキャッシュを無効にする</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -700,7 +700,7 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>開発者向けオプション</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>デバッグモード</value>
   </data>
   <data name="ScalingModes_Description_UnknownEffect" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_Profiler" xml:space="preserve">
     <value>パフォーマンス解析</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>フォントキャッシュの無効化</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -814,7 +814,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>不検出</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>動的な検出統計を有効にする</value>
   </data>
   <data name="Home_TouchSupport_EnableTouchSupport.Header" xml:space="preserve">

--- a/src/Magpie/Resources.language-ko.resw
+++ b/src/Magpie/Resources.language-ko.resw
@@ -706,16 +706,16 @@
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>오류</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>디버그 모드</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>효과 캐시 사용 안 함</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>효과를 구분분석 할 때 소스 코드 저장</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>효과를 컴파일 할 때 경고를 오류로 취급</value>
   </data>
   <data name="AppSettings_ErrorDialog_ReadFailed" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_FPS_Unlock" xml:space="preserve">
     <value>잠금 해제</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>폰트 캐시 비활성화</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -814,7 +814,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>감지 안 함</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>동직 감지용 통계 사용</value>
   </data>
   <data name="Home_TouchSupport_EnableTouchSupport.Header" xml:space="preserve">

--- a/src/Magpie/Resources.language-pl.resw
+++ b/src/Magpie/Resources.language-pl.resw
@@ -274,16 +274,16 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Opcje programistyczne</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Debugowanie</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Wyłącz pamięć podręczną efektów</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Zapisz kod źródłowy podczas parsowania efektów</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Traktuj ostrzeżenia jako błędy podczas kompilacji efektów</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -308,7 +308,7 @@
   <data name="Overlay_Profiler_Timings_Total" xml:space="preserve">
     <value>Łącznie</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Wyłącz pamięć podręczną czcionek</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -356,7 +356,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>Nigdy</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Włącz statystyki dla wykrywania dynamicznego</value>
   </data>
   <data name="Overlay_Profiler_FrameRate" xml:space="preserve">

--- a/src/Magpie/Resources.language-pt-BR.resw
+++ b/src/Magpie/Resources.language-pt-BR.resw
@@ -582,7 +582,7 @@
   <data name="Overlay_FPS_Unlock" xml:space="preserve">
     <value>Desfixar</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Desativar cache de fonte</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
@@ -651,7 +651,7 @@
   <data name="Profile_General_CaptureMethod_Default" xml:space="preserve">
     <value>Padrão</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Desativar cache de efeito</value>
   </data>
   <data name="Profile_SourceWindow_CaptureTitleBar.Header" xml:space="preserve">
@@ -660,7 +660,7 @@
   <data name="Profile_SourceWindow.Header" xml:space="preserve">
     <value>Janela de origem</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Tratar avisos como erros ao compilar efeitos</value>
   </data>
   <data name="Profile_SourceWindow_CaptureTitleBar.Description" xml:space="preserve">
@@ -729,10 +729,10 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Opções do desenvolvedor</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Modo de depuração(debug)</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Salvar código-fonte ao interpretar efeitos</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -808,7 +808,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Dynamic.Content" xml:space="preserve">
     <value>Dinâmica</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Ativar estatísticas para detecção dinâmica</value>
   </data>
   <data name="Home_TouchSupport_EnableTouchSupport_LearnMore.Content" xml:space="preserve">

--- a/src/Magpie/Resources.language-ru.resw
+++ b/src/Magpie/Resources.language-ru.resw
@@ -678,16 +678,16 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Настройки разработчика</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Режим отладки</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Отключить кэш эффектов</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Сохранение исходного кода при анализе эффектов</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Рассматривать предупреждения как ошибки при компиляции эффектов</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_Profiler_Timings_SwitchToPasses" xml:space="preserve">
     <value>Переключиться на проходы</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Выключить кэш шрифтов</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -799,7 +799,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Dynamic.Content" xml:space="preserve">
     <value>Динамически</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Включить статистику для динамического обнаружения</value>
   </data>
   <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">

--- a/src/Magpie/Resources.language-tr.resw
+++ b/src/Magpie/Resources.language-tr.resw
@@ -624,16 +624,16 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Geliştirici seçenekleri</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Hata kipi</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Efekt önbelleğini devre dışı bırak</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Efektleri ayrıştırırken kaynak kodunu kaydet</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Efektleri derlerken uyarıları hata olarak ele alma</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_Profiler_Timings_SwitchToEffects" xml:space="preserve">
     <value>Efektleri değiştir</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Yazı tipi önbelleği etkisizleştir</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -802,7 +802,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>Asla</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Dinamik algılama için istatistikleri etkinleştir</value>
   </data>
   <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">

--- a/src/Magpie/Resources.language-uk.resw
+++ b/src/Magpie/Resources.language-uk.resw
@@ -534,10 +534,10 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Параметри розробника</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Вимкнути кеш ефектів</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Розглядайте попередження як помилки під час компіляції ефектів</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -697,10 +697,10 @@
   <data name="ExportDialog_Title" xml:space="preserve">
     <value>Експорт режимів масштабування</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Збереження вихідного коду під час синтаксичного аналізу ефектів</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Режим налагодження</value>
   </data>
   <data name="NotifyIcon_MainWindow" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_Profiler_Timings_SwitchToEffects" xml:space="preserve">
     <value>Переключитися на ефекти</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Вимкнути кеш шрифтів</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">

--- a/src/Magpie/Resources.language-vi.resw
+++ b/src/Magpie/Resources.language-vi.resw
@@ -676,19 +676,19 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>Cài đặt nhà phát triển</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>Chế độ gỡ lỗi</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>Tắt cache hiệu ứng</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>Tắt cache phông chữ</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>Lưu mã nguồn khi đọc hiệu ứng</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>Đặt cảnh bảo như lỗi khi đọc hiệu ứng</value>
   </data>
   <data name="Settings_General.Header" xml:space="preserve">
@@ -811,7 +811,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>Không</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>Bật thống kê để phát hiện động</value>
   </data>
   <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -669,16 +669,16 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>开发者选项</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>调试模式</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>禁用效果缓存</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>解析效果时保存源代码</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>编译效果时将警告视为错误</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -760,7 +760,7 @@
   <data name="Overlay_FPS_Unlock" xml:space="preserve">
     <value>解锁</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>禁用字体缓存</value>
   </data>
   <data name="Home_Activation_AllowScalingMaximized.Header" xml:space="preserve">
@@ -808,7 +808,7 @@
   <data name="Home_Advanced_DeveloperOptions_DuplicateFrameDetection_Never.Content" xml:space="preserve">
     <value>从不检测</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_EnableStatisticsForDynamicDetection.Header" xml:space="preserve">
     <value>启用动态检测统计</value>
   </data>
   <data name="Overlay_Profiler_DynamicDetection" xml:space="preserve">
@@ -864,5 +864,8 @@
   </data>
   <data name="Profile_Performance_NoGraphicsCard.Title" xml:space="preserve">
     <value>由于找不到兼容的显卡，将使用 CPU 渲染。很可能达不到理想性能。</value>
+  </data>
+  <data name="Home_Advanced_DeveloperOptions_MinFrameRate.Header" xml:space="preserve">
+    <value>最小帧率</value>
   </data>
 </root>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -868,4 +868,7 @@
   <data name="Home_Advanced_DeveloperOptions_MinFrameRate.Header" xml:space="preserve">
     <value>最小帧率</value>
   </data>
+  <data name="Home_Advanced_DeveloperOptions_MinFrameRate.Description" xml:space="preserve">
+    <value>稳定 GPU 频率以减少卡顿，但会导致功耗增加</value>
+  </data>
 </root>

--- a/src/Magpie/Resources.language-zh-Hant.resw
+++ b/src/Magpie/Resources.language-zh-Hant.resw
@@ -591,16 +591,16 @@
   <data name="Home_Advanced_DeveloperOptions.Header" xml:space="preserve">
     <value>開發者選項</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DebugMode.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DebugMode.Header" xml:space="preserve">
     <value>除錯模式</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableEffectCache.Header" xml:space="preserve">
     <value>停用效果快取</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_SaveEffectSources.Header" xml:space="preserve">
     <value>剖析效果時保存原始碼</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_WarningsAreErrors.Header" xml:space="preserve">
     <value>編譯效果時將警告視為錯誤</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
@@ -742,7 +742,7 @@
   <data name="Overlay_FPS_Lock" xml:space="preserve">
     <value>鎖定</value>
   </data>
-  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Content" xml:space="preserve">
+  <data name="Home_Advanced_DeveloperOptions_DisableFontCache.Header" xml:space="preserve">
     <value>停用字型快取</value>
   </data>
   <data name="Overlay_FPS_Unlock" xml:space="preserve">

--- a/src/Magpie/ScalingModesPage.cpp
+++ b/src/Magpie/ScalingModesPage.cpp
@@ -9,7 +9,6 @@
 
 using namespace ::Magpie;
 using namespace winrt;
-using namespace Windows::Globalization::NumberFormatting;
 using namespace Windows::UI::Xaml::Controls::Primitives;
 using namespace Windows::UI::Xaml::Input;
 
@@ -17,20 +16,6 @@ namespace winrt::Magpie::implementation {
 
 ScalingModesPage::ScalingModesPage() {
 	_BuildEffectMenu();
-}
-
-INumberFormatter2 ScalingModesPage::NumberFormatter() noexcept {
-	static DecimalFormatter numberFormatter = []() {
-		DecimalFormatter result;
-		IncrementNumberRounder rounder;
-		// 保留四位小数
-		rounder.Increment(0.0001);
-		result.NumberRounder(rounder);
-		result.FractionDigits(0);
-		return result;
-	}();
-
-	return numberFormatter;
 }
 
 void ScalingModesPage::ComboBox_DropDownOpened(IInspectable const& sender, IInspectable const&) {

--- a/src/Magpie/ScalingModesPage.h
+++ b/src/Magpie/ScalingModesPage.h
@@ -12,8 +12,6 @@ struct ScalingModesPage : ScalingModesPageT<ScalingModesPage> {
 		return *_viewModel;
 	}
 
-	static Windows::Globalization::NumberFormatting::INumberFormatter2 NumberFormatter() noexcept;
-
 	void ComboBox_DropDownOpened(IInspectable const& sender, IInspectable const&);
 
 	void EffectSettingsCard_Loaded(IInspectable const& sender, RoutedEventArgs const&);
@@ -45,7 +43,6 @@ private:
 
 namespace winrt::Magpie::factory_implementation {
 
-struct ScalingModesPage : ScalingModesPageT<ScalingModesPage, implementation::ScalingModesPage> {
-};
+struct ScalingModesPage : ScalingModesPageT<ScalingModesPage, implementation::ScalingModesPage> {};
 
 }

--- a/src/Magpie/ScalingModesPage.idl
+++ b/src/Magpie/ScalingModesPage.idl
@@ -4,8 +4,6 @@ namespace Magpie {
 
 		ScalingModesViewModel ViewModel { get; };
 
-		static Windows.Globalization.NumberFormatting.INumberFormatter2 NumberFormatter { get; };
-
 		// https://github.com/microsoft/microsoft-ui-xaml/issues/7579
 		void UnloadObject(Windows.UI.Xaml.DependencyObject object);
 	}

--- a/src/Magpie/ScalingModesPage.xaml
+++ b/src/Magpie/ScalingModesPage.xaml
@@ -372,12 +372,12 @@
 																			</local:SimpleStackPanel.Resources>
 																			<local:SimpleStackPanel Spacing="8">
 																				<TextBlock x:Uid="ScalingModes_ScaleFlyout_WidthFactor" />
-																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingModesPage.NumberFormatter, Mode=OneTime}"
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 																				                Value="{x:Bind ScalingFactorX, Mode=TwoWay}" />
 																			</local:SimpleStackPanel>
 																			<local:SimpleStackPanel Spacing="8">
 																				<TextBlock x:Uid="ScalingModes_ScaleFlyout_HeightFactor" />
-																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingModesPage.NumberFormatter, Mode=OneTime}"
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 																				                Value="{x:Bind ScalingFactorY, Mode=TwoWay}" />
 																			</local:SimpleStackPanel>
 																		</local:SimpleStackPanel>
@@ -394,12 +394,12 @@
 																			</local:SimpleStackPanel.Resources>
 																			<local:SimpleStackPanel Spacing="8">
 																				<TextBlock x:Uid="ScalingModes_ScaleFlyout_WidthPixels" />
-																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingModesPage.NumberFormatter, Mode=OneTime}"
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 																				                Value="{x:Bind ScalingPixelsX, Mode=TwoWay}" />
 																			</local:SimpleStackPanel>
 																			<local:SimpleStackPanel Spacing="8">
 																				<TextBlock x:Uid="ScalingModes_ScaleFlyout_HeightPixels" />
-																				<muxc:NumberBox NumberFormatter="{x:Bind local:ScalingModesPage.NumberFormatter, Mode=OneTime}"
+																				<muxc:NumberBox NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 																				                Value="{x:Bind ScalingPixelsY, Mode=TwoWay}" />
 																			</local:SimpleStackPanel>
 																		</local:SimpleStackPanel>

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -377,7 +377,13 @@ void ScalingService::_StartScale(HWND hWnd, const Profile& profile) {
 	options.IsSimulateExclusiveFullscreen(settings.IsSimulateExclusiveFullscreen());
 	options.duplicateFrameDetectionMode = settings.DuplicateFrameDetectionMode();
 	options.IsStatisticsForDynamicDetectionEnabled(settings.IsStatisticsForDynamicDetectionEnabled());
-	options.minFrameRate = settings.MinFrameRate();
+	
+	if (options.maxFrameRate) {
+		// 最小帧数不能大于最大帧数
+		options.minFrameRate = std::min(settings.MinFrameRate(), *options.maxFrameRate);
+	} else {
+		options.minFrameRate = settings.MinFrameRate();
+	}
 
 	_isAutoScaling = profile.isAutoScale;
 	_scalingRuntime->Start(hWnd, std::move(options));

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -377,6 +377,7 @@ void ScalingService::_StartScale(HWND hWnd, const Profile& profile) {
 	options.IsSimulateExclusiveFullscreen(settings.IsSimulateExclusiveFullscreen());
 	options.duplicateFrameDetectionMode = settings.DuplicateFrameDetectionMode();
 	options.IsStatisticsForDynamicDetectionEnabled(settings.IsStatisticsForDynamicDetectionEnabled());
+	options.minFrameRate = settings.MinFrameRate();
 
 	_isAutoScaling = profile.isAutoScale;
 	_scalingRuntime->Start(hWnd, std::move(options));

--- a/src/Magpie/ScalingService.h
+++ b/src/Magpie/ScalingService.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <winrt/Magpie.h>
+#include <winrt/Windows.System.Threading.h>
 #include "Event.h"
 #include "ScalingError.h"
 

--- a/src/Magpie/SettingsCard.Resource.xaml
+++ b/src/Magpie/SettingsCard.Resource.xaml
@@ -129,19 +129,19 @@
 								<Style BasedOn="{StaticResource DefaultSliderStyle}"
 								       TargetType="Slider">
 									<Style.Setters>
-										<Setter Property="MinWidth" Value="{ThemeResource SettingsCardContentMinWidth}" />
+										<Setter Property="MinWidth" Value="{StaticResource SettingsCardContentMinWidth}" />
 									</Style.Setters>
 								</Style>
 								<Style BasedOn="{StaticResource DefaultComboBoxStyle}"
 								       TargetType="ComboBox">
 									<Style.Setters>
-										<Setter Property="MinWidth" Value="{ThemeResource SettingsCardContentMinWidth}" />
+										<Setter Property="MinWidth" Value="{StaticResource SettingsCardContentMinWidth}" />
 									</Style.Setters>
 								</Style>
 								<Style BasedOn="{StaticResource DefaultTextBoxStyle}"
 								       TargetType="TextBox">
 									<Style.Setters>
-										<Setter Property="MinWidth" Value="{ThemeResource SettingsCardContentMinWidth}" />
+										<Setter Property="MinWidth" Value="{StaticResource SettingsCardContentMinWidth}" />
 									</Style.Setters>
 								</Style>
 								<Style TargetType="muxc:NumberBox">

--- a/src/Magpie/SettingsPage.h
+++ b/src/Magpie/SettingsPage.h
@@ -21,7 +21,6 @@ private:
 
 namespace winrt::Magpie::factory_implementation {
 
-struct SettingsPage : SettingsPageT<SettingsPage, implementation::SettingsPage> {
-};
+struct SettingsPage : SettingsPageT<SettingsPage, implementation::SettingsPage> {};
 
 }

--- a/src/Magpie/UpdateService.cpp
+++ b/src/Magpie/UpdateService.cpp
@@ -12,6 +12,8 @@
 #include <bcrypt.h>
 #include <wil/resource.h>	// 再次包含以激活 CNG 相关包装器
 #include "App.h"
+#include <winrt/Windows.Web.Http.h>
+#include <winrt/Windows.Storage.Streams.h>
 
 using namespace ::Magpie;
 using namespace winrt::Magpie::implementation;

--- a/src/Magpie/UpdateService.h
+++ b/src/Magpie/UpdateService.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Event.h"
+#include <winrt/Windows.System.Threading.h>
 
 namespace Magpie {
 

--- a/src/Magpie/pch.h
+++ b/src/Magpie/pch.h
@@ -45,13 +45,8 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.Metadata.h>
-#include <winrt/Windows.Globalization.NumberFormatting.h>
-#include <winrt/Windows.Graphics.Imaging.h>
-#include <winrt/Windows.UI.Core.h>
-#include <winrt/Windows.Graphics.Display.h>
-#include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.System.h>
-#include <winrt/Windows.System.Threading.h>
+#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
@@ -66,8 +61,6 @@
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
 #include <winrt/Windows.UI.Text.h>
-#include <winrt/Windows.Web.Http.h>
-#include <winrt/Windows.Web.Http.Headers.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.AnimatedVisuals.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>


### PR DESCRIPTION
Close #899 

这个功能的目的使 GPU 频率保持平稳，不会因为帧率突然提高而卡顿。最小帧率默认是 10 FPS，这里是一个权衡：不能过低使 GPU 空闲，也不能过高徒增功耗。这个功能无法避免 GPU 频率变化，降低能耗本就是实现重复帧检测的初衷，它类似于预热机制，使 GPU 的频率切换更加平滑。