### PR TITLE
修复全屏缩放会遮挡弹窗的问题

### DIFF
--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -159,6 +159,16 @@ ScalingError SrcTracker::Set(HWND hWnd, const ScalingOptions& options) noexcept 
 	return _CalcSrcRect(options, borderThicknessInFrame);
 }
 
+static bool IsOwnedWindow(HWND hwndOwner, HWND hwndTest) noexcept {
+	HWND hwndCur = hwndTest;
+	while (bool(hwndCur = GetWindowOwner(hwndCur))) {
+		if (hwndCur == hwndOwner) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static bool IsPrimaryMouseButtonDown() noexcept {
 	const bool isSwapped = GetSystemMetrics(SM_SWAPBUTTON);
 	const int vkPrimary = isSwapped ? VK_RBUTTON : VK_LBUTTON;
@@ -195,6 +205,7 @@ bool SrcTracker::UpdateState(
 	}
 
 	_isFocused = hwndFore == _hWnd;
+	_isOwnedWindowFocused = !_isFocused && IsOwnedWindow(_hWnd, hwndFore);
 
 	const bool oldMaximized = _isMaximized;
 	UINT showCmd = Win32Helper::GetWindowShowCmd(_hWnd);
@@ -408,6 +419,11 @@ static bool GetClientRectOfUWP(HWND hWnd, RECT& rect) noexcept {
 	}
 
 	return true;
+}
+
+bool SrcTracker::SetFocus() const noexcept {
+	// 如果源窗口存在弹窗（即被源窗口所有的窗口），应把弹窗设为前台窗口
+	return SetForegroundWindow(GetWindow(_hWnd, GW_ENABLEDPOPUP));
 }
 
 ScalingError SrcTracker::_CalcSrcRect(const ScalingOptions& options, LONG borderThicknessInFrame) noexcept {

--- a/src/Magpie.Core/SrcTracker.h
+++ b/src/Magpie.Core/SrcTracker.h
@@ -62,6 +62,12 @@ public:
 		return _isFocused;
 	}
 
+	bool IsOwnedWindowFocused() const noexcept {
+		return _isOwnedWindowFocused;
+	}
+
+	bool SetFocus() const noexcept;
+
 	// IsMaximized 已定义为宏
 	bool IsZoomed() const noexcept {
 		return _isMaximized;
@@ -86,6 +92,7 @@ private:
 	SrcWindowKind _windowKind = SrcWindowKind::Native;
 
 	bool _isFocused = false;
+	bool _isOwnedWindowFocused = false;
 	bool _isMaximized = false;
 	bool _isMoving = false;
 };

--- a/src/Magpie.Core/include/EffectDesc.h
+++ b/src/Magpie.Core/include/EffectDesc.h
@@ -1,9 +1,7 @@
 #pragma once
-#include <variant>
 #include "SmallVector.h"
-
-struct ID3D10Blob;
-typedef ID3D10Blob ID3DBlob;
+#include <d3dcommon.h>
+#include <variant>
 
 namespace Magpie {
 

--- a/src/Magpie.Core/include/ScalingRuntime.h
+++ b/src/Magpie.Core/include/ScalingRuntime.h
@@ -32,7 +32,7 @@ private:
 	// 确保 _dispatcher 完成初始化
 	const winrt::DispatcherQueue& _Dispatcher() noexcept;
 
-	bool _SetIsScaling(bool value);
+	void _IsScaling(bool value);
 
 	std::thread _scalingThread;
 

--- a/src/Magpie/AboutPage.cpp
+++ b/src/Magpie/AboutPage.cpp
@@ -3,9 +3,9 @@
 #if __has_include("AboutPage.g.cpp")
 #include "AboutPage.g.cpp"
 #endif
-#include "Win32Helper.h"
 #include "CommonSharedConstants.h"
 #include "ToastService.h"
+#include "Win32Helper.h"
 
 using namespace Magpie;
 

--- a/src/Magpie/AboutViewModel.cpp
+++ b/src/Magpie/AboutViewModel.cpp
@@ -3,7 +3,6 @@
 #if __has_include("AboutViewModel.g.cpp")
 #include "AboutViewModel.g.cpp"
 #endif
-#include "Version.h"
 #include "UpdateService.h"
 #include "AppSettings.h"
 #include "StrHelper.h"

--- a/src/Magpie/AdaptersService.cpp
+++ b/src/Magpie/AdaptersService.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
-#include <d3d11_4.h>
 #include "AdaptersService.h"
-#include "Logger.h"
-#include "Win32Helper.h"
 #include "App.h"
 #include "DirectXHelper.h"
+#include "Logger.h"
+#include "Win32Helper.h"
+#include <d3d11_4.h>
 
 using namespace winrt::Magpie::implementation;
 using namespace winrt;

--- a/src/Magpie/AdaptersService.h
+++ b/src/Magpie/AdaptersService.h
@@ -1,7 +1,6 @@
 #pragma once
-#include "SmallVector.h"
-#include <dxgi1_6.h>
 #include "Event.h"
+#include <dxgi1_6.h>
 
 namespace Magpie {
 

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -19,26 +19,26 @@
 #if __has_include("App.g.cpp")
 #include "App.g.cpp"
 #endif
-#include "Win32Helper.h"
-#include "Logger.h"
-#include "ShortcutService.h"
+#include "AdaptersService.h"
 #include "CommonSharedConstants.h"
-#include "ScalingService.h"
-#include <CoreWindow.h>
+#include "ControlSizeTrigger.h"
 #include "EffectsService.h"
-#include "UpdateService.h"
+#include "IsEqualStateTrigger.h"
+#include "IsNullStateTrigger.h"
 #include "LocalizationService.h"
-#include "ToastService.h"
+#include "Logger.h"
+#include "MainWindow.h"
 #include "NotifyIconService.h"
+#include "ScalingService.h"
 #include "SettingsCard.h"
 #include "SettingsExpander.h"
 #include "SettingsGroup.h"
-#include "ControlSizeTrigger.h"
-#include "IsEqualStateTrigger.h"
-#include "IsNullStateTrigger.h"
+#include "ShortcutService.h"
 #include "TextBlockHelper.h"
-#include "MainWindow.h"
-#include "AdaptersService.h"
+#include "ToastService.h"
+#include "UpdateService.h"
+#include "Win32Helper.h"
+#include <CoreWindow.h>
 
 using namespace ::Magpie;
 using namespace winrt;

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
-#include "App.h"
 #include "AppSettings.h"
+#include "App.h"
 #include "AutoStartHelper.h"
 #include "CommonSharedConstants.h"
 #include "JsonHelper.h"

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -3,7 +3,6 @@
 #include "Event.h"
 #include "Shortcut.h"
 #include "Profile.h"
-#include <parallel_hashmap/phmap.h>
 #include <rapidjson/document.h>
 
 namespace Magpie {

--- a/src/Magpie/EffectsService.cpp
+++ b/src/Magpie/EffectsService.cpp
@@ -1,12 +1,11 @@
 #include "pch.h"
-#include "EffectsService.h"
-#include "StrHelper.h"
-#include "Win32Helper.h"
 #include "CommonSharedConstants.h"
-#include "Logger.h"
-#include <d3dcompiler.h>	// ID3DBlob
 #include "EffectCompiler.h"
 #include "EffectDesc.h"
+#include "EffectsService.h"
+#include "Logger.h"
+#include "StrHelper.h"
+#include "Win32Helper.h"
 
 using namespace winrt;
 

--- a/src/Magpie/HomePage.cpp
+++ b/src/Magpie/HomePage.cpp
@@ -3,8 +3,8 @@
 #if __has_include("HomePage.g.cpp")
 #include "HomePage.g.cpp"
 #endif
-#include "XamlHelper.h"
 #include "ControlHelper.h"
+#include "XamlHelper.h"
 
 using namespace ::Magpie;
 

--- a/src/Magpie/HomeViewModel.h
+++ b/src/Magpie/HomeViewModel.h
@@ -46,7 +46,7 @@ struct HomeViewModel : HomeViewModelT<HomeViewModel>, wil::notify_property_chang
 
 	void OpenScreenshotSaveDirectory() const noexcept;
 
-	void ChangeScreenshotSaveDirectory() noexcept;
+	fire_and_forget ChangeScreenshotSaveDirectory() noexcept;
 
 	bool IsTouchSupportEnabled() const noexcept;
 	fire_and_forget IsTouchSupportEnabled(bool value);

--- a/src/Magpie/LocalizationService.cpp
+++ b/src/Magpie/LocalizationService.cpp
@@ -1,9 +1,8 @@
 #include "pch.h"
-#include "LocalizationService.h"
 #include "AppSettings.h"
-#include <winrt/Windows.System.UserProfile.h>
-#include "StrHelper.h"
+#include "LocalizationService.h"
 #include <bcp47mrm.h>
+#include <winrt/Windows.System.UserProfile.h>
 
 using namespace winrt;
 

--- a/src/Magpie/MainWindow.cpp
+++ b/src/Magpie/MainWindow.cpp
@@ -1,16 +1,15 @@
 #include "pch.h"
 #include "MainWindow.h"
-#include "CommonSharedConstants.h"
-#include "Win32Helper.h"
-#include "ThemeHelper.h"
-#include <ShellScalingApi.h>
-#include "resource.h"
-#include "EffectsService.h"
-#include "AppSettings.h"
 #include "App.h"
+#include "AppSettings.h"
 #include "CaptionButtonsControl.h"
-#include "TitleBarControl.h"
+#include "CommonSharedConstants.h"
+#include "EffectsService.h"
+#include "resource.h"
 #include "SmoothResizeHelper.h"
+#include "TitleBarControl.h"
+#include "Win32Helper.h"
+#include <ShellScalingApi.h>
 
 using namespace winrt;
 using namespace winrt::Magpie::implementation;

--- a/src/Magpie/NotifyIconService.cpp
+++ b/src/Magpie/NotifyIconService.cpp
@@ -1,11 +1,11 @@
 #include "pch.h"
-#include "NotifyIconService.h"
+#include "App.h"
 #include "CommonSharedConstants.h"
 #include "Logger.h"
+#include "NotifyIconService.h"
 #include "resource.h"
-#include "App.h"
-#include <CommCtrl.h>
 #include "ScalingService.h"
+#include <CommCtrl.h>
 
 using namespace winrt::Magpie::implementation;
 using namespace winrt;

--- a/src/Magpie/ProfilePage.cpp
+++ b/src/Magpie/ProfilePage.cpp
@@ -3,9 +3,9 @@
 #if __has_include("ProfilePage.g.cpp")
 #include "ProfilePage.g.cpp"
 #endif
+#include "App.h"
 #include "ControlHelper.h"
 #include "Profile.h"
-#include "App.h"
 
 using namespace ::Magpie;
 using namespace winrt;

--- a/src/Magpie/ProfileService.cpp
+++ b/src/Magpie/ProfileService.cpp
@@ -1,11 +1,10 @@
 #include "pch.h"
-#include "ProfileService.h"
-#include "Win32Helper.h"
 #include "AppSettings.h"
 #include "AppXReader.h"
-#include <regex>
+#include "ProfileService.h"
 #include "StrHelper.h"
-#include "AdaptersService.h"
+#include "Win32Helper.h"
+#include <regex>
 
 using namespace ::Magpie;
 

--- a/src/Magpie/ProfileViewModel.h
+++ b/src/Magpie/ProfileViewModel.h
@@ -28,7 +28,7 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel>,
 
 	fire_and_forget OpenProgramLocation() const noexcept;
 
-	void ChangeExeForLaunching() const noexcept;
+	fire_and_forget ChangeExeForLaunching() noexcept;
 
 	hstring Name() const noexcept;
 

--- a/src/Magpie/RootPage.cpp
+++ b/src/Magpie/RootPage.cpp
@@ -3,9 +3,7 @@
 #if __has_include("RootPage.g.cpp")
 #include "RootPage.g.cpp"
 #endif
-
 #include "XamlHelper.h"
-#include "Logger.h"
 #include "Win32Helper.h"
 #include "ProfileService.h"
 #include "AppXReader.h"

--- a/src/Magpie/ScalingModesService.cpp
+++ b/src/Magpie/ScalingModesService.cpp
@@ -1,11 +1,11 @@
 #include "pch.h"
-#include "ScalingModesService.h"
 #include "AppSettings.h"
-#include "StrHelper.h"
-#include "JsonHelper.h"
-#include "EffectsService.h"
 #include "EffectHelper.h"
+#include "EffectsService.h"
+#include "JsonHelper.h"
 #include "ScalingMode.h"
+#include "ScalingModesService.h"
+#include "StrHelper.h"
 
 using namespace ::Magpie;
 using namespace winrt;

--- a/src/Magpie/ScalingModesViewModel.cpp
+++ b/src/Magpie/ScalingModesViewModel.cpp
@@ -3,11 +3,8 @@
 #if __has_include("ScalingModesViewModel.g.cpp")
 #include "ScalingModesViewModel.g.cpp"
 #endif
-#include "EffectsService.h"
 #include "AppSettings.h"
-#include "EffectHelper.h"
 #include "Logger.h"
-#include "StrHelper.h"
 #include "Win32Helper.h"
 #include "ScalingMode.h"
 #include "FileDialogHelper.h"
@@ -46,8 +43,8 @@ static std::optional<std::filesystem::path> OpenFileDialogForJson(
 fire_and_forget ScalingModesViewModel::Export() noexcept {
 	ResourceLoader resourceLoader =
 		ResourceLoader::GetForCurrentView(CommonSharedConstants::APP_RESOURCE_MAP_ID);
-	hstring title = resourceLoader.GetString(L"Dialog_Export_Title");
-	hstring jsonFileStr = resourceLoader.GetString(L"Dialog_JsonFile");
+	const hstring title = resourceLoader.GetString(L"Dialog_Export_Title");
+	const hstring jsonFileStr = resourceLoader.GetString(L"Dialog_JsonFile");
 
 	auto weakThis = get_weak();
 

--- a/src/Magpie/ScalingModesViewModel.h
+++ b/src/Magpie/ScalingModesViewModel.h
@@ -9,7 +9,7 @@ struct ScalingModesViewModel : ScalingModesViewModelT<ScalingModesViewModel>,
                                wil::notify_property_changed_base<ScalingModesViewModel> {
 	ScalingModesViewModel();
 
-	void Export() const noexcept;
+	fire_and_forget Export() noexcept;
 
 	void Import() {
 		_Import(false);
@@ -68,7 +68,7 @@ private:
 
 	void _ScalingModesService_Removed(uint32_t index);
 
-	void _Import(bool legacy);
+	fire_and_forget _Import(bool legacy);
 
 	IObservableVector<IInspectable> _scalingModes = single_threaded_observable_vector<IInspectable>();
 

--- a/src/Magpie/ShortcutService.cpp
+++ b/src/Magpie/ShortcutService.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
-#include "ShortcutService.h"
-#include "Logger.h"
-#include "ShortcutHelper.h"
+#include "App.h"
 #include "AppSettings.h"
 #include "CommonSharedConstants.h"
-#include "App.h"
+#include "Logger.h"
+#include "ShortcutHelper.h"
+#include "ShortcutService.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/Magpie/ShortcutService.h
+++ b/src/Magpie/ShortcutService.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <winrt/Magpie.h>
 #include "Event.h"
+#include <winrt/Magpie.h>
 
 namespace Magpie {
 

--- a/src/Magpie/ToastPage.cpp
+++ b/src/Magpie/ToastPage.cpp
@@ -3,11 +3,11 @@
 #if __has_include("ToastPage.g.cpp")
 #include "ToastPage.g.cpp"
 #endif
+#include "App.h"
 #include "Win32Helper.h"
 #include "IconHelper.h"
 #include "LocalizationService.h"
 #include "XamlHelper.h"
-#include "App.h"
 #include <dwmapi.h>
 
 using namespace ::Magpie;

--- a/src/Magpie/ToastService.cpp
+++ b/src/Magpie/ToastService.cpp
@@ -1,12 +1,12 @@
 #include "pch.h"
-#include "ToastService.h"
+#include "App.h"
 #include "CommonSharedConstants.h"
+#include "MainWindow.h"
+#include "ToastService.h"
+#include "Win32Helper.h"
+#include "XamlHelper.h"
 #include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
-#include "XamlHelper.h"
-#include "App.h"
-#include "MainWindow.h"
-#include "Win32Helper.h"
 
 using namespace winrt::Magpie::implementation;
 using namespace winrt;

--- a/src/Magpie/UpdateService.cpp
+++ b/src/Magpie/UpdateService.cpp
@@ -1,20 +1,20 @@
 #include "pch.h"
-#include "UpdateService.h"
+#include "App.h"
+#include "AppSettings.h"
+#include "CommonSharedConstants.h"
 #include "JsonHelper.h"
 #include "Logger.h"
-#include "StrHelper.h"
-#include "Version.h"
-#include "AppSettings.h"
-#include "Win32Helper.h"
-#include "CommonSharedConstants.h"
-#include "App.h"
 #include "MainWindow.h"
-#include <winrt/Windows.Web.Http.h>
-#include <winrt/Windows.Storage.Streams.h>
-#include <zip/zip.h>
+#include "StrHelper.h"
+#include "UpdateService.h"
+#include "Version.h"
+#include "Win32Helper.h"
 #include <bcrypt.h>
-#include <wil/resource.h>	// 再次包含以激活 CNG 相关包装器
 #include <rapidjson/document.h>
+#include <wil/resource.h>	// 再次包含以激活 CNG 相关包装器
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Web.Http.h>
+#include <zip/zip.h>
 
 using namespace ::Magpie;
 using namespace winrt::Magpie::implementation;

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -1,15 +1,15 @@
 #pragma once
-#include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
-#include <winrt/Windows.UI.Xaml.Hosting.h>
-#include <CoreWindow.h>
-#include "XamlHelper.h"
-#include "Win32Helper.h"
-#include "ThemeHelper.h"
-#include "Logger.h"
 #include "Event.h"
+#include "Logger.h"
+#include "ThemeHelper.h"
+#include "Win32Helper.h"
 #include "WindowBase.h"
+#include "XamlHelper.h"
+#include <CoreWindow.h>
 #include <dwmapi.h>
 #include <shellapi.h>
+#include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
+#include <winrt/Windows.UI.Xaml.Hosting.h>
 
 namespace Magpie {
 


### PR DESCRIPTION
https://github.com/Blinue/Magpie/discussions/1182#discussioncomment-13657215

全屏模式缩放时缩放窗口是置顶的，并遮挡源窗口的弹窗。如果弹窗是模态的，这会导致源窗口无法交互，除非退出缩放。这个 PR 添加了检测弹窗的机制，在这种情况下将缩放窗口置于弹窗下面。