### PR TITLE
修复主窗口调整大小时边缘闪烁

### DIFF
--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -224,6 +224,7 @@
       <DependentUpon>SimpleStackPanel.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="SmoothResizeHelper.h" />
     <ClInclude Include="TextBlockHelper.h">
       <DependentUpon>TextBlockHelper.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -407,6 +408,7 @@
       <DependentUpon>SimpleStackPanel.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="SmoothResizeHelper.cpp" />
     <ClCompile Include="TextBlockHelper.cpp">
       <DependentUpon>TextBlockHelper.idl</DependentUpon>
       <SubType>Code</SubType>

--- a/src/Magpie/Magpie.vcxproj.filters
+++ b/src/Magpie/Magpie.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="AdaptersService.cpp">
       <Filter>Services</Filter>
     </ClCompile>
+    <ClCompile Include="SmoothResizeHelper.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -159,6 +162,9 @@
     </ClInclude>
     <ClInclude Include="AdaptersService.h">
       <Filter>Services</Filter>
+    </ClInclude>
+    <ClInclude Include="SmoothResizeHelper.h">
+      <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Magpie/MainWindow.cpp
+++ b/src/Magpie/MainWindow.cpp
@@ -145,7 +145,7 @@ bool MainWindow::Create() noexcept {
 		ChangeWindowMessageFilterEx(Handle(), WM_GETTITLEBARINFOEX, MSGFLT_ALLOW, nullptr);
 	}
 
