### PR TITLE
允许快捷键使用 Tab、Print Screen 和 Pause/Break

### DIFF
--- a/src/Magpie/Magpie.vcxproj.filters
+++ b/src/Magpie/Magpie.vcxproj.filters
@@ -326,7 +326,9 @@
     <Page Include="ToastPage.xaml">
       <Filter>Pages</Filter>
     </Page>
-    <Page Include="BlueInfoBarStyle.xaml" />
+    <Page Include="BlueInfoBarStyle.xaml">
+      <Filter>Styles</Filter>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Resources.language-zh-Hans.resw">
@@ -395,6 +397,7 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natstepfilter" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Magpie.rc">

--- a/src/Magpie/ShortcutControl.cpp
+++ b/src/Magpie/ShortcutControl.cpp
@@ -149,9 +149,6 @@ LRESULT ShortcutControl::_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM 
 	bool isKeyDown = wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN;
 
 	switch (code) {
-	case VK_TAB:
-		// Tab 键传给系统以移动焦点
-		return CallNextHookEx(NULL, nCode, wParam, lParam);
 	case VK_LWIN:
 	case VK_RWIN:
 		_that->_pressedKeys.win = isKeyDown;
@@ -173,6 +170,11 @@ LRESULT ShortcutControl::_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM 
 		break;
 	default:
 	{
+		if (code == VK_TAB && !_that->_pressedKeys.win && !_that->_pressedKeys.ctrl && !_that->_pressedKeys.alt) {
+			// 把 Tab 和 Shift+Tab 传给系统以移动焦点
+			return CallNextHookEx(NULL, nCode, wParam, lParam);
+		}
+
 		if (code == VK_RETURN && get_class_name(FocusManager::GetFocusedElement(_that->XamlRoot())) == name_of<Button>()) {
 			// 此时用户通过 Tab 键将焦点移到了对话框按钮上
 			return CallNextHookEx(NULL, nCode, wParam, lParam);

--- a/src/Magpie/ShortcutControl.cpp
+++ b/src/Magpie/ShortcutControl.cpp
@@ -171,9 +171,9 @@ LRESULT ShortcutControl::_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM 
 	default:
 	{
 		if (code == VK_TAB) {
-			// 如果没有按下修饰键或者只按下 Shift 修饰键，那么此 Tab 用于移动焦点，把它交给
-			// 系统处理；否则将它计入快捷键。一旦计入快捷键，对应的释放消息也不能交给系统，
-			// 因此应检查 _pressedKeys.code。
+			// 如果没有按下修饰键或者只按下 Shift，那么此 Tab 用于移动焦点，应把它交给系统
+			// 处理，否则将它计入快捷键。一旦计入快捷键，对应的释放消息也不能交给系统，因此
+			// 应检查 _pressedKeys.code。
 			if (!_that->_pressedKeys.win && !_that->_pressedKeys.ctrl &&
 				!_that->_pressedKeys.alt && _that->_pressedKeys.code != VK_TAB) {
 				return CallNextHookEx(NULL, nCode, wParam, lParam);

--- a/src/Magpie/ShortcutControl.cpp
+++ b/src/Magpie/ShortcutControl.cpp
@@ -170,19 +170,29 @@ LRESULT ShortcutControl::_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM 
 		break;
 	default:
 	{
-		if (code == VK_TAB && !_that->_pressedKeys.win && !_that->_pressedKeys.ctrl && !_that->_pressedKeys.alt) {
-			// 把 Tab 和 Shift+Tab 传给系统以移动焦点
-			return CallNextHookEx(NULL, nCode, wParam, lParam);
-		}
-
-		if (code == VK_RETURN && get_class_name(FocusManager::GetFocusedElement(_that->XamlRoot())) == name_of<Button>()) {
-			// 此时用户通过 Tab 键将焦点移到了对话框按钮上
-			return CallNextHookEx(NULL, nCode, wParam, lParam);
+		if (code == VK_TAB) {
+			// 如果没有按下修饰键或者只按下 Shift 修饰键，那么此 Tab 用于移动焦点，把它交给
+			// 系统处理；否则将它计入快捷键。一旦计入快捷键，对应的释放消息也不能交给系统，
+			// 因此应检查 _pressedKeys.code。
+			if (!_that->_pressedKeys.win && !_that->_pressedKeys.ctrl &&
+				!_that->_pressedKeys.alt && _that->_pressedKeys.code != VK_TAB) {
+				return CallNextHookEx(NULL, nCode, wParam, lParam);
+			}
+		} else if (code == VK_RETURN) {
+			// 焦点在对话框按钮上时按下 Enter 键应触发该按钮，因此交给系统处理
+			if (get_class_name(FocusManager::GetFocusedElement(_that->XamlRoot())) == name_of<Button>()) {
+				return CallNextHookEx(NULL, nCode, wParam, lParam);
+			}
 		}
 
 		if (ShortcutHelper::IsValidKeyCode((uint8_t)code)) {
 			if (isKeyDown) {
-				_that->_pressedKeys.code = (uint8_t)code;
+				if (_that->_pressedKeys.code == (uint8_t)code) {
+					// 忽略按住某个键触发的自动重复击键
+					return -1;
+				} else {
+					_that->_pressedKeys.code = (uint8_t)code;
+				}
 			} else {
 				_that->_pressedKeys.code = 0;
 			}
@@ -222,7 +232,7 @@ LRESULT ShortcutControl::_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM 
 			}
 
 			if (modCount == 1) {
-				// Modifiers 个数为 1 时不显示错误
+				// 只按下一个修饰键时不显示错误
 				isPrimaryButtonEnabled = false;
 			} else {
 				error = ShortcutHelper::CheckShortcut(previewShortcut);

--- a/src/Magpie/ShortcutHelper.cpp
+++ b/src/Magpie/ShortcutHelper.cpp
@@ -62,8 +62,8 @@ bool ShortcutHelper::IsValidKeyCode(uint8_t code) noexcept {
 			keyCodes.insert(i);
 		}
 
-		keyCodes.insert((uint8_t)VK_INSERT);	// Insert
-		keyCodes.insert((uint8_t)VK_DELETE);	// Delete
+		keyCodes.insert((uint8_t)VK_INSERT);
+		keyCodes.insert((uint8_t)VK_DELETE);
 		keyCodes.insert((uint8_t)VK_ADD);		// 加（小键盘）
 		keyCodes.insert((uint8_t)VK_SUBTRACT);	// 减（小键盘）
 		keyCodes.insert((uint8_t)VK_MULTIPLY);	// 乘（小键盘）
@@ -71,6 +71,10 @@ bool ShortcutHelper::IsValidKeyCode(uint8_t code) noexcept {
 		keyCodes.insert((uint8_t)VK_DECIMAL);	// .（小键盘）
 		keyCodes.insert((uint8_t)VK_BACK);		// Backspace
 		keyCodes.insert((uint8_t)VK_RETURN);	// 回车
+		keyCodes.insert((uint8_t)VK_TAB);
+		keyCodes.insert((uint8_t)VK_SNAPSHOT);	// Print Screen
+		keyCodes.insert((uint8_t)VK_PAUSE);
+		keyCodes.insert((uint8_t)VK_CANCEL);	// Break（即 Ctrl+Pause）
 
 		return keyCodes;
 	}();


### PR DESCRIPTION
Closing #1133 

以前不支持这些键的考虑是它们承担着特殊的职能，现在发现只要能拦截原始功能支持它们无害，尤其是 RegisterHotkey 将阻止注册系统快捷键，比如 Alt+Tab、Win+Tab 和 Win+PrintScreen。三个 Lock 键仍不支持，因为如果前台窗口的 IL 更高，无法拦截 Lock 键的原始功能。