### PR TITLE
修复CuNNy的死链

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -267,10 +267,10 @@
       ]
     },
     {
-      "login": "cunnyplapper",
-      "name": "cunnyplapper",
-      "avatar_url": "https://avatars.githubusercontent.com/u/160966585?v=4",
-      "profile": "https://github.com/cunnyplapper",
+      "login": "funnyplanter",
+      "name": "funnyplanter",
+      "avatar_url": "https://avatars.githubusercontent.com/u/173073947?v=4",
+      "profile": "https://github.com/funnyplanter",
       "contributions": [
         "code"
       ]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Thanks go to these wonderful people:
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nellydocs"><img src="https://avatars.githubusercontent.com/u/71311423?v=4?s=100" width="100px;" alt="nellydocs"/><br /><sub><b>nellydocs</b></sub></a><br /><a href="#translation-nellydocs" title="Translation">🌍</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/cunnyplapper"><img src="https://avatars.githubusercontent.com/u/160966585?v=4?s=100" width="100px;" alt="cunnyplapper"/><br /><sub><b>cunnyplapper</b></sub></a><br /><a href="https://github.com/Blinue/Magpie/commits?author=cunnyplapper" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/funnyplanter"><img src="https://avatars.githubusercontent.com/u/173073947?v=4?s=100" width="100px;" alt="funnyplanter"/><br /><sub><b>funnyplanter</b></sub></a><br /><a href="https://github.com/Blinue/Magpie/commits?author=funnyplanter" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/eriforce"><img src="https://avatars.githubusercontent.com/u/8393109?v=4?s=100" width="100px;" alt="Erich Yu"/><br /><sub><b>Erich Yu</b></sub></a><br /><a href="https://github.com/Blinue/Magpie/commits?author=eriforce" title="Code">💻</a></td>
     </tr>
   </tbody>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -117,7 +117,7 @@ Magpie 是一个轻量级的窗口缩放工具，内置了多种高效的缩放�
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nellydocs"><img src="https://avatars.githubusercontent.com/u/71311423?v=4?s=100" width="100px;" alt="nellydocs"/><br /><sub><b>nellydocs</b></sub></a><br /><a href="#translation-nellydocs" title="Translation">🌍</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/cunnyplapper"><img src="https://avatars.githubusercontent.com/u/160966585?v=4?s=100" width="100px;" alt="cunnyplapper"/><br /><sub><b>cunnyplapper</b></sub></a><br /><a href="https://github.com/Blinue/Magpie/commits?author=cunnyplapper" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/funnyplanter"><img src="https://avatars.githubusercontent.com/u/173073947?v=4?s=100" width="100px;" alt="funnyplanter"/><br /><sub><b>funnyplanter</b></sub></a><br /><a href="https://github.com/Blinue/Magpie/commits?author=funnyplanter" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/eriforce"><img src="https://avatars.githubusercontent.com/u/8393109?v=4?s=100" width="100px;" alt="Erich Yu"/><br /><sub><b>Erich Yu</b></sub></a><br /><a href="https://github.com/Blinue/Magpie/commits?author=eriforce" title="Code">💻</a></td>
     </tr>
   </tbody>

--- a/docs/Built-in effects.md
+++ b/docs/Built-in effects.md
@@ -124,7 +124,7 @@ Magpie ships with a handful of effects that can be used in combinations. Most of
     * Bloom Amount
     * Filter Kernel Shape
 
-* CuNNy family：Suitable for visual novel-style images. The DS variants offer a subtle denoise effect. Provided by [CuNNy](https://github.com/cunnyplapper/CuNNy)
+* CuNNy family：Suitable for visual novel-style images. The DS variants offer a subtle denoise effect. Provided by [CuNNy](https://github.com/funnyplanter/CuNNy)
   * Output size: twice that of the input
 
 * Deband

--- a/docs/内置效果介绍.md
+++ b/docs/内置效果介绍.md
@@ -124,7 +124,7 @@ Magpie 内置了大量效果供组合使用，大部分提供了参数选项以�
     * Bloom Amount
     * Filter Kernel Shape
 
-* CuNNy 族：适合视觉小说风格图像的缩放，由 [CuNNy](https://github.com/cunnyplapper/CuNNy) 提供。DS 变体有轻微降噪效果
+* CuNNy 族：适合视觉小说风格图像的缩放，由 [CuNNy](https://github.com/funnyplanter/CuNNy) 提供。DS 变体有轻微降噪效果
   * 输出尺寸：输入的两倍
 
 * Deband：去除色带

--- a/src/Effects/CuNNy/CuNNy-16x16C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-16x16C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 16x16C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 16x16C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-16x16C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-16x16C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 16x16C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 16x16C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-2x4C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-2x4C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 2x4C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 2x4C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-2x4C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-2x4C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 2x4C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 2x4C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-3x4C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-3x4C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 3x4C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 3x4C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-3x4C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-3x4C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 3x4C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 3x4C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-4x16C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-4x16C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 4x16C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 4x16C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-4x16C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-4x16C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 4x16C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 4x16C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-4x4C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-4x4C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 4x4C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 4x4C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-4x4C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-4x4C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 4x4C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 4x4C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-4x8C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-4x8C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 4x8C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 4x8C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-4x8C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-4x8C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 4x8C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 4x8C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-6x8C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-6x8C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 6x8C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 6x8C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-6x8C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-6x8C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 6x8C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 6x8C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-8x16C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-8x16C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 8x16C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 8x16C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-8x16C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-8x16C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 8x16C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 8x16C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-8x4C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-8x4C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 8x4C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 8x4C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-8x4C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-8x4C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 8x4C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 8x4C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-8x8C-NVL-DN.hlsl
+++ b/src/Effects/CuNNy/CuNNy-8x8C-NVL-DN.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 8x8C BILINEAR RGB NVL DN - https://github.com/cunnyplapper/CuNNy
+// CuNNy 8x8C BILINEAR RGB NVL DN - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Effects/CuNNy/CuNNy-8x8C-NVL.hlsl
+++ b/src/Effects/CuNNy/CuNNy-8x8C-NVL.hlsl
@@ -1,4 +1,4 @@
-// CuNNy 8x8C BILINEAR RGB NVL - https://github.com/cunnyplapper/CuNNy
+// CuNNy 8x8C BILINEAR RGB NVL - https://github.com/funnyplanter/CuNNy
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
https://github.com/cunnyplapper/CuNNy 链接现已无法访问，替换为 https://github.com/funnyplanter/CuNNy

此PR只替换了上面给出的链接。`.all-contributorsrc` 里单独出现了 cunnyplapper，目前暂未替换，不确定要不要换。