-	Content()->TitleBar().SizeChanged([this](winrt::IInspectable const&, SizeChangedEventArgs const&) {
+	Content()->TitleBar().LeftBottomPointChanged([this] {
 		_ResizeTitleBarWindow();
 	});
 
@@ -619,31 +619,31 @@ void MainWindow::_ResizeTitleBarWindow() noexcept {
 		return;
 	}
 
-	TitleBarControl& titleBar = Content()->TitleBar();
-
-	// 获取标题栏的边框矩形
-	Rect rect{0.0f, 0.0f, (float)titleBar.ActualWidth(), (float)titleBar.ActualHeight()};
-	rect = titleBar.TransformToVisual(*Content()).TransformBounds(rect);
-
-	const float dpiScale = CurrentDpi() / float(USER_DEFAULT_SCREEN_DPI);
-	const uint32_t topBorderHeight = _GetTopBorderHeight();
-
 	// 将标题栏窗口置于 XAML Islands 窗口上方，覆盖上边框和标题栏控件
-	const int titleBarX = (int)std::floorf(rect.X * dpiScale);
-	const int titleBarWidth = (int)std::ceilf(rect.Width * dpiScale);
+	const Point leftBottom = Content()->TitleBar().LeftBottomPoint();
+	const float dpiScale = CurrentDpi() / float(USER_DEFAULT_SCREEN_DPI);
+
+	const int titleBarX = (int)std::floorf(leftBottom.X * dpiScale);
+
+	// 右边界使用客户区边界
+	RECT clientRect;
+	GetClientRect(Handle(), &clientRect);
+	const int titleBarWidth = clientRect.right - titleBarX;
+
+	const uint32_t topBorderHeight = _GetTopBorderHeight();
+	// 不知为何，直接向上取整有时无法遮盖 TitleBarControl
+	const int titleBarHeight = topBorderHeight + (int)std::floorf(leftBottom.Y * dpiScale + 1);
+
 	SetWindowPos(
 		_hwndTitleBar.get(),
 		HWND_TOP,
-		titleBarX,
-		0,
-		titleBarWidth,
-		topBorderHeight + (int)std::floorf(rect.Height * dpiScale + 1),	// 不知为何，直接向上取整有时无法遮盖 TitleBarControl
+		titleBarX, 0, titleBarWidth, titleBarHeight,
 		SWP_SHOWWINDOW
 	);
 
 	if (_hwndMaximizeButton) {
 		static const float captionButtonHeightInDips = [&]() {
-			return titleBar.CaptionButtons().CaptionButtonSize().Height;
+			return Content()->TitleBar().CaptionButtons().CaptionButtonSize().Height;
 		}();
 
 		const int captionButtonHeightInPixels = (int)std::ceilf(captionButtonHeightInDips * dpiScale);

--- a/src/Magpie/MainWindow.h
+++ b/src/Magpie/MainWindow.h
@@ -32,6 +32,8 @@ private:
 	wil::unique_hwnd _hwndTitleBar;
 	HWND _hwndMaximizeButton = NULL;
 	bool _trackingMouse = false;
+
+	bool _smoothResizedEnabled = false;
 };
 
 }

--- a/src/Magpie/RootPage.cpp
+++ b/src/Magpie/RootPage.cpp
@@ -199,7 +199,10 @@ void RootPage::NavigationView_DisplayModeChanged(MUXC::NavigationView const& nv,
 	bool isExpanded = nv.DisplayMode() == MUXC::NavigationViewDisplayMode::Expanded;
 	nv.IsPaneToggleButtonVisible(!isExpanded);
 	if (isExpanded) {
-		nv.IsPaneOpen(true);
+		// 延迟设置 IsPaneOpen 才能起作用
+		Dispatcher().RunAsync(CoreDispatcherPriority::Low, [nv(MUXC::NavigationView(nv))]() {
+			nv.IsPaneOpen(true);
+		});
 	}
 
 	// !!! HACK !!!

--- a/src/Magpie/SmoothResizeHelper.cpp
+++ b/src/Magpie/SmoothResizeHelper.cpp
@@ -1,0 +1,42 @@
+#include "pch.h"
+#include "SmoothResizeHelper.h"
+#include <inspectable.h>
+
+// 来自 https://github.com/ALTaleX531/TranslucentFlyouts/blob/017970cbac7b77758ab6217628912a8d551fcf7c/TFModern/DiagnosticsHandler.cpp#L71-L84
+DECLARE_INTERFACE_IID_(IFrameworkApplicationPrivate, IInspectable, "B3AB45D8-6A4E-4E76-A00D-32D4643A9F1A") {
+	STDMETHOD(StartOnCurrentThread)(void* callback) PURE;
+	STDMETHOD(CreateIsland)(void** island) PURE;
+	STDMETHOD(CreateIslandWithAppWindow)(void* app_window, void** island) PURE;
+	STDMETHOD(CreateIslandWithContentBridge)(void* owner, void* content_bridge, void** island) PURE;
+	STDMETHOD(RemoveIsland)(void* island) PURE;
+	STDMETHOD(SetSynchronizationWindow)(HWND hwnd) PURE;
+};
+
+namespace Magpie {
+
+bool SmoothResizeHelper::EnableResizeSync(HWND hWnd, const winrt::Application& app) noexcept {
+	// UWP 使用这个未记录的接口实现平滑调整尺寸
+	// https://gist.github.com/apkipa/20cae438aef2a8633f99e10e0b90b11e
+	static auto enableResizeLayoutSynchronization = []() {
+		HMODULE hUser32 = GetModuleHandle(L"user32");
+		assert(hUser32);
+		using tEnableResizeLayoutSynchronization = void(WINAPI*)(HWND hwnd, BOOL enable);
+		return (tEnableResizeLayoutSynchronization)GetProcAddress(hUser32, MAKEINTRESOURCEA(2615));
+	}();
+
+	// 检查是否支持 IFrameworkApplicationPrivate 接口
+	if (!app.try_as<IFrameworkApplicationPrivate>() || !enableResizeLayoutSynchronization) {
+		return false;
+	}
+
+	enableResizeLayoutSynchronization(hWnd, TRUE);
+	return true;
+}
+
+void SmoothResizeHelper::SyncWindowSize(HWND hWnd, const winrt::Application& app) noexcept {
+	// @apkipa 发现在 WM_SIZE 中调用 IFrameworkApplicationPrivate::SetSynchronizationWindow 可以防止闪烁。
+	// 原理仍不清楚，似乎这个接口内部会调用 SynchronizedCommit，刚好实现了 UWP 调整大小的方法。
+	app.try_as<IFrameworkApplicationPrivate>()->SetSynchronizationWindow(hWnd);
+}
+
+}

--- a/src/Magpie/SmoothResizeHelper.h
+++ b/src/Magpie/SmoothResizeHelper.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Magpie {
+
+struct SmoothResizeHelper {
+	// 初始化 XAML Islands 后调用
+	static bool EnableResizeSync(HWND hWnd, const winrt::Application& app) noexcept;
+
+	// WM_SIZE 中调用
+	static void SyncWindowSize(HWND hWnd, const winrt::Application& app) noexcept;
+};
+
+}

--- a/src/Magpie/TitlebarControl.cpp
+++ b/src/Magpie/TitlebarControl.cpp
@@ -38,6 +38,7 @@ void TitleBarControl::TitleBarControl_Loading(FrameworkElement const&, IInspecta
 		bool expanded = args.DisplayMode() == MUXC::NavigationViewDisplayMode::Expanded;
 		VisualStateManager::GoToState(
 			*this, expanded ? L"Expanded" : L"Compact", App::Get().RootPage()->IsLoaded());
+		LeftBottomPointChanged.Invoke();
 	});
 }
 
@@ -48,6 +49,13 @@ void TitleBarControl::IsWindowActive(bool value) {
 
 CaptionButtonsControl& TitleBarControl::CaptionButtons() noexcept {
 	return *get_self<CaptionButtonsControl>(TitleBarControlT::CaptionButtons());
+}
+
+Point TitleBarControl::LeftBottomPoint() noexcept {
+	const auto& rootPage = App::Get().RootPage();
+	bool expanded = rootPage->RootNavigationView().DisplayMode() == MUXC::NavigationViewDisplayMode::Expanded;
+	// 左边界不包含 RootStackPanel 的 Margin。Margin 属性在动画播放结束才会改变，不要使用。
+	return TransformToVisual(*rootPage).TransformPoint({ expanded ? 0.0f : 46.0f, (float)ActualHeight()});
 }
 
 }

--- a/src/Magpie/TitlebarControl.h
+++ b/src/Magpie/TitlebarControl.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "TitleBarControl.g.h"
+#include "Event.h"
 
 namespace winrt::Magpie::implementation {
 
@@ -18,6 +19,10 @@ struct TitleBarControl : TitleBarControlT<TitleBarControl>,
 	void IsWindowActive(bool value);
 
 	CaptionButtonsControl& CaptionButtons() noexcept;
+
+	Point LeftBottomPoint() noexcept;
+
+	::Magpie::Event<> LeftBottomPointChanged;
 
 private:
 	Imaging::SoftwareBitmapSource _logo{ nullptr };

--- a/src/Magpie/TitlebarControl.xaml
+++ b/src/Magpie/TitlebarControl.xaml
@@ -4,18 +4,18 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="using:Magpie"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             x:Name="Root"
              Height="40"
              HorizontalAlignment="Stretch"
              VerticalAlignment="Top"
              Loading="TitleBarControl_Loading"
              mc:Ignorable="d">
 	<Grid>
-		<local:SimpleStackPanel Margin="16,10,0,0"
+		<local:SimpleStackPanel x:Name="RootStackPanel"
+		                        Padding="16,10,0,0"
 		                        Orientation="Horizontal"
 		                        Spacing="8">
 			<local:SimpleStackPanel.RenderTransform>
-				<TranslateTransform x:Name="TitleTranslation" />
+				<TranslateTransform x:Name="RootStackPanelTranslation" />
 			</local:SimpleStackPanel.RenderTransform>
 			<Image Width="16"
 			       Height="16"
@@ -38,10 +38,10 @@
 					<VisualTransition From="Expanded"
 					                  To="Compact">
 						<Storyboard>
-							<DoubleAnimation Storyboard.TargetName="TitleTranslation"
+							<DoubleAnimation Storyboard.TargetName="RootStackPanelTranslation"
 							                 Storyboard.TargetProperty="X"
 							                 From="0"
-							                 To="45"
+							                 To="46"
 							                 Duration="0:0:0.22">
 								<DoubleAnimation.EasingFunction>
 									<ExponentialEase EasingMode="EaseOut"
@@ -53,9 +53,9 @@
 					<VisualTransition From="Compact"
 					                  To="Expanded">
 						<Storyboard>
-							<DoubleAnimation Storyboard.TargetName="TitleTranslation"
+							<DoubleAnimation Storyboard.TargetName="RootStackPanelTranslation"
 							                 Storyboard.TargetProperty="X"
-							                 From="45"
+							                 From="46"
 							                 To="0"
 							                 Duration="0:0:0.22">
 								<DoubleAnimation.EasingFunction>
@@ -70,7 +70,8 @@
 				<VisualState x:Name="Expanded" />
 				<VisualState x:Name="Compact">
 					<VisualState.Setters>
-						<Setter Target="Root.Margin" Value="45,0,0,0" />
+						<!--  不要在根元素上应用 Margin，否则调整窗口尺寸时控制按钮位置不稳定  -->
+						<Setter Target="RootStackPanel.Margin" Value="46,0,0,0" />
 					</VisualState.Setters>
 				</VisualState>
 			</VisualStateGroup>

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -231,7 +231,7 @@ protected:
 				FillRect(hdc, &rcTopBorder, hBrush);
 			}
 
-			// 绘制客户区，它会在调整窗口尺寸时短暂可见
+			// 绘制客户区。如果 SmoothResizeHelper::EnableResizeSync 失败，调整窗口尺寸时客户区会短暂可见
 			if (ps.rcPaint.bottom > topBorderHeight) {
 				RECT rcRest = ps.rcPaint;
 				rcRest.top = topBorderHeight;


### PR DESCRIPTION
XAML Islands 一直以来存在不能流畅调整大小的问题，https://github.com/microsoft/microsoft-ui-xaml/issues/759 已经存在五年多，最新的 WinUI 3 仍没有修复。现在 apkipa 找到了办法 https://github.com/Blinue/Magpie/pull/1071#issuecomment-2710669084 ，效果相当好。 

（说个题外话，这个功能的官方名称似乎是 Smooth Window Resize，[有个文档](https://learn.microsoft.com/en-us/uwp/api/windows.ui.windowmanagement.appwindow?view=winrt-26100#limitations)使用了这个名词。）

### 解决方案

1. 初始化 XAML Islands 后调用未记录的函数 EnableResizeLayoutSynchronization。
2. 处理 WM_SIZE 时调用 IFrameworkApplicationPrivate::SetSynchronizationWindow。IFrameworkApplicationPrivate 是一个内部 COM 接口，可以通过 Application 检索得到。

### 风险

鉴于微软有过随意更改内部接口 ABI 的历史，使用 IFrameworkApplicationPrivate 可能会造成崩溃。我已在多个 Windows 版本中测试（下至 Win10 v1903，上至 Win11 24H2），这个接口一直可用。我猜出于兼容性考虑微软已经把它冻结了，这个接口很早就有软件在用。

### 已知问题

Win10 存在一个 bug，如果鼠标在调整大小时长时间静止然后移动，窗口内容会严重滞后，并露出原始标题栏。我暂时没找到解决办法，不过这个 bug 不容易触发，而且即使触发了下一次调整窗口时也会复原。