### PR TITLE
扩展新建配置弹窗中名称文本框右键菜单功能

### DIFF
--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -877,6 +877,15 @@
   <data name="Home_Advanced_DeveloperOptions_BenchmarkMode.Content" xml:space="preserve">
     <value>Benchmark mode</value>
   </data>
+  <data name="Root_NewProfileFlyout_NameContextFlyout_AppName" xml:space="preserve">
+    <value>Fill with application name</value>
+  </data>
+  <data name="Root_NewProfileFlyout_NameContextFlyout_ProcessName" xml:space="preserve">
+    <value>Fill with process name</value>
+  </data>
+  <data name="Root_NewProfileFlyout_NameContextFlyout_WindowTitle" xml:space="preserve">
+    <value>Fill with window title</value>
+  </data>
   <data name="TextMenuFlyout_Copy" xml:space="preserve">
     <value>Copy</value>
   </data>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -877,6 +877,15 @@
   <data name="Home_Advanced_DeveloperOptions_BenchmarkMode.Content" xml:space="preserve">
     <value>性能测试模式</value>
   </data>
+  <data name="Root_NewProfileFlyout_NameContextFlyout_AppName" xml:space="preserve">
+    <value>填入应用名</value>
+  </data>
+  <data name="Root_NewProfileFlyout_NameContextFlyout_ProcessName" xml:space="preserve">
+    <value>填入进程名</value>
+  </data>
+  <data name="Root_NewProfileFlyout_NameContextFlyout_WindowTitle" xml:space="preserve">
+    <value>填入窗口标题</value>
+  </data>
   <data name="TextMenuFlyout_Copy" xml:space="preserve">
     <value>复制</value>
   </data>

--- a/src/Magpie/RootPage.cpp
+++ b/src/Magpie/RootPage.cpp
@@ -254,6 +254,7 @@ void RootPage::NewProfileNameContextFlyout_Opening(IInspectable const&, IInspect
 	CandidateWindowItem* selectedItem = get_self<CandidateWindowItem>(
 		_newProfileViewModel->CandidateWindows().GetAt(idx).as<winrt::Magpie::CandidateWindowItem>());
 
+	// 设置每个选项的可见性
 	bool shouldInit = true;
 	for (const MenuFlyoutItemBase& item : menuItems) {
 		IInspectable tag = item.Tag();
@@ -269,13 +270,13 @@ void RootPage::NewProfileNameContextFlyout_Opening(IInspectable const&, IInspect
 		shouldInit = false;
 
 		if (*id == 1) {
-			// 填入进程名
+			// 填入进程名选项
 			item.Visibility(selectedItem->AUMID().empty() ? Visibility::Visible : Visibility::Collapsed);
 		} else if (*id == 2) {
-			// 填入应用名
+			// 填入应用名选项
 			item.Visibility(selectedItem->AUMID().empty() ? Visibility::Collapsed : Visibility::Visible);
 		} else {
-			// 填入窗口标题
+			// 填入窗口标题选项
 			item.Visibility(Visibility::Visible);
 		}
 	}
@@ -284,7 +285,7 @@ void RootPage::NewProfileNameContextFlyout_Opening(IInspectable const&, IInspect
 		return;
 	}
 
-	// 初始化
+	// 惰性初始化
 	ResourceLoader resourceLoader =
 		ResourceLoader::GetForCurrentView(CommonSharedConstants::APP_RESOURCE_MAP_ID);
 

--- a/src/Magpie/RootPage.h
+++ b/src/Magpie/RootPage.h
@@ -37,6 +37,8 @@ struct RootPage : RootPageT<RootPage> {
 
 	void NewProfileConfirmButton_Click(IInspectable const&, RoutedEventArgs const&);
 
+	void NewProfileNameContextFlyout_Opening(IInspectable const&, IInspectable const&);
+
 	void NewProfileNameTextBox_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args);
 
 	void NavigateToAboutPage();

--- a/src/Magpie/RootPage.xaml
+++ b/src/Magpie/RootPage.xaml
@@ -114,7 +114,9 @@
 											         KeyDown="NewProfileNameTextBox_KeyDown"
 											         Text="{x:Bind NewProfileViewModel.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
 												<TextBox.ContextFlyout>
-													<local:TextMenuFlyout />
+													<!--  必须设置 x:Name，否则无法编译  -->
+													<local:TextMenuFlyout x:Name="NewProfileNameContextFlyout"
+													                      Opening="NewProfileNameContextFlyout_Opening" />
 												</TextBox.ContextFlyout>
 											</TextBox>
 										</local:SimpleStackPanel>


### PR DESCRIPTION
支持填入窗口标题和进程名（非打包应用）/应用名（打包应用），如果标题比进程名更准确，这可以减少键入。

![image](https://github.com/user-attachments/assets/c1b175d7-85f5-4766-a0c3-6b80d1b65fbd)
