### PR TITLE
提高 GPU 优先级

### DIFF
--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -17,6 +17,7 @@
 #include "OverlayDrawer.h"
 #include "CursorManager.h"
 #include "EffectsProfiler.h"
+#include <d3dkmthk.h>
 
 namespace Magpie {
 
@@ -84,6 +85,17 @@ static void LogAdapter(IDXGIAdapter4* adapter) noexcept {
 		desc.VendorId, desc.DeviceId, StrHelper::UTF16ToUTF8(desc.Description)));
 }
 
+static void SetGpuPriority() noexcept {
+	// 来自 https://github.com/obsproject/obs-studio/blob/16cb051a57bb357fe866252c1360ce2c38e2deec/libobs-d3d11/d3d11-subsystem.cpp#L429
+	// 不使用 REALTIME 优先级，它会造成系统不稳定，而且可能会导致源窗口卡顿。
+	// OBS 还调用了 SetGPUThreadPriority，但这个接口似乎无用。
+	NTSTATUS status = D3DKMTSetProcessSchedulingPriorityClass(
+		GetCurrentProcess(), D3DKMT_SCHEDULINGPRIORITYCLASS_HIGH);
+	if (status != STATUS_SUCCESS) {
+		Logger::Get().NTError("D3DKMTSetProcessSchedulingPriorityClass 失败", status);
+	}
+}
+
 ScalingError Renderer::Initialize() noexcept {
 	_backendThread = std::thread(std::bind(&Renderer::_BackendThreadProc, this));
 
@@ -93,6 +105,9 @@ ScalingError Renderer::Initialize() noexcept {
 	}
 
 	LogAdapter(_frontendResources.GetGraphicsAdapter());
+
+	// 每次创建 D3D 设备后尝试提高 GPU 优先级，OBS 也是这么做的
+	SetGpuPriority();
 
 	if (!_CreateSwapChain()) {
 		Logger::Get().Error("_CreateSwapChain 失败");


### PR DESCRIPTION
使用和 OBS 同样的方法提高 GPU 优先级，某些情况下这可以提高流畅度。有几点需要注意：

1. 我们始终使用“高”优先级。一方面“实时”优先级会造成系统不稳定：OBS 在硬件加速 GPU 调度 (HAGS) 打开时使用“高”优先级否则使用“实时”优先级，[但实际上即使没有打开 HAGS，“实时”优先级也会造成问题](https://github.com/LizardByte/Sunshine/blob/9c08c75a44097a5a5c866d70ccf0c8c080257a0c/src/platform/windows/display_base.cpp#L662)。另一方面我不想让过于激进的优化影响到源窗口的流畅度。
2. [OBS 还使用 IDXGIDevice::SetGPUThreadPriority 提高优先级](https://github.com/obsproject/obs-studio/blob/16cb051a57bb357fe866252c1360ce2c38e2deec/libobs-d3d11/d3d11-subsystem.cpp#L437)。这个接口一般被认为无用，但 OBS 传了一个未记录的值，[似乎真的有用](https://zhuanlan.zhihu.com/p/22604757356)。我尝试传入相同的值但接口返回 0x8876086A (D3DERR_NOTAVAILABLE)，顺带一提我这里 OBS 的调用也会失败，证明这不是专为 OBS 开的后门。 