### PR TITLE
IUnknown::as 替换为 IUnknown::try_as

### DIFF
--- a/src/BuildOptions.props
+++ b/src/BuildOptions.props
@@ -12,7 +12,7 @@
     <DebugBorder>false</DebugBorder>
     <!-- 在性能分析器上显示调试信息 -->
     <DebugInfoOnOverlay>false</DebugInfoOnOverlay>
-    <!--使用 composition swapchain 呈现-->
+    <!-- 使用 composition swapchain 呈现 -->
     <UseCompSwapchain>false</UseCompSwapchain>
 
     <CommitId></CommitId>

--- a/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
+++ b/src/Magpie.Core/GraphicsCaptureFrameSource.cpp
@@ -95,7 +95,7 @@ FrameSourceState GraphicsCaptureFrameSource::_Update() noexcept {
 	winrt::IDirect3DSurface d3dSurface = frame.Surface();
 
 	winrt::com_ptr<::Windows::Graphics::DirectX::Direct3D11::IDirect3DDxgiInterfaceAccess> dxgiInterfaceAccess(
-		d3dSurface.as<::Windows::Graphics::DirectX::Direct3D11::IDirect3DDxgiInterfaceAccess>()
+		d3dSurface.try_as<::Windows::Graphics::DirectX::Direct3D11::IDirect3DDxgiInterfaceAccess>()
 	);
 
 	winrt::com_ptr<ID3D11Texture2D> withFrame;

--- a/src/Magpie.Core/Win32Helper.cpp
+++ b/src/Magpie.Core/Win32Helper.cpp
@@ -716,7 +716,7 @@ static winrt::com_ptr<IShellView> FindDesktopFolderView() noexcept {
 	}
 
 	winrt::com_ptr<IShellBrowser> shellBrowser;
-	hr = dispatch.as<IServiceProvider>()->QueryService(
+	hr = dispatch.try_as<IServiceProvider>()->QueryService(
 		SID_STopLevelBrowser, IID_PPV_ARGS(&shellBrowser));
 	if (FAILED(hr)) {
 		Logger::Get().ComError("IServiceProvider::QueryService 失败", hr);

--- a/src/Magpie/AboutPage.cpp
+++ b/src/Magpie/AboutPage.cpp
@@ -37,7 +37,7 @@ void AboutPage::Discussions_Click(IInspectable const&, RoutedEventArgs const&) {
 
 void AboutPage::InfoBar_SizeChanged(IInspectable const& sender, SizeChangedEventArgs const&) const {
 	// 修复 InfoBar 中 Tooltip 的主题
-	XamlHelper::UpdateThemeOfTooltips(sender.as<MUXC::InfoBar>(), ActualTheme());
+	XamlHelper::UpdateThemeOfTooltips(sender.try_as<MUXC::InfoBar>(), ActualTheme());
 }
 
 }

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -131,7 +131,7 @@ bool App::Initialize(const wchar_t* arguments) {
 		// Win10 中隐藏 DesktopWindowXamlSource 窗口
 		if (Win32Helper::GetOSVersion().IsWin10()) {
 			HWND hwndDWXS;
-			coreWindow.as<ICoreWindowInterop>()->get_WindowHandle(&hwndDWXS);
+			coreWindow.try_as<ICoreWindowInterop>()->get_WindowHandle(&hwndDWXS);
 			ShowWindow(hwndDWXS, SW_HIDE);
 		}
 

--- a/src/Magpie/AutoStartHelper.cpp
+++ b/src/Magpie/AutoStartHelper.cpp
@@ -470,7 +470,7 @@ static bool IsAutoStartShortcutExist(std::wstring& arguments) noexcept {
 
 	// https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishelllinka-getarguments
 	// 推荐从 IPropertyStore 检索参数
-	com_ptr<IPropertyStore> propertyStore = shellLink.as<IPropertyStore>();
+	com_ptr<IPropertyStore> propertyStore = shellLink.try_as<IPropertyStore>();
 	if (!propertyStore) {
 		Logger::Get().Error("获取 IPropertyStore 失败");
 		return false;

--- a/src/Magpie/ControlHelper.cpp
+++ b/src/Magpie/ControlHelper.cpp
@@ -17,7 +17,7 @@ void ControlHelper::ComboBox_DropDownOpened(const IInspectable& sender) {
 
 	// 修复下拉框位置不正确的问题
 	// https://github.com/microsoft/microsoft-ui-xaml/issues/4551
-	ComboBox comboBox = sender.as<ComboBox>();
+	ComboBox comboBox = sender.try_as<ComboBox>();
 	IInspectable selectedItem = comboBox.SelectedItem();
 	if (!selectedItem) {
 		return;
@@ -34,12 +34,12 @@ void ControlHelper::ComboBox_DropDownOpened(const IInspectable& sender) {
 
 void ControlHelper::NumberBox_Loaded(const IInspectable& sender) {
 	// 确保模板已应用
-	sender.as<MUXC::NumberBox>().ApplyTemplate();
+	sender.try_as<MUXC::NumberBox>().ApplyTemplate();
 
 	// 设置内部 TextBox 的右键菜单
-	sender.as<IControlProtected>()
+	sender.try_as<IControlProtected>()
 		.GetTemplateChild(L"InputBox")
-		.as<TextBox>()
+		.try_as<TextBox>()
 		.ContextFlyout(winrt::Magpie::TextMenuFlyout());
 }
 

--- a/src/Magpie/ControlSizeTrigger.cpp
+++ b/src/Magpie/ControlSizeTrigger.cpp
@@ -60,16 +60,16 @@ void ControlSizeTrigger::RegisterDependencyProperties() {
 }
 
 void ControlSizeTrigger::_OnPropertyChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-	get_self<ControlSizeTrigger>(sender.as<Magpie::ControlSizeTrigger>())->_UpdateTrigger();
+	get_self<ControlSizeTrigger>(sender.try_as<Magpie::ControlSizeTrigger>())->_UpdateTrigger();
 }
 
 void ControlSizeTrigger::_OnTargetElementChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& e) {
-	ControlSizeTrigger* that = get_self<ControlSizeTrigger>(sender.as<Magpie::ControlSizeTrigger>());
+	ControlSizeTrigger* that = get_self<ControlSizeTrigger>(sender.try_as<Magpie::ControlSizeTrigger>());
 
 	that->_targetElementSizeChangedRevoker.revoke();
 
 	if (IInspectable newValue = e.NewValue()) {
-		that->_targetElementSizeChangedRevoker = newValue.as<FrameworkElement>().SizeChanged(auto_revoke,
+		that->_targetElementSizeChangedRevoker = newValue.try_as<FrameworkElement>().SizeChanged(auto_revoke,
 			[that](IInspectable const&, SizeChangedEventArgs const&) {
 				that->_UpdateTrigger();
 			}

--- a/src/Magpie/ControlSizeTrigger.h
+++ b/src/Magpie/ControlSizeTrigger.h
@@ -12,22 +12,22 @@ struct ControlSizeTrigger : ControlSizeTriggerT<ControlSizeTrigger> {
     static DependencyProperty MinHeightProperty() { return _minHeightProperty; }
     static DependencyProperty TargetElementProperty() { return _targetElementProperty; }
 
-    bool CanTrigger() { return GetValue(_canTriggerProperty).as<bool>(); }
+    bool CanTrigger() { return GetValue(_canTriggerProperty).try_as<bool>().value(); }
     void CanTrigger(bool value) { SetValue(_canTriggerProperty, box_value(value)); }
 
-    double MaxWidth() { return GetValue(_maxWidthProperty).as<double>(); }
+    double MaxWidth() { return GetValue(_maxWidthProperty).try_as<double>().value(); }
     void MaxWidth(double value) { SetValue(_maxWidthProperty, box_value(value)); }
 
-    double MinWidth() { return GetValue(_minWidthProperty).as<double>(); }
+    double MinWidth() { return GetValue(_minWidthProperty).try_as<double>().value(); }
     void MinWidth(double value) { SetValue(_minWidthProperty, box_value(value)); }
 
-    double MaxHeight() { return GetValue(_maxHeightProperty).as<double>(); }
+    double MaxHeight() { return GetValue(_maxHeightProperty).try_as<double>().value(); }
     void MaxHeight(double value) { SetValue(_maxHeightProperty, box_value(value)); }
 
-    double MinHeight() { return GetValue(_minHeightProperty).as<double>(); }
+    double MinHeight() { return GetValue(_minHeightProperty).try_as<double>().value(); }
     void MinHeight(double value) { SetValue(_minHeightProperty, box_value(value)); }
 
-    FrameworkElement TargetElement() { return GetValue(_targetElementProperty).as<FrameworkElement>(); }
+    FrameworkElement TargetElement() { return GetValue(_targetElementProperty).try_as<FrameworkElement>(); }
     void TargetElement(FrameworkElement const& value) { SetValue(_targetElementProperty, box_value(value)); }
 
 private:

--- a/src/Magpie/EffectParametersViewModel.cpp
+++ b/src/Magpie/EffectParametersViewModel.cpp
@@ -136,7 +136,7 @@ void EffectParametersViewModel::_ScalingModeBoolParameter_PropertyChanged(
 	}
 
 	ScalingModeBoolParameter* boolParamImpl =
-		get_self<ScalingModeBoolParameter>(sender.as<Magpie::ScalingModeBoolParameter>());
+		get_self<ScalingModeBoolParameter>(sender.try_as<Magpie::ScalingModeBoolParameter>());
 	const std::string& effectName = _effectInfo->params[boolParamImpl->Index()].name;
 	_Data()[StrHelper::UTF8ToUTF16(effectName)] = (float)boolParamImpl->Value();
 
@@ -152,7 +152,7 @@ void EffectParametersViewModel::_ScalingModeFloatParameter_PropertyChanged(
 	}
 
 	ScalingModeFloatParameter* floatParamImpl =
-		get_self<ScalingModeFloatParameter>(sender.as<Magpie::ScalingModeFloatParameter>());
+		get_self<ScalingModeFloatParameter>(sender.try_as<Magpie::ScalingModeFloatParameter>());
 	const std::string& effectName = _effectInfo->params[floatParamImpl->Index()].name;
 	_Data()[StrHelper::UTF8ToUTF16(effectName)] = (float)floatParamImpl->Value();
 

--- a/src/Magpie/HomePage.cpp
+++ b/src/Magpie/HomePage.cpp
@@ -12,7 +12,7 @@ namespace winrt::Magpie::implementation {
 
 void HomePage::TimerSlider_Loaded(IInspectable const& sender, RoutedEventArgs const&) const {
 	// 修正 Slider 中 Tooltip 的主题
-	XamlHelper::UpdateThemeOfTooltips(sender.as<Slider>(), ActualTheme());
+	XamlHelper::UpdateThemeOfTooltips(sender.try_as<Slider>(), ActualTheme());
 }
 
 void HomePage::ComboBox_DropDownOpened(IInspectable const& sender, IInspectable const&) const {
@@ -21,7 +21,7 @@ void HomePage::ComboBox_DropDownOpened(IInspectable const& sender, IInspectable 
 
 void HomePage::InfoBar_SizeChanged(IInspectable const& sender, SizeChangedEventArgs const&) const {
 	// 修复 InfoBar 中 Tooltip 的主题
-	XamlHelper::UpdateThemeOfTooltips(sender.as<MUXC::InfoBar>(), ActualTheme());
+	XamlHelper::UpdateThemeOfTooltips(sender.try_as<MUXC::InfoBar>(), ActualTheme());
 }
 
 }

--- a/src/Magpie/IsEqualStateTrigger.cpp
+++ b/src/Magpie/IsEqualStateTrigger.cpp
@@ -26,7 +26,7 @@ void IsEqualStateTrigger::RegisterDependencyProperties() {
 }
 
 void IsEqualStateTrigger::_OnPropertyChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-	get_self<IsEqualStateTrigger>(sender.as<Magpie::IsEqualStateTrigger>())->_UpdateTrigger();
+	get_self<IsEqualStateTrigger>(sender.try_as<Magpie::IsEqualStateTrigger>())->_UpdateTrigger();
 }
 
 static bool AreValuesEqual(IInspectable const& value1, IInspectable const& value2) {
@@ -43,13 +43,13 @@ static bool AreValuesEqual(IInspectable const& value1, IInspectable const& value
 	}
 	
 	if (IPropertyValue v1 = value1.try_as<IPropertyValue>()) {
-		IPropertyValue v2 = value1.as<IPropertyValue>();
+		IPropertyValue v2 = value1.try_as<IPropertyValue>();
 
 		// 没有必要为每种类型都添加处理逻辑，IsEqualStateTrigger 目前只在 SettingsCard 中用于比较枚举类型
 		switch (v1.Type()) {
 		case PropertyType::OtherType:
 		{
-			return value1.as<IReference<ContentAlignment>>() == value2.as<IReference<ContentAlignment>>();
+			return value1.try_as<ContentAlignment>() == value2.try_as<ContentAlignment>();
 		}
 		default:
 			return false;

--- a/src/Magpie/IsNullStateTrigger.cpp
+++ b/src/Magpie/IsNullStateTrigger.cpp
@@ -22,7 +22,7 @@ void IsNullStateTrigger::RegisterDependencyProperties() {
 }
 
 void IsNullStateTrigger::_OnValueChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-	get_self<IsNullStateTrigger>(sender.as<Magpie::IsNullStateTrigger>())->_UpdateTrigger();
+	get_self<IsNullStateTrigger>(sender.try_as<Magpie::IsNullStateTrigger>())->_UpdateTrigger();
 }
 
 void IsNullStateTrigger::_UpdateTrigger() {

--- a/src/Magpie/KeyVisual.cpp
+++ b/src/Magpie/KeyVisual.cpp
@@ -60,7 +60,7 @@ void KeyVisual::OnApplyTemplate() {
 
 	_isEnabledChangedRevoker.revoke();
 
-	_keyPresenter = GetTemplateChild(L"KeyPresenter").as<ContentPresenter>();
+	_keyPresenter = GetTemplateChild(L"KeyPresenter").try_as<ContentPresenter>();
 
 	_Update();
 	_SetEnabledState();
@@ -100,7 +100,7 @@ void KeyVisual::_Update() {
 	{
 		Style(_GetStyleSize(L"IconKeyVisualStyle"));
 
-		PathIcon winIcon = XamlReader::Load(LR"(<PathIcon xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Data="M9,17V9h8v8ZM0,17V9H8v8ZM9,8V0h8V8ZM0,8V0H8V8Z" />)").as<PathIcon>();
+		PathIcon winIcon = XamlReader::Load(LR"(<PathIcon xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Data="M9,17V9h8v8ZM0,17V9H8v8ZM9,8V0h8V8ZM0,8V0H8V8Z" />)").try_as<PathIcon>();
 		Viewbox winIconContainer;
 		winIconContainer.Child(winIcon);
 		winIconContainer.HorizontalAlignment(HorizontalAlignment::Center);
@@ -145,7 +145,7 @@ Style KeyVisual::_GetStyleSize(std::wstring_view styleName) const {
 
 	return App::Get().Resources()
 		.Lookup(box_value(StrHelper::Concat(prefix, styleName)))
-		.as<Windows::UI::Xaml::Style>();
+		.try_as<Windows::UI::Xaml::Style>();
 }
 
 double KeyVisual::_GetIconSize() const {
@@ -160,7 +160,7 @@ double KeyVisual::_GetIconSize() const {
 
 	return App::Get().Resources()
 		.Lookup(box_value(key))
-		.as<double>();
+		.try_as<double>().value();
 }
 
 void KeyVisual::_SetErrorState() {

--- a/src/Magpie/NewProfileViewModel.cpp
+++ b/src/Magpie/NewProfileViewModel.cpp
@@ -158,7 +158,7 @@ void NewProfileViewModel::CandidateWindowIndex(int value) {
 
 	if (value >= 0) {
 		Name(get_self<CandidateWindowItem>(_candidateWindows.GetAt(value)
-			.as<winrt::Magpie::CandidateWindowItem>())->DefaultProfileName());
+			.try_as<winrt::Magpie::CandidateWindowItem>())->DefaultProfileName());
 	} else {
 		Name({});
 	}
@@ -177,7 +177,7 @@ void NewProfileViewModel::Confirm() const noexcept {
 	}
 
 	CandidateWindowItem* selectedItem = get_self<CandidateWindowItem>(
-		_candidateWindows.GetAt(_candidateWindowIndex).as<winrt::Magpie::CandidateWindowItem>());
+		_candidateWindows.GetAt(_candidateWindowIndex).try_as<winrt::Magpie::CandidateWindowItem>());
 	hstring aumid = selectedItem->AUMID();
 	ProfileService::Get().AddProfile(!aumid.empty(), aumid.empty() ? selectedItem->Path() : aumid,
 		selectedItem->ClassName(), _name, _profileIndex - 1);

--- a/src/Magpie/PageFrame.cpp
+++ b/src/Magpie/PageFrame.cpp
@@ -100,7 +100,7 @@ void PageFrame::ScrollViewer_ViewChanging(IInspectable const&, ScrollViewerViewC
 }
 
 void PageFrame::ScrollViewer_KeyDown(IInspectable const& sender, KeyRoutedEventArgs const& args) {
-	auto scrollViewer = sender.as<struct ScrollViewer>();
+	auto scrollViewer = sender.try_as<struct ScrollViewer>();
 	switch (args.Key()) {
 	case VirtualKey::Up:
 		scrollViewer.ChangeView(scrollViewer.HorizontalOffset(), scrollViewer.VerticalOffset() - 100, 1);

--- a/src/Magpie/PageFrame.xaml
+++ b/src/Magpie/PageFrame.xaml
@@ -35,7 +35,7 @@
 			                Content="{x:Bind Icon, Mode=OneWay}"
 			                IsTabStop="False" />
 			<TextBlock Grid.Column="1"
-			           local:TextBlockHelper.IsAutoTooltip="True"
+			           local:TextBlockHelper.IsAutoTooltipEnabled="True"
 			           FontSize="28"
 			           FontWeight="SemiBold"
 			           Text="{x:Bind Title, Mode=OneWay}"

--- a/src/Magpie/ProfilePage.cpp
+++ b/src/Magpie/ProfilePage.cpp
@@ -15,7 +15,7 @@ using namespace Windows::UI::Xaml::Input;
 namespace winrt::Magpie::implementation {
 
 void ProfilePage::OnNavigatedTo(Navigation::NavigationEventArgs const& args) {
-	int profileIdx = args.Parameter().as<int>();
+	int profileIdx = args.Parameter().try_as<int>().value();
 	_viewModel = make_self<ProfileViewModel>(profileIdx);
 }
 
@@ -35,7 +35,7 @@ void ProfilePage::InitialWindowedScaleFactorComboBox_SelectionChanged(IInspectab
 	} else {
 		const double minWidth = App::Get().Resources()
 			.Lookup(box_value(L"SettingsCardContentMinWidth"))
-			.as<double>();
+			.try_as<double>().value();
 		InitialWindowedScaleFactorComboBox().MinWidth(minWidth);
 		CustomInitialWindowedScaleFactorNumberBox().Visibility(Visibility::Collapsed);
 		CustomInitialWindowedScaleFactorLabel().Visibility(Visibility::Collapsed);
@@ -50,7 +50,7 @@ void ProfilePage::CursorScalingComboBox_SelectionChanged(IInspectable const&, Se
 	} else {
 		const double minWidth = App::Get().Resources()
 			.Lookup(box_value(L"SettingsCardContentMinWidth"))
-			.as<double>();
+			.try_as<double>().value();
 		CursorScalingComboBox().MinWidth(minWidth);
 		CustomCursorScalingNumberBox().Visibility(Visibility::Collapsed);
 		CustomCursorScalingLabel().Visibility(Visibility::Collapsed);

--- a/src/Magpie/RootPage.cpp
+++ b/src/Magpie/RootPage.cpp
@@ -146,7 +146,7 @@ void RootPage::NavigationView_SelectionChanged(
 			return;
 		}
 
-		IInspectable tag = selectedItem.as<MUXC::NavigationViewItem>().Tag();
+		IInspectable tag = selectedItem.try_as<MUXC::NavigationViewItem>().Tag();
 		if (tag) {
 			hstring tagStr = unbox_value<hstring>(tag);
 			Interop::TypeName typeName;
@@ -184,10 +184,10 @@ void RootPage::NavigationView_PaneOpening(MUXC::NavigationView const&, IInspecta
 	// 因此这里手动删除
 	const MUXC::NavigationView& nv = RootNavigationView();
 	for (const IInspectable& item : nv.MenuItems()) {
-		ToolTipService::SetToolTip(item.as<DependencyObject>(), nullptr);
+		ToolTipService::SetToolTip(item.try_as<DependencyObject>(), nullptr);
 	}
 	for (const IInspectable& item : nv.FooterMenuItems()) {
-		ToolTipService::SetToolTip(item.as<DependencyObject>(), nullptr);
+		ToolTipService::SetToolTip(item.try_as<DependencyObject>(), nullptr);
 	}
 }
 
@@ -207,8 +207,8 @@ void RootPage::NavigationView_DisplayModeChanged(MUXC::NavigationView const& nv,
 
 	// !!! HACK !!!
 	// 使导航栏的可滚动区域不会覆盖标题栏
-	FrameworkElement menuItemsScrollViewer = nv.as<IControlProtected>()
-		.GetTemplateChild(L"MenuItemsScrollViewer").as<FrameworkElement>();
+	FrameworkElement menuItemsScrollViewer = nv.try_as<IControlProtected>()
+		.GetTemplateChild(L"MenuItemsScrollViewer").try_as<FrameworkElement>();
 	menuItemsScrollViewer.Margin({ 0,isExpanded ? TitleBar().ActualHeight() : 0.0,0,0});
 
 	XamlHelper::UpdateThemeOfTooltips(*this, ActualTheme());
@@ -250,7 +250,7 @@ void RootPage::NewProfileNameContextFlyout_Opening(IInspectable const&, IInspect
 	}
 
 	CandidateWindowItem* selectedItem = get_self<CandidateWindowItem>(
-		_newProfileViewModel->CandidateWindows().GetAt(idx).as<winrt::Magpie::CandidateWindowItem>());
+		_newProfileViewModel->CandidateWindows().GetAt(idx).try_as<winrt::Magpie::CandidateWindowItem>());
 
 	// 设置每个选项的可见性
 	bool shouldInit = true;
@@ -444,7 +444,7 @@ void RootPage::_UpdateIcons(bool skipDesktop) {
 		}
 
 		MUXC::NavigationViewItem item = navMenuItems.GetAt(FIRST_PROFILE_ITEM_IDX + i)
-			.as<MUXC::NavigationViewItem>();
+			.try_as<MUXC::NavigationViewItem>();
 		_LoadIcon(item, profiles[i]);
 	}
 }
@@ -464,7 +464,7 @@ void RootPage::_ProfileService_ProfileAdded(Profile& profile) {
 void RootPage::_ProfileService_ProfileRenamed(uint32_t idx) {
 	RootNavigationView().MenuItems()
 		.GetAt(FIRST_PROFILE_ITEM_IDX + idx)
-		.as<MUXC::NavigationViewItem>()
+		.try_as<MUXC::NavigationViewItem>()
 		.Content(box_value(AppSettings::Get().Profiles()[idx].name));
 }
 
@@ -493,7 +493,7 @@ void RootPage::_UpdateNewProfileNameTextBox(bool fillWithTitle) {
 	}
 
 	CandidateWindowItem* selectedItem = get_self<CandidateWindowItem>(
-		_newProfileViewModel->CandidateWindows().GetAt(idx).as<winrt::Magpie::CandidateWindowItem>());
+		_newProfileViewModel->CandidateWindows().GetAt(idx).try_as<winrt::Magpie::CandidateWindowItem>());
 	hstring text = fillWithTitle ? selectedItem->Title() : selectedItem->DefaultProfileName();
 
 	TextBox textBox = NewProfileNameTextBox();

--- a/src/Magpie/RootPage.xaml
+++ b/src/Magpie/RootPage.xaml
@@ -104,7 +104,7 @@
 														                  Content="{x:Bind Icon, Mode=OneWay}" />
 														<TextBlock Grid.Column="1"
 														           VerticalAlignment="Center"
-														           local:TextBlockHelper.IsAutoTooltip="True"
+														           local:TextBlockHelper.IsAutoTooltipEnabled="True"
 														           Text="{x:Bind Title, Mode=OneWay}"
 														           TextTrimming="CharacterEllipsis" />
 													</Grid>
@@ -136,7 +136,7 @@
 													<DataTemplate>
 														<TextBlock MaxWidth="300"
 														           HorizontalAlignment="Stretch"
-														           local:TextBlockHelper.IsAutoTooltip="True"
+														           local:TextBlockHelper.IsAutoTooltipEnabled="True"
 														           Text="{Binding}"
 														           TextTrimming="CharacterEllipsis" />
 													</DataTemplate>

--- a/src/Magpie/ScalingModeItem.cpp
+++ b/src/Magpie/ScalingModeItem.cpp
@@ -20,7 +20,7 @@ using namespace ::Magpie;
 namespace winrt::Magpie::implementation {
 
 static ScalingModeEffectItem& GetEffectItemImpl(const IInspectable& item) noexcept {
-	return *get_self<ScalingModeEffectItem>(item.as<winrt::Magpie::ScalingModeEffectItem>());
+	return *get_self<ScalingModeEffectItem>(item.try_as<winrt::Magpie::ScalingModeEffectItem>());
 }
 
 ScalingModeItem::ScalingModeItem(uint32_t index, bool isInitialExpanded)

--- a/src/Magpie/ScalingModesPage.cpp
+++ b/src/Magpie/ScalingModesPage.cpp
@@ -27,12 +27,12 @@ void ScalingModesPage::NumberBox_Loaded(IInspectable const& sender, RoutedEventA
 }
 
 void ScalingModesPage::EffectSettingsCard_Loaded(IInspectable const& sender, RoutedEventArgs const&) {
-	XamlHelper::UpdateThemeOfTooltips(sender.as<DependencyObject>(), ActualTheme());
+	XamlHelper::UpdateThemeOfTooltips(sender.try_as<DependencyObject>(), ActualTheme());
 }
 
 void ScalingModesPage::AddEffectButton_Click(IInspectable const& sender, RoutedEventArgs const&) {
-	Button btn = sender.as<Button>();
-	_curScalingMode = get_self<ScalingModeItem>(btn.Tag().as<winrt::Magpie::ScalingModeItem>());
+	Button btn = sender.try_as<Button>();
+	_curScalingMode = get_self<ScalingModeItem>(btn.Tag().try_as<winrt::Magpie::ScalingModeItem>());
 	_addEffectMenuFlyout.ShowAt(btn);
 }
 
@@ -58,12 +58,12 @@ void ScalingModesPage::ScalingModeMoreOptionsButton_Click(IInspectable const& se
 }
 
 void ScalingModesPage::RemoveScalingModeMenuItem_Click(IInspectable const& sender, RoutedEventArgs const&) {
-	MenuFlyoutItem menuItem = sender.as<MenuFlyoutItem>();
-	ScalingModeItem* scalingModeItem = get_self<ScalingModeItem>(menuItem.Tag().as<winrt::Magpie::ScalingModeItem>());
+	MenuFlyoutItem menuItem = sender.try_as<MenuFlyoutItem>();
+	ScalingModeItem* scalingModeItem = get_self<ScalingModeItem>(menuItem.Tag().try_as<winrt::Magpie::ScalingModeItem>());
 	if (scalingModeItem->IsInUse()) {
 		// 如果有缩放配置正在使用此缩放模式则弹出确认弹窗
 		FlyoutBase::GetAttachedFlyout(menuItem)
-			.ShowAt(_moreOptionsButton.as<FrameworkElement>());
+			.ShowAt(_moreOptionsButton.try_as<FrameworkElement>());
 	} else {
 		scalingModeItem->Remove();
 	}
@@ -113,9 +113,9 @@ void ScalingModesPage::_BuildEffectMenu() noexcept {
 		}
 
 		if (isLSubMenu) {
-			return l.as<MenuFlyoutSubItem>().Text() < r.as<MenuFlyoutSubItem>().Text();
+			return l.try_as<MenuFlyoutSubItem>().Text() < r.try_as<MenuFlyoutSubItem>().Text();
 		} else {
-			return l.as<MenuFlyoutItem>().Text() < r.as<MenuFlyoutItem>().Text();
+			return l.try_as<MenuFlyoutItem>().Text() < r.try_as<MenuFlyoutItem>().Text();
 		}
 	});
 
@@ -131,8 +131,8 @@ void ScalingModesPage::_BuildEffectMenu() noexcept {
 		std::vector<MenuFlyoutItemBase> itemsVec(items.Size(), nullptr);
 		items.GetMany(0, itemsVec);
 		std::sort(itemsVec.begin(), itemsVec.end(), [](const MenuFlyoutItemBase& l, const MenuFlyoutItemBase& r) {
-			hstring lEffectName = unbox_value<hstring>(l.as<MenuFlyoutItem>().Tag());
-			hstring rEffectName = unbox_value<hstring>(r.as<MenuFlyoutItem>().Tag());
+			hstring lEffectName = unbox_value<hstring>(l.try_as<MenuFlyoutItem>().Tag());
+			hstring rEffectName = unbox_value<hstring>(r.try_as<MenuFlyoutItem>().Tag());
 
 			const EffectInfo* lEffectInfo = EffectsService::Get().GetEffect(lEffectName);
 			const EffectInfo* rEffectInfo = EffectsService::Get().GetEffect(rEffectName);
@@ -148,7 +148,7 @@ void ScalingModesPage::_BuildEffectMenu() noexcept {
 }
 
 void ScalingModesPage::_AddEffectMenuFlyoutItem_Click(IInspectable const& sender, RoutedEventArgs const&) {
-	hstring effectName = unbox_value<hstring>(sender.as<MenuFlyoutItem>().Tag());
+	hstring effectName = unbox_value<hstring>(sender.try_as<MenuFlyoutItem>().Tag());
 	_curScalingMode->AddEffect(effectName);
 }
 

--- a/src/Magpie/ScalingModesPage.xaml
+++ b/src/Magpie/ScalingModesPage.xaml
@@ -215,7 +215,7 @@
 																	</ListView.Resources>
 																	<ListView.ItemTemplate>
 																		<DataTemplate x:DataType="x:String">
-																			<TextBlock local:TextBlockHelper.IsAutoTooltip="True"
+																			<TextBlock local:TextBlockHelper.IsAutoTooltipEnabled="True"
 																			           FontStyle="Italic"
 																			           Text="{x:Bind Mode=OneTime}"
 																			           TextTrimming="CharacterEllipsis" />

--- a/src/Magpie/SettingsCard.Resource.xaml
+++ b/src/Magpie/SettingsCard.Resource.xaml
@@ -232,8 +232,7 @@
 							         Visibility="Collapsed">
 								<ContentPresenter x:Name="PART_ActionIconPresenter"
 								                  Content="{TemplateBinding ActionIcon}"
-								                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
-								                  ToolTipService.ToolTip="{TemplateBinding ActionIconToolTip}" />
+								                  FontFamily="{ThemeResource SymbolThemeFontFamily}" />
 							</Viewbox>
 							<VisualStateManager.VisualStateGroups>
 								<VisualStateGroup x:Name="CommonStates">

--- a/src/Magpie/SettingsCard.cpp
+++ b/src/Magpie/SettingsCard.cpp
@@ -47,7 +47,6 @@ DependencyProperty SettingsCard::_headerProperty{ nullptr };
 DependencyProperty SettingsCard::_descriptionProperty{ nullptr };
 DependencyProperty SettingsCard::_headerIconProperty{ nullptr };
 DependencyProperty SettingsCard::_actionIconProperty{ nullptr };
-DependencyProperty SettingsCard::_actionIconToolTipProperty{ nullptr };
 DependencyProperty SettingsCard::_isClickEnabledProperty{ nullptr };
 DependencyProperty SettingsCard::_contentAlignmentProperty{ nullptr };
 DependencyProperty SettingsCard::_isActionIconVisibleProperty{ nullptr };
@@ -60,7 +59,7 @@ SettingsCard::SettingsCard() {
 SettingsCard::~SettingsCard() {
 	// 不知为何必须手动释放 StateTriggers，否则会内存泄露
 	if (auto stateGroup = GetTemplateChild(ContentAlignmentStates)) {
-		for (VisualState state : stateGroup.as<VisualStateGroup>().States()) {
+		for (VisualState state : stateGroup.try_as<VisualStateGroup>().States()) {
 			state.StateTriggers().Clear();
 		}
 	}
@@ -72,7 +71,7 @@ void SettingsCard::RegisterDependencyProperties() {
 		xaml_typename<IInspectable>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(nullptr, [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsCard>(sender.as<class_type>())->_OnHeaderChanged();
+			get_self<SettingsCard>(sender.try_as<class_type>())->_OnHeaderChanged();
 		})
 	);
 
@@ -81,7 +80,7 @@ void SettingsCard::RegisterDependencyProperties() {
 		xaml_typename<IInspectable>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(nullptr, [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsCard>(sender.as<class_type>())->_OnDescriptionChanged();
+			get_self<SettingsCard>(sender.try_as<class_type>())->_OnDescriptionChanged();
 		})
 	);
 
@@ -90,7 +89,7 @@ void SettingsCard::RegisterDependencyProperties() {
 		xaml_typename<IconElement>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(nullptr, [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsCard>(sender.as<class_type>())->_OnHeaderIconChanged();
+			get_self<SettingsCard>(sender.try_as<class_type>())->_OnHeaderIconChanged();
 		})
 	);
 
@@ -101,19 +100,12 @@ void SettingsCard::RegisterDependencyProperties() {
 		PropertyMetadata(box_value(L"\ue974"))
 	);
 
-	_actionIconToolTipProperty = DependencyProperty::Register(
-		L"ActionIconToolTip",
-		xaml_typename<hstring>(),
-		xaml_typename<class_type>(),
-		nullptr
-	);
-
 	_isClickEnabledProperty = DependencyProperty::Register(
 		L"IsClickEnabled",
 		xaml_typename<bool>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(box_value(false), [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsCard>(sender.as<class_type>())->_OnIsClickEnabledChanged();
+			get_self<SettingsCard>(sender.try_as<class_type>())->_OnIsClickEnabledChanged();
 		})
 	);
 
@@ -129,7 +121,7 @@ void SettingsCard::RegisterDependencyProperties() {
 		xaml_typename<bool>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(box_value(true), [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsCard>(sender.as<class_type>())->_OnActionIconChanged();
+			get_self<SettingsCard>(sender.try_as<class_type>())->_OnActionIconChanged();
 		})
 	);
 
@@ -138,7 +130,7 @@ void SettingsCard::RegisterDependencyProperties() {
 		xaml_typename<bool>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(box_value(false), [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsCard>(sender.as<class_type>())->_OnIsWrapEnabledChanged();
+			get_self<SettingsCard>(sender.try_as<class_type>())->_OnIsWrapEnabledChanged();
 		})
 	);
 }
@@ -149,7 +141,7 @@ void SettingsCard::OnApplyTemplate() {
 	// https://github.com/microsoft/microsoft-ui-xaml/issues/7792
 	// 对于 Content，模板中的样式不起作用
 	auto resources = Resources();
-	for (const auto& [key, value] : GetTemplateChild(RootGrid).as<Grid>().Resources()) {
+	for (const auto& [key, value] : GetTemplateChild(RootGrid).try_as<Grid>().Resources()) {
 		resources.Insert(key, value);
 	}
 
@@ -165,7 +157,7 @@ void SettingsCard::OnApplyTemplate() {
 	_OnDescriptionChanged();
 	_OnIsClickEnabledChanged();
 
-	VisualStateGroup contentAlignmentStatesGroup = GetTemplateChild(ContentAlignmentStates).as<VisualStateGroup>();
+	VisualStateGroup contentAlignmentStatesGroup = GetTemplateChild(ContentAlignmentStates).try_as<VisualStateGroup>();
 	_contentAlignmentStatesChangedRevoker = contentAlignmentStatesGroup.CurrentStateChanged(auto_revoke, [this](IInspectable const&, VisualStateChangedEventArgs const& args) {
 		_CheckVerticalSpacingState(args.NewState());
 	});
@@ -255,8 +247,8 @@ void SettingsCard::_OnIsWrapEnabledChanged() const {
 	if (trigger1 && trigger2) {
 		// CanTrigger 无法使用 TemplateBinding?
 		const bool isWrapEnabled = IsWrapEnabled();
-		trigger1.as<ControlSizeTrigger>().CanTrigger(isWrapEnabled);
-		trigger2.as<ControlSizeTrigger>().CanTrigger(isWrapEnabled);
+		trigger1.try_as<ControlSizeTrigger>().CanTrigger(isWrapEnabled);
+		trigger2.try_as<ControlSizeTrigger>().CanTrigger(isWrapEnabled);
 	}
 }
 

--- a/src/Magpie/SettingsCard.h
+++ b/src/Magpie/SettingsCard.h
@@ -13,7 +13,6 @@ struct SettingsCard : SettingsCardT<SettingsCard> {
 	static DependencyProperty DescriptionProperty() { return _descriptionProperty; }
 	static DependencyProperty HeaderIconProperty() { return _headerIconProperty; }
 	static DependencyProperty ActionIconProperty() { return _actionIconProperty; }
-	static DependencyProperty ActionIconToolTipProperty() { return _actionIconToolTipProperty; }
 	static DependencyProperty IsClickEnabledProperty() { return _isClickEnabledProperty; }
 	static DependencyProperty ContentAlignmentProperty() { return _contentAlignmentProperty; }
 	static DependencyProperty IsActionIconVisibleProperty() { return _isActionIconVisibleProperty; }
@@ -25,25 +24,22 @@ struct SettingsCard : SettingsCardT<SettingsCard> {
 	IInspectable Description() const { return GetValue(_descriptionProperty); }
 	void Description(IInspectable const& value) const { SetValue(_descriptionProperty, value); }
 
-	IconElement HeaderIcon() const { return GetValue(_headerIconProperty).as<IconElement>(); }
+	IconElement HeaderIcon() const { return GetValue(_headerIconProperty).try_as<IconElement>(); }
 	void HeaderIcon(IconElement const& value) const { SetValue(_headerIconProperty, value); }
 
-	IconElement ActionIcon() const { return GetValue(_actionIconProperty).as<IconElement>(); }
+	IconElement ActionIcon() const { return GetValue(_actionIconProperty).try_as<IconElement>(); }
 	void ActionIcon(IconElement const& value) const { SetValue(_actionIconProperty, value); }
 
-	hstring ActionIconToolTip() const { return GetValue(_actionIconToolTipProperty).as<hstring>(); }
-	void ActionIconToolTip(const hstring& value) const { SetValue(_actionIconToolTipProperty, box_value(value)); }
-
-	bool IsClickEnabled() const { return GetValue(_isClickEnabledProperty).as<bool>(); }
+	bool IsClickEnabled() const { return GetValue(_isClickEnabledProperty).try_as<bool>().value(); }
 	void IsClickEnabled(bool value) const { SetValue(_isClickEnabledProperty, box_value(value)); }
 
-	ContentAlignment ContentAlignment() const { return GetValue(_contentAlignmentProperty).as<Magpie::ContentAlignment>(); }
+	ContentAlignment ContentAlignment() const { return GetValue(_contentAlignmentProperty).try_as<Magpie::ContentAlignment>().value(); }
 	void ContentAlignment(Magpie::ContentAlignment value) const { SetValue(_contentAlignmentProperty, box_value(value)); }
 
-	bool IsActionIconVisible() const { return GetValue(_isActionIconVisibleProperty).as<bool>(); }
+	bool IsActionIconVisible() const { return GetValue(_isActionIconVisibleProperty).try_as<bool>().value(); }
 	void IsActionIconVisible(bool value) const { SetValue(_isActionIconVisibleProperty, box_value(value)); }
 
-	bool IsWrapEnabled() const { return GetValue(_isWrapEnabledProperty).as<bool>(); }
+	bool IsWrapEnabled() const { return GetValue(_isWrapEnabledProperty).try_as<bool>().value(); }
 	void IsWrapEnabled(bool value) const { SetValue(_isWrapEnabledProperty, box_value(value)); }
 
 	void OnApplyTemplate();
@@ -57,7 +53,6 @@ private:
 	static DependencyProperty _descriptionProperty;
 	static DependencyProperty _headerIconProperty;
 	static DependencyProperty _actionIconProperty;
-	static DependencyProperty _actionIconToolTipProperty;
 	static DependencyProperty _isClickEnabledProperty;
 	static DependencyProperty _contentAlignmentProperty;
 	static DependencyProperty _isActionIconVisibleProperty;

--- a/src/Magpie/SettingsCard.idl
+++ b/src/Magpie/SettingsCard.idl
@@ -29,7 +29,6 @@ namespace Magpie{
 		static Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty HeaderIconProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty ActionIconProperty { get; };
-		static Windows.UI.Xaml.DependencyProperty ActionIconToolTipProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty IsClickEnabledProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty ContentAlignmentProperty { get; };
 		static Windows.UI.Xaml.DependencyProperty IsActionIconVisibleProperty { get; };
@@ -39,7 +38,6 @@ namespace Magpie{
 		Object Description;
 		Windows.UI.Xaml.Controls.IconElement HeaderIcon;
 		Windows.UI.Xaml.Controls.IconElement ActionIcon;
-		String ActionIconToolTip;
 		Boolean IsClickEnabled;
 		ContentAlignment ContentAlignment;
 		Boolean IsActionIconVisible;

--- a/src/Magpie/SettingsExpander.cpp
+++ b/src/Magpie/SettingsExpander.cpp
@@ -91,7 +91,7 @@ void SettingsExpander::RegisterDependencyProperties() {
 		xaml_typename<IVector<IInspectable>>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(nullptr, [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsExpander>(sender.as<class_type>())->_OnItemsConnectedPropertyChanged();
+			get_self<SettingsExpander>(sender.try_as<class_type>())->_OnItemsConnectedPropertyChanged();
 		})
 	);
 
@@ -100,7 +100,7 @@ void SettingsExpander::RegisterDependencyProperties() {
 		xaml_typename<IInspectable>(),
 		xaml_typename<class_type>(),
 		PropertyMetadata(nullptr, [](DependencyObject const& sender, DependencyPropertyChangedEventArgs const&) {
-			get_self<SettingsExpander>(sender.as<class_type>())->_OnItemsConnectedPropertyChanged();
+			get_self<SettingsExpander>(sender.try_as<class_type>())->_OnItemsConnectedPropertyChanged();
 		})
 	);
 
@@ -146,9 +146,9 @@ void SettingsExpander::OnApplyTemplate() {
 }
 
 void SettingsExpander::_OnIsExpandedChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args) {
-	SettingsExpander* that = get_self<SettingsExpander>(sender.as<class_type>());
+	SettingsExpander* that = get_self<SettingsExpander>(sender.try_as<class_type>());
 
-	if (args.NewValue().as<bool>()) {
+	if (args.NewValue().try_as<bool>().value()) {
 		that->Expanded.Invoke();
 	} else {
 		that->Collapsed.Invoke();
@@ -160,7 +160,7 @@ void SettingsExpander::_OnIsExpandedChanged(DependencyObject const& sender, Depe
 }
 
 void SettingsExpander::_OnItemsConnectedPropertyChanged() {
-	ItemsControl itemsContainer = GetTemplateChild(PART_ItemsContainer).as<ItemsControl>();
+	ItemsControl itemsContainer = GetTemplateChild(PART_ItemsContainer).try_as<ItemsControl>();
 	if (!itemsContainer) {
 		return;
 	}
@@ -180,7 +180,7 @@ void SettingsExpander::_OnItemsConnectedPropertyChanged() {
 			const wchar_t* key = settingsCard.IsClickEnabled()
 				? L"ClickableSettingsExpanderItemStyle"
 				: L"DefaultSettingsExpanderItemStyle";
-			settingsCard.Style(resources.Lookup(box_value(key)).as<Windows::UI::Xaml::Style>());
+			settingsCard.Style(resources.Lookup(box_value(key)).try_as<Windows::UI::Xaml::Style>());
 		}
 	}
 }

--- a/src/Magpie/SettingsExpander.h
+++ b/src/Magpie/SettingsExpander.h
@@ -27,22 +27,22 @@ struct SettingsExpander : SettingsExpanderT<SettingsExpander> {
 	IInspectable Description() const { return GetValue(_descriptionProperty); }
 	void Description(IInspectable const& value) const { SetValue(_descriptionProperty, value); }
 
-	IconElement HeaderIcon() const { return GetValue(_headerIconProperty).as<IconElement>(); }
+	IconElement HeaderIcon() const { return GetValue(_headerIconProperty).try_as<IconElement>(); }
 	void HeaderIcon(IconElement const& value)const { SetValue(_headerIconProperty, value); }
 
 	IInspectable Content() const { return GetValue(_contentProperty); }
 	void Content(IInspectable const& value) const { SetValue(_contentProperty, value); }
 
-	UIElement ItemsHeader() const { return GetValue(_itemsHeaderProperty).as<UIElement>(); }
+	UIElement ItemsHeader() const { return GetValue(_itemsHeaderProperty).try_as<UIElement>(); }
 	void ItemsHeader(UIElement const& value) const { SetValue(_itemsHeaderProperty, value); }
 
-	UIElement ItemsFooter() const { return GetValue(_itemsFooterProperty).as<UIElement>(); }
+	UIElement ItemsFooter() const { return GetValue(_itemsFooterProperty).try_as<UIElement>(); }
 	void ItemsFooter(UIElement const& value) const { SetValue(_itemsFooterProperty, value); }
 
-	bool IsExpanded() const { return GetValue(_isExpandedProperty).as<bool>(); }
+	bool IsExpanded() const { return GetValue(_isExpandedProperty).try_as<bool>().value(); }
 	void IsExpanded(bool value) const { SetValue(_isExpandedProperty, box_value(value)); }
 
-	IVector<IInspectable> Items() const { return GetValue(_itemsProperty).as<IVector<IInspectable>>(); }
+	IVector<IInspectable> Items() const { return GetValue(_itemsProperty).try_as<IVector<IInspectable>>(); }
 	void Items(IVector<IInspectable> const& value) const { SetValue(_itemsProperty, value); }
 
 	IInspectable ItemsSource() const { return GetValue(_itemsSourceProperty); }
@@ -51,7 +51,7 @@ struct SettingsExpander : SettingsExpanderT<SettingsExpander> {
 	IInspectable ItemTemplate() const { return GetValue(_itemTemplateProperty); }
 	void ItemTemplate(IInspectable const& value) const { SetValue(_itemTemplateProperty, value); }
 
-	bool IsWrapEnabled() const { return GetValue(_isWrapEnabledProperty).as<bool>(); }
+	bool IsWrapEnabled() const { return GetValue(_isWrapEnabledProperty).try_as<bool>().value(); }
 	void IsWrapEnabled(bool value) const { SetValue(_isWrapEnabledProperty, box_value(value)); }
 
 	void OnApplyTemplate();

--- a/src/Magpie/SettingsGroup.cpp
+++ b/src/Magpie/SettingsGroup.cpp
@@ -43,7 +43,7 @@ void SettingsGroup::OnApplyTemplate() {
 }
 
 void SettingsGroup::_OnDescriptionChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args) {
-	SettingsGroup* that = get_self<SettingsGroup>(sender.as<class_type>());
+	SettingsGroup* that = get_self<SettingsGroup>(sender.try_as<class_type>());
 
 	if (FrameworkElement descriptionPresenter = that->GetTemplateChild(L"DescriptionPresenter").try_as<FrameworkElement>()) {
 		descriptionPresenter.Visibility(args.NewValue() == nullptr ? Visibility::Collapsed : Visibility::Visible);

--- a/src/Magpie/TextBlockHelper.cpp
+++ b/src/Magpie/TextBlockHelper.cpp
@@ -12,26 +12,26 @@ using namespace Windows::UI::Xaml::Controls;
 
 namespace winrt::Magpie::implementation {
 
-DependencyProperty TextBlockHelper::_isAutoTooltipProperty{ nullptr };
+DependencyProperty TextBlockHelper::_isAutoTooltipEnabledProperty{ nullptr };
 
 void TextBlockHelper::RegisterDependencyProperties() {
-    _isAutoTooltipProperty = DependencyProperty::RegisterAttached(
-        L"IsAutoTooltip",
+    _isAutoTooltipEnabledProperty = DependencyProperty::RegisterAttached(
+        L"IsAutoTooltipEnabled",
         xaml_typename<bool>(),
         { hstring(L"Magpie.TextBlockHelper"), Interop::TypeKind::Metadata },
-        PropertyMetadata(box_value(false), _OnIsAutoTooltipChanged)
+        PropertyMetadata(box_value(false), _OnIsAutoTooltipEnabledChanged)
     );
 }
 
-void TextBlockHelper::_OnIsAutoTooltipChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args) {
-    TextBlock tb = sender.as<TextBlock>();
+void TextBlockHelper::_OnIsAutoTooltipEnabledChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args) {
+    TextBlock tb = sender.try_as<TextBlock>();
 
-    bool newValue = args.NewValue().as<bool>();
+    bool newValue = args.NewValue().try_as<bool>().value();
     _SetTooltipBasedOnTrimmingState(tb, newValue);
 
     if (newValue) {
         tb.SizeChanged([](IInspectable const& sender, SizeChangedEventArgs const&) {
-            _SetTooltipBasedOnTrimmingState(sender.as<TextBlock>(), true);
+            _SetTooltipBasedOnTrimmingState(sender.try_as<TextBlock>(), true);
         });
         tb.RegisterPropertyChangedCallback(
             TextBlock::TextProperty(),
@@ -39,7 +39,7 @@ void TextBlockHelper::_OnIsAutoTooltipChanged(DependencyObject const& sender, De
                 // 等待布局更新
                 App::Get().Dispatcher().RunAsync(
                     CoreDispatcherPriority::Low,
-                    std::bind_front(&_SetTooltipBasedOnTrimmingState, sender.as<TextBlock>(), true)
+                    std::bind_front(&_SetTooltipBasedOnTrimmingState, sender.try_as<TextBlock>(), true)
                 );
             }
         );

--- a/src/Magpie/TextBlockHelper.h
+++ b/src/Magpie/TextBlockHelper.h
@@ -7,20 +7,20 @@ namespace winrt::Magpie::implementation {
 // https://stackoverflow.com/questions/21615593/how-can-i-automatically-show-a-tooltip-if-the-text-is-too-long
 struct TextBlockHelper {
     static void RegisterDependencyProperties();
-    static DependencyProperty IsAutoTooltipProperty() { return _isAutoTooltipProperty; }
+    static DependencyProperty IsAutoTooltipEnabledProperty() { return _isAutoTooltipEnabledProperty; }
 
-    static bool GetIsAutoTooltip(DependencyObject target) {
-        return unbox_value<bool>(target.GetValue(_isAutoTooltipProperty));
+    static bool GetIsAutoTooltipEnabled(DependencyObject target) {
+        return unbox_value<bool>(target.GetValue(_isAutoTooltipEnabledProperty));
     }
 
-    static void SetIsAutoTooltip(DependencyObject target, bool value) {
-        target.SetValue(_isAutoTooltipProperty, box_value(value));
+    static void SetIsAutoTooltipEnabled(DependencyObject target, bool value) {
+        target.SetValue(_isAutoTooltipEnabledProperty, box_value(value));
     }
 
 private:
-    static DependencyProperty _isAutoTooltipProperty;
+    static DependencyProperty _isAutoTooltipEnabledProperty;
 
-    static void _OnIsAutoTooltipChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args);
+    static void _OnIsAutoTooltipEnabledChanged(DependencyObject const& sender, DependencyPropertyChangedEventArgs const& args);
 
     static void _SetTooltipBasedOnTrimmingState(const TextBlock& tb, bool isAttached);
 };

--- a/src/Magpie/TextBlockHelper.idl
+++ b/src/Magpie/TextBlockHelper.idl
@@ -1,7 +1,7 @@
 namespace Magpie {
     static runtimeclass TextBlockHelper {
-        static Windows.UI.Xaml.DependencyProperty IsAutoTooltipProperty{ get; };
-        static Boolean GetIsAutoTooltip(Windows.UI.Xaml.DependencyObject target);
-        static void SetIsAutoTooltip(Windows.UI.Xaml.DependencyObject target, Boolean value);
+        static Windows.UI.Xaml.DependencyProperty IsAutoTooltipEnabledProperty{ get; };
+        static Boolean GetIsAutoTooltipEnabled(Windows.UI.Xaml.DependencyObject target);
+        static void SetIsAutoTooltipEnabled(Windows.UI.Xaml.DependencyObject target, Boolean value);
     }
 }

--- a/src/Magpie/TextMenuFlyout.cpp
+++ b/src/Magpie/TextMenuFlyout.cpp
@@ -31,9 +31,9 @@ void TextMenuFlyout::MenuFlyout_Opening(IInspectable const&, IInspectable const&
 		TextBox textBox = target.try_as<TextBox>();
 		if (!textBox) {
 			if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-				textBox = numberBox.as<IControlProtected>()
+				textBox = numberBox.try_as<IControlProtected>()
 					.GetTemplateChild(L"InputBox")
-					.as<TextBox>();
+					.try_as<TextBox>();
 			}
 		}
 		if (textBox) {
@@ -124,7 +124,7 @@ void TextMenuFlyout::Cut_Click(IInspectable const&, RoutedEventArgs const&) {
 	if (TextBox textBox = target.try_as<TextBox>()) {
 		textBox.CutSelectionToClipboard();
 	} else if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-		numberBox.as<IControlProtected>().GetTemplateChild(L"InputBox").as<TextBox>().CutSelectionToClipboard();
+		numberBox.try_as<IControlProtected>().GetTemplateChild(L"InputBox").try_as<TextBox>().CutSelectionToClipboard();
 	}
 }
 
@@ -137,9 +137,9 @@ void TextMenuFlyout::Copy_Click(IInspectable const&, RoutedEventArgs const&) {
 	if (TextBox textBox = target.try_as<TextBox>()) {
 		textBox.CopySelectionToClipboard();
 	} else if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-		numberBox.as<IControlProtected>()
+		numberBox.try_as<IControlProtected>()
 			.GetTemplateChild(L"InputBox")
-			.as<TextBox>()
+			.try_as<TextBox>()
 			.CopySelectionToClipboard();
 	}
 }
@@ -153,9 +153,9 @@ void TextMenuFlyout::Paste_Click(IInspectable const&, RoutedEventArgs const&) {
 	if (TextBox textBox = target.try_as<TextBox>()) {
 		textBox.PasteFromClipboard();
 	} else if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-		numberBox.as<IControlProtected>()
+		numberBox.try_as<IControlProtected>()
 			.GetTemplateChild(L"InputBox")
-			.as<TextBox>()
+			.try_as<TextBox>()
 			.PasteFromClipboard();
 	}
 }
@@ -169,9 +169,9 @@ void TextMenuFlyout::Undo_Click(IInspectable const&, RoutedEventArgs const&) {
 	if (TextBox textBox = target.try_as<TextBox>()) {
 		textBox.Undo();
 	} else if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-		numberBox.as<IControlProtected>()
+		numberBox.try_as<IControlProtected>()
 			.GetTemplateChild(L"InputBox")
-			.as<TextBox>()
+			.try_as<TextBox>()
 			.Undo();
 	}
 }
@@ -185,9 +185,9 @@ void TextMenuFlyout::Redo_Click(IInspectable const&, RoutedEventArgs const&) {
 	if (TextBox textBox = target.try_as<TextBox>()) {
 		textBox.Redo();
 	} else if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-		numberBox.as<IControlProtected>()
+		numberBox.try_as<IControlProtected>()
 			.GetTemplateChild(L"InputBox")
-			.as<TextBox>()
+			.try_as<TextBox>()
 			.Redo();
 	}
 }
@@ -207,9 +207,9 @@ void TextMenuFlyout::SelectAll_Click(IInspectable const&, RoutedEventArgs const&
 	if (TextBox textBox = target.try_as<TextBox>()) {
 		textBox.SelectAll();
 	} else if (MUXC::NumberBox numberBox = target.try_as<MUXC::NumberBox>()) {
-		numberBox.as<IControlProtected>()
+		numberBox.try_as<IControlProtected>()
 			.GetTemplateChild(L"InputBox")
-			.as<TextBox>()
+			.try_as<TextBox>()
 			.SelectAll();
 	}
 }

--- a/src/Magpie/ToastPage.cpp
+++ b/src/Magpie/ToastPage.cpp
@@ -138,7 +138,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 	UpdateToastPosition(_hwndToast, frameRect, true);
 
 	// 创建新的 TeachingTip
-	MUXC::TeachingTip curTeachingTip = FindName(L"MessageTeachingTip").as<MUXC::TeachingTip>();
+	MUXC::TeachingTip curTeachingTip = FindName(L"MessageTeachingTip").try_as<MUXC::TeachingTip>();
 	// 帮助 XAML 选择合适的字体，直接设置 TeachingTip 的 Language 属性无用
 	MessageTeachingTipContent().Language(LocalizationService::Get().Language());
 
@@ -158,11 +158,11 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 			return;
 		}
 
-		IControlProtected protectedAccessor = teachingTip.as<IControlProtected>();
+		IControlProtected protectedAccessor = teachingTip.try_as<IControlProtected>();
 
 		// 隐藏关闭按钮
 		if (DependencyObject closeButton = protectedAccessor.GetTemplateChild(L"AlternateCloseButton")) {
-			closeButton.as<FrameworkElement>().Visibility(Visibility::Collapsed);
+			closeButton.try_as<FrameworkElement>().Visibility(Visibility::Collapsed);
 		}
 
 		// 检查 Tag 记录，修复弹出动画只需执行一次

--- a/src/Magpie/XamlHelper.cpp
+++ b/src/Magpie/XamlHelper.cpp
@@ -59,7 +59,7 @@ void XamlHelper::UpdateThemeOfXamlPopups(const XamlRoot& root, ElementTheme them
 	}
 
 	for (const auto& popup : VisualTreeHelper::GetOpenPopupsForXamlRoot(root)) {
-		FrameworkElement child = popup.Child().as<FrameworkElement>();
+		FrameworkElement child = popup.Child().try_as<FrameworkElement>();
 		child.RequestedTheme(theme);
 		UpdateThemeOfTooltips(child, theme);
 	}

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -58,7 +58,7 @@ protected:
 
 		// 初始化 XAML Islands
 		_xamlSource = DesktopWindowXamlSource();
-		_xamlSourceNative2 = _xamlSource.as<IDesktopWindowXamlSourceNative2>();
+		_xamlSourceNative2 = _xamlSource.try_as<IDesktopWindowXamlSourceNative2>();
 		_xamlSourceNative2->AttachToWindow(this->Handle());
 		_xamlSourceNative2->get_WindowHandle(&_hwndXamlIsland);
 		_xamlSource.Content(*content);
@@ -360,7 +360,7 @@ protected:
 					// 来自 https://github.com/microsoft/microsoft-ui-xaml/issues/3577#issuecomment-1399250405
 					if (winrt::CoreWindow coreWindow = winrt::CoreWindow::GetForCurrentThread()) {
 						HWND hwndDWXS;
-						coreWindow.as<ICoreWindowInterop>()->get_WindowHandle(&hwndDWXS);
+						coreWindow.try_as<ICoreWindowInterop>()->get_WindowHandle(&hwndDWXS);
 						PostMessage(hwndDWXS, WM_SIZE, wParam, lParam);
 					}
 


### PR DESCRIPTION
try_as 不会抛出异常，这有助于减少二进制文件的体积。我们从不使用异常，如果有未处理的异常程序会中止，因此 as 换为 try_as 没有让情况变遭，只是从未处理异常而中止变为空指针访问而中止。

MSVC 编译的体积减少了 5KB，Clang 编译的体积减少了 7KB。

其他更改：删除 SettingsCard.ActionIconToolTip 属性，我们从未使用它。