### PR TITLE
修复删除缩放模式时崩溃

### DIFF
--- a/src/Magpie/EffectParametersViewModel.cpp
+++ b/src/Magpie/EffectParametersViewModel.cpp
@@ -121,11 +121,17 @@ EffectParametersViewModel::EffectParametersViewModel(uint32_t scalingModeIdx, ui
 	}
 }
 
+// 应确保被删除后依然处于合法的状态，调用任何方法都不会崩溃，见 ScalingModeItem::_IsRemoved
+bool EffectParametersViewModel::_IsRemoved() const noexcept {
+	return _scalingModeIdx == std::numeric_limits<uint32_t>::max() ||
+		_effectIdx == std::numeric_limits<uint32_t>::max();
+}
+
 void EffectParametersViewModel::_ScalingModeBoolParameter_PropertyChanged(
 	IInspectable const& sender,
 	PropertyChangedEventArgs const& args
 ) {
-	if (args.PropertyName() != L"Value") {
+	if (_IsRemoved() || args.PropertyName() != L"Value") {
 		return;
 	}
 
@@ -141,7 +147,7 @@ void EffectParametersViewModel::_ScalingModeFloatParameter_PropertyChanged(
 	IInspectable const& sender,
 	PropertyChangedEventArgs const& args
 ) {
-	if (args.PropertyName() != L"Value") {
+	if (_IsRemoved() || args.PropertyName() != L"Value") {
 		return;
 	}
 
@@ -153,12 +159,12 @@ void EffectParametersViewModel::_ScalingModeFloatParameter_PropertyChanged(
 	LazySaveAppSettings();
 }
 
-phmap::flat_hash_map<std::wstring, float>& EffectParametersViewModel::_Data() {
+phmap::flat_hash_map<std::wstring, float>& EffectParametersViewModel::_Data() const {
 	ScalingMode& scalingMode = ScalingModesService::Get().GetScalingMode(_scalingModeIdx);
 	return scalingMode.effects[_effectIdx].parameters;
 }
 
-inline hstring ScalingModeFloatParameter::ValueText() const noexcept {
+hstring ScalingModeFloatParameter::ValueText() const noexcept {
 	return App::DoubleFormatter().FormatDouble(_value);
 }
 

--- a/src/Magpie/EffectParametersViewModel.h
+++ b/src/Magpie/EffectParametersViewModel.h
@@ -121,11 +121,13 @@ struct EffectParametersViewModel : EffectParametersViewModelT<EffectParametersVi
 	}
 
 private:
+	bool _IsRemoved() const noexcept;
+
 	void _ScalingModeBoolParameter_PropertyChanged(IInspectable const& sender, PropertyChangedEventArgs const& args);
 
 	void _ScalingModeFloatParameter_PropertyChanged(IInspectable const& sender, PropertyChangedEventArgs const& args);
 
-	phmap::flat_hash_map<std::wstring, float>& _Data();
+	phmap::flat_hash_map<std::wstring, float>& _Data() const;
 
 	IVector<IInspectable> _boolParams{ nullptr };
 	IVector<IInspectable> _floatParams{ nullptr };

--- a/src/Magpie/ScalingModeEffectItem.cpp
+++ b/src/Magpie/ScalingModeEffectItem.cpp
@@ -44,6 +44,10 @@ ScalingModeEffectItem::ScalingModeEffectItem(uint32_t scalingModeIdx, uint32_t e
 }
 
 void ScalingModeEffectItem::ScalingModeIdx(uint32_t value) noexcept {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	_scalingModeIdx = value;
 
 	if (_parametersViewModel) {
@@ -52,6 +56,10 @@ void ScalingModeEffectItem::ScalingModeIdx(uint32_t value) noexcept {
 }
 
 void ScalingModeEffectItem::EffectIdx(uint32_t value) noexcept {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	_effectIdx = value;
 
 	if (_parametersViewModel) {
@@ -60,10 +68,18 @@ void ScalingModeEffectItem::EffectIdx(uint32_t value) noexcept {
 }
 
 bool ScalingModeEffectItem::CanScale() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	return _effectInfo && _effectInfo->CanScale();
 }
 
 bool ScalingModeEffectItem::HasParameters() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	return _effectInfo && !_effectInfo->params.empty();
 }
 
@@ -93,6 +109,10 @@ IVector<IInspectable> ScalingModeEffectItem::ScalingTypes() noexcept {
 }
 
 int ScalingModeEffectItem::ScalingType() const noexcept {
+	if (_IsRemoved()) {
+		return (int)ScalingType::Normal;
+	}
+
 	return (int)_Data().scalingType;
 }
 
@@ -118,7 +138,7 @@ static SIZE GetMonitorSize() noexcept {
 }
 
 void ScalingModeEffectItem::ScalingType(int value) {
-	if (value < 0) {
+	if (_IsRemoved() || value < 0) {
 		return;
 	}
 
@@ -149,19 +169,35 @@ void ScalingModeEffectItem::ScalingType(int value) {
 }
 
 bool ScalingModeEffectItem::IsShowScalingFactors() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	::Magpie::ScalingType scalingType = _Data().scalingType;
 	return scalingType == ::Magpie::ScalingType::Normal || scalingType == ::Magpie::ScalingType::Fit;
 }
 
 bool ScalingModeEffectItem::IsShowScalingPixels() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	return _Data().scalingType == ::Magpie::ScalingType::Absolute;
 }
 
 double ScalingModeEffectItem::ScalingFactorX() const noexcept {
+	if (_IsRemoved()) {
+		return 0.0;
+	}
+
 	return _Data().scale.first;
 }
 
 void ScalingModeEffectItem::ScalingFactorX(double value) {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	EffectOption& data = _Data();
 	if (data.scalingType != ::Magpie::ScalingType::Normal && data.scalingType != ::Magpie::ScalingType::Fit) {
 		return;
@@ -177,10 +213,18 @@ void ScalingModeEffectItem::ScalingFactorX(double value) {
 }
 
 double ScalingModeEffectItem::ScalingFactorY() const noexcept {
+	if (_IsRemoved()) {
+		return 0.0;
+	}
+
 	return _Data().scale.second;
 }
 
 void ScalingModeEffectItem::ScalingFactorY(double value) {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	EffectOption& data = _Data();
 	if (data.scalingType != ::Magpie::ScalingType::Normal && data.scalingType != ::Magpie::ScalingType::Fit) {
 		return;
@@ -195,10 +239,18 @@ void ScalingModeEffectItem::ScalingFactorY(double value) {
 }
 
 double ScalingModeEffectItem::ScalingPixelsX() const noexcept {
+	if (_IsRemoved()) {
+		return 0.0;
+	}
+
 	return _Data().scale.first;
 }
 
 void ScalingModeEffectItem::ScalingPixelsX(double value) {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	EffectOption& data = _Data();
 	if (data.scalingType != ::Magpie::ScalingType::Absolute) {
 		return;
@@ -213,10 +265,18 @@ void ScalingModeEffectItem::ScalingPixelsX(double value) {
 }
 
 double ScalingModeEffectItem::ScalingPixelsY() const noexcept {
+	if (_IsRemoved()) {
+		return 0.0;
+	}
+
 	return _Data().scale.second;
 }
 
 void ScalingModeEffectItem::ScalingPixelsY(double value) {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	EffectOption& data = _Data();
 	if (data.scalingType != ::Magpie::ScalingType::Absolute) {
 		return;
@@ -231,32 +291,62 @@ void ScalingModeEffectItem::ScalingPixelsY(double value) {
 }
 
 void ScalingModeEffectItem::Remove() {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	Removed.Invoke(_effectIdx);
+
+	_effectIdx = std::numeric_limits<uint32_t>::max();
 }
 
 bool ScalingModeEffectItem::CanMove() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	const ScalingMode& mode = ScalingModesService::Get().GetScalingMode(_scalingModeIdx);
 	return mode.effects.size() > 1 && Win32Helper::IsProcessElevated();
 }
 
 bool ScalingModeEffectItem::CanMoveUp() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	return _effectIdx > 0;
 }
 
 bool ScalingModeEffectItem::CanMoveDown() const noexcept {
+	if (_IsRemoved()) {
+		return false;
+	}
+
 	const ScalingMode& mode = ScalingModesService::Get().GetScalingMode(_scalingModeIdx);
 	return _effectIdx + 1 < (uint32_t)mode.effects.size();
 }
 
 void ScalingModeEffectItem::MoveUp() noexcept {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	Moved.Invoke(*this, true);
 }
 
 void ScalingModeEffectItem::MoveDown() noexcept {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	Moved.Invoke(*this, false);
 }
 
 void ScalingModeEffectItem::RefreshMoveState() {
+	if (_IsRemoved()) {
+		return;
+	}
+
 	RaisePropertyChanged(L"CanMove");
 	RaisePropertyChanged(L"CanMoveUp");
 	RaisePropertyChanged(L"CanMoveDown");
@@ -268,6 +358,12 @@ EffectOption& ScalingModeEffectItem::_Data() noexcept {
 
 const EffectOption& ScalingModeEffectItem::_Data() const noexcept {
 	return ScalingModesService::Get().GetScalingMode(_scalingModeIdx).effects[_effectIdx];
+}
+
+// 应确保被删除后依然处于合法的状态，调用任何方法都不会崩溃，见 ScalingModeItem::_IsRemoved
+bool ScalingModeEffectItem::_IsRemoved() const noexcept {
+	return _scalingModeIdx == std::numeric_limits<uint32_t>::max() ||
+		_effectIdx == std::numeric_limits<uint32_t>::max();
 }
 
 }

--- a/src/Magpie/ScalingModeEffectItem.h
+++ b/src/Magpie/ScalingModeEffectItem.h
@@ -87,6 +87,8 @@ struct ScalingModeEffectItem : ScalingModeEffectItemT<ScalingModeEffectItem>,
 	::Magpie::Event<uint32_t> Removed;
 
 private:
+	bool _IsRemoved() const noexcept;
+
 	::Magpie::EffectOption& _Data() noexcept;
 	const ::Magpie::EffectOption& _Data() const noexcept;
 

--- a/src/Magpie/ScalingModeItem.h
+++ b/src/Magpie/ScalingModeItem.h
@@ -78,6 +78,8 @@ struct ScalingModeItem : ScalingModeItemT<ScalingModeItem>,
 private:
 	void _Index(uint32_t value) noexcept;
 
+	bool _IsRemoved() const noexcept;
+
 	void _ScalingModesService_Added(::Magpie::EffectAddedWay);
 
 	void _ScalingModesService_Moved(uint32_t index, bool isMoveUp);
@@ -103,6 +105,7 @@ private:
 	::Magpie::Event<::Magpie::EffectAddedWay>::EventRevoker _scalingModeAddedRevoker;
 	::Magpie::Event<uint32_t, bool>::EventRevoker _scalingModeMovedRevoker;
 	::Magpie::Event<uint32_t>::EventRevoker _scalingModeRemovedRevoker;
+	IObservableVector<IInspectable>::VectorChanged_revoker _effectsChangedRevoker;
 
 	hstring _renameText;
 	std::wstring_view _trimedRenameText;


### PR DESCRIPTION
Close #1154

又一个 WinUI 的 bug，删除缩放模式后 ScalingModeItem 不会立刻析构，而且可能会尝试更新绑定导致崩溃。这个 PR 使 ScalingModeItem、ScalingModeEffectItem 和 EffectParametersViewModel 被删除后仍处于合法的状态，不会因为调用其中的方法而崩溃。这个 bug 似乎在 CPU 较弱时更常见。

缩放模式页面过于复杂，以后会重新设计。