### PR TITLE
默认快捷键的 Win 改为 Alt 以避免和系统快捷键冲突

### DIFF
--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -1058,7 +1058,7 @@ bool AppSettings::_SetDefaultShortcuts() noexcept {
 
 	Shortcut& scaleShortcut = _shortcuts[(size_t)ShortcutAction::Scale];
 	if (scaleShortcut.IsEmpty()) {
-		scaleShortcut.win = true;
+		scaleShortcut.alt = true;
 		scaleShortcut.shift = true;
 		scaleShortcut.code = 'A';
 
@@ -1067,7 +1067,7 @@ bool AppSettings::_SetDefaultShortcuts() noexcept {
 
 	Shortcut& windowedModeScaleShortcut = _shortcuts[(size_t)ShortcutAction::WindowedModeScale];
 	if (windowedModeScaleShortcut.IsEmpty()) {
-		windowedModeScaleShortcut.win = true;
+		windowedModeScaleShortcut.alt = true;
 		windowedModeScaleShortcut.shift = true;
 		windowedModeScaleShortcut.code = 'Q';
 
@@ -1076,7 +1076,7 @@ bool AppSettings::_SetDefaultShortcuts() noexcept {
 
 	Shortcut& overlayShortcut = _shortcuts[(size_t)ShortcutAction::Toolbar];
 	if (overlayShortcut.IsEmpty()) {
-		overlayShortcut.win = true;
+		overlayShortcut.alt = true;
 		overlayShortcut.shift = true;
 		overlayShortcut.code = 'D';
 


### PR DESCRIPTION
Close #1136 

[KB5055627](https://support.microsoft.com/en-us/topic/april-25-2025-kb5055627-os-build-26100-3915-preview-9324a361-965a-4496-8fd8-ba8a9de9fc38) 后 Win+Shift+A 被 Recall 占用，导致快捷键注册失败。这个 PR 将默认快捷键组合中的 Win 键改为 Alt 键，现在默认快捷键如下：

全屏模式缩放：Alt+Shift+A
窗口模式缩放：Alt+Shift+Q
工具栏状态切换：Alt+Shift+D

新的默认快捷键只有第一次打开 Magpie 时才生效，如果已经有设置文件则不会做更改。