### PR TITLE
修复选择快捷方式作为启动器时丢失参数

### DIFF
--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -759,7 +759,7 @@ bool AppSettings::_LoadProfile(
 
 		JsonHelper::ReadString(profileObj, "launcherPath", profile.launcherPath);
 		// 将旧版本的相对路径转换为绝对路径
-		if (PathIsRelative(profile.launcherPath.c_str())) {
+		if (!profile.launcherPath.empty() && PathIsRelative(profile.launcherPath.c_str())) {
 			size_t delimPos = profile.pathRule.find_last_of(L'\\');
 			if (delimPos != std::wstring::npos) {
 				wil::unique_hlocal_string combinedPath;

--- a/src/Magpie/FileDialogHelper.cpp
+++ b/src/Magpie/FileDialogHelper.cpp
@@ -11,10 +11,13 @@ using namespace winrt;
 namespace Magpie {
 
 // 出错返回空，取消返回空字符串
-std::optional<std::wstring> FileDialogHelper::OpenFileDialog(IFileDialog* fileDialog, FILEOPENDIALOGOPTIONS options) noexcept {
-	FILEOPENDIALOGOPTIONS options1{};
-	fileDialog->GetOptions(&options1);
-	fileDialog->SetOptions(options1 | options | FOS_FORCEFILESYSTEM);
+std::optional<std::wstring> FileDialogHelper::OpenFileDialog(
+	IFileDialog* fileDialog,
+	FILEOPENDIALOGOPTIONS options
+) noexcept {
+	FILEOPENDIALOGOPTIONS oldOptions{};
+	fileDialog->GetOptions(&oldOptions);
+	fileDialog->SetOptions(oldOptions | options | FOS_FORCEFILESYSTEM | FOS_OKBUTTONNEEDSINTERACTION);
 
 	if (fileDialog->Show(App::Get().MainWindow().Handle()) != S_OK) {
 		// 被用户取消

--- a/src/Magpie/Profile.h
+++ b/src/Magpie/Profile.h
@@ -48,8 +48,7 @@ struct Profile {
 	std::wstring pathRule;
 	std::wstring classNameRule;
 
-	// 如果在同一个驱动器上则存储相对路径，否则存储绝对路径
-	// 若为空使用 pathRule
+	// 允许 exe 和 lnk
 	std::wstring launcherPath;
 
 	CursorScaling cursorScaling = CursorScaling::NoScaling;

--- a/src/Magpie/ProfileViewModel.cpp
+++ b/src/Magpie/ProfileViewModel.cpp
@@ -149,7 +149,9 @@ void ProfileViewModel::ChangeExeForLaunching() const noexcept {
 		fileDialog->SetFolder(shellItem.get());
 	}
 
-	std::optional<std::wstring> exePath = FileDialogHelper::OpenFileDialog(fileDialog.get(), FOS_STRICTFILETYPES);
+	// 可能返回 exe 或 lnk
+	std::optional<std::wstring> exePath = FileDialogHelper::OpenFileDialog(
+		fileDialog.get(), FOS_STRICTFILETYPES | FOS_NODEREFERENCELINKS);
 	if (!exePath || exePath->empty() || *exePath == _data->pathRule) {
 		return;
 	}

--- a/src/Magpie/ProfileViewModel.cpp
+++ b/src/Magpie/ProfileViewModel.cpp
@@ -149,14 +149,16 @@ void ProfileViewModel::ChangeExeForLaunching() const noexcept {
 		fileDialog->SetFolder(shellItem.get());
 	}
 
-	// 可能返回 exe 或 lnk
-	std::optional<std::wstring> exePath = FileDialogHelper::OpenFileDialog(
+	// GH#1158
+	// 选择 exe 的快捷方式时 IFileOpenDialog 默认解析它指向的文件路径，导致参数丢失。
+	// FOS_NODEREFERENCELINKS 可以禁止解析，直接返回 lnk 文件。
+	std::optional<std::wstring> launcherPath = FileDialogHelper::OpenFileDialog(
 		fileDialog.get(), FOS_STRICTFILETYPES | FOS_NODEREFERENCELINKS);
-	if (!exePath || exePath->empty() || *exePath == _data->pathRule) {
+	if (!launcherPath || launcherPath->empty() || *launcherPath == _data->pathRule) {
 		return;
 	}
 
-	_data->launcherPath = std::move(*exePath);
+	_data->launcherPath = std::move(*launcherPath);
 	AppSettings::Get().SaveAsync();
 }
 


### PR DESCRIPTION
Close #1158

选择 exe 的快捷方式时 IFileOpenDialog 默认会提取出路径并忽略参数，现在使用 FOS_NODEREFERENCELINKS 选项使 IFileDialog 直接返回 lnk。

当快捷方式包含参数时，Magpie 的启动参数选项就无效了。虽然可以在 UI 中给出提示，但我们不是很想实现，如果用快捷方式作为启动器，用户应该知道自己在做什么。