### PR TITLE
全屏缩放默认不再置顶

### DIFF
--- a/src/Magpie.Core/AdaptivePresenter.h
+++ b/src/Magpie.Core/AdaptivePresenter.h
@@ -7,7 +7,7 @@ namespace Magpie {
 // 根据需要在交换链和 DirectComposition 两种呈现方式间切换。交换链可以触发
 // DirectFlip/IndependentFlip 以最小化延迟，DirectComposition 在调整尺寸
 // 时闪烁更少，这个呈现器旨在结合两者的优势。
-class AdaptivePresenter : public PresenterBase {
+class AdaptivePresenter final : public PresenterBase {
 protected:
 	bool _Initialize(HWND hwndAttach) noexcept override;
 

--- a/src/Magpie.Core/CompSwapchainPresenter.h
+++ b/src/Magpie.Core/CompSwapchainPresenter.h
@@ -5,7 +5,7 @@
 
 namespace Magpie {
 
-class CompSwapchainPresenter : public PresenterBase {
+class CompSwapchainPresenter final : public PresenterBase {
 protected:
 	bool _Initialize(HWND hwndAttach) noexcept override;
 

--- a/src/Magpie.Core/ScalingOptions.cpp
+++ b/src/Magpie.Core/ScalingOptions.cpp
@@ -36,46 +36,6 @@ static std::string LogEffects(const std::vector<EffectOption>& effects) noexcept
 	return result;
 }
 
-bool ScalingOptions::Prepare() noexcept {
-	if (screenshotsDir.empty()) {
-		Logger::Get().Error("screenshotsDir 为空");
-		return false;
-	}
-
-	if (!showToast) {
-		Logger::Get().Error("showToast 为空");
-		return false;
-	}
-
-	if (!showError) {
-		Logger::Get().Error("showError 为空");
-		return false;
-	}
-
-	if (!save) {
-		Logger::Get().Error("save 为空");
-		return false;
-	}
-
-	if (IsWindowedMode()) {
-		if (Is3DGameMode()) {
-			return false;
-		}
-
-		// Desktop Duplication 不支持窗口模式缩放
-		if (captureMethod == CaptureMethod::DesktopDuplication) {
-			captureMethod = CaptureMethod::GraphicsCapture;
-		}
-	}
-
-	// GDI 和 DwmSharedSurface 不支持捕获标题栏
-	if (captureMethod == CaptureMethod::GDI || captureMethod == CaptureMethod::DwmSharedSurface) {
-		IsCaptureTitleBar(false);
-	}
-
-	return true;
-}
-
 void ScalingOptions::Log() const noexcept {
 	Logger::Get().Info(fmt::format(R"(缩放选项
 	IsWindowedMode: {}

--- a/src/Magpie.Core/ScalingRuntime.cpp
+++ b/src/Magpie.Core/ScalingRuntime.cpp
@@ -51,9 +51,7 @@ ScalingRuntime::~ScalingRuntime() {
 }
 
 bool ScalingRuntime::Start(HWND hwndSrc, ScalingOptions&& options) {
-	if (!options.Prepare()) {
-		return false;
-	}
+	assert(!options.screenshotsDir.empty() && options.showToast && options.showError && options.save);
 
 	_Dispatcher().TryEnqueue([this, hwndSrc, options(std::move(options))]() mutable {
 		// 初始化时视为处于缩放状态

--- a/src/Magpie.Core/ScalingWindow.h
+++ b/src/Magpie.Core/ScalingWindow.h
@@ -7,7 +7,7 @@ namespace Magpie {
 
 class CursorManager;
 
-class ScalingWindow : public WindowBaseT<ScalingWindow> {
+class ScalingWindow final : public WindowBaseT<ScalingWindow> {
 	using base_type = WindowBaseT<ScalingWindow>;
 	friend base_type;
 

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -435,8 +435,10 @@ ScalingError SrcTracker::_CalcSrcRect(const ScalingOptions& options, LONG border
 		// DWM 绘制，前者无需裁剪，后者不能裁剪。
 		_srcRect = _windowRect;
 	} else {
+		const bool isCaptureTitleBar = options.RealIsCaptureTitleBar();
+		
 		// UWP 窗口都是 NoTitleBar 类型，但可能使用子窗口作为“客户区”
-		if (_windowKind == SrcWindowKind::NoTitleBar && !options.IsCaptureTitleBar() && GetClientRectOfUWP(_hWnd, _srcRect)) {
+		if (_windowKind == SrcWindowKind::NoTitleBar && !isCaptureTitleBar && GetClientRectOfUWP(_hWnd, _srcRect)) {
 			_srcRect.top = std::max(_srcRect.top, _windowFrameRect.top + borderThicknessInFrame);
 		} else {
 			_srcRect.left = _windowFrameRect.left + borderThicknessInFrame;
@@ -444,7 +446,7 @@ ScalingError SrcTracker::_CalcSrcRect(const ScalingOptions& options, LONG border
 			_srcRect.right = _windowFrameRect.right - borderThicknessInFrame;
 			_srcRect.bottom = _windowFrameRect.bottom - borderThicknessInFrame;
 
-			if (!options.IsCaptureTitleBar() || _windowKind == SrcWindowKind::OnlyThickFrame) {
+			if (!isCaptureTitleBar || _windowKind == SrcWindowKind::OnlyThickFrame) {
 				RECT clientRect;
 				if (!Win32Helper::GetClientScreenRect(_hWnd, clientRect)) {
 					Logger::Get().Error("GetClientScreenRect 失败");

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -608,6 +608,8 @@ bool AppSettings::_Save(const _AppSettingsData& data) noexcept {
 	writer.Double(data._minFrameRate);
 	writer.Key("disableFP16");
 	writer.Bool(data._isFP16Disabled);
+	writer.Key("keepOnTop");
+	writer.Bool(data._isKeepOnTop);
 
 	ScalingModesService::Get().Export(writer);
 
@@ -808,6 +810,7 @@ void AppSettings::_LoadSettings(const rapidjson::GenericObject<true, rapidjson::
 	JsonHelper::ReadBool(root, "enableStatisticsForDynamicDetection", _isStatisticsForDynamicDetectionEnabled);
 	JsonHelper::ReadFloat(root, "minFrameRate", _minFrameRate);
 	JsonHelper::ReadBool(root, "disableFP16", _isFP16Disabled);
+	JsonHelper::ReadBool(root, "keepOnTop", _isKeepOnTop);
 
 	[[maybe_unused]] bool result = ScalingModesService::Get().Import(root, true);
 	assert(result);

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -75,6 +75,7 @@ struct _AppSettingsData {
 	bool _isCheckForPreviewUpdates = false;
 	bool _isStatisticsForDynamicDetectionEnabled = false;
 	bool _isFP16Disabled = false;
+	bool _isKeepOnTop = false;
 };
 
 class AppSettings : private _AppSettingsData {
@@ -203,6 +204,15 @@ public:
 
 	void IsFP16Disabled(bool value) noexcept {
 		_isFP16Disabled = value;
+		SaveAsync();
+	}
+
+	bool IsKeepOnTop() const noexcept {
+		return _isKeepOnTop;
+	}
+
+	void IsKeepOnTop(bool value) noexcept {
+		_isKeepOnTop = value;
 		SaveAsync();
 	}
 

--- a/src/Magpie/HomePage.xaml
+++ b/src/Magpie/HomePage.xaml
@@ -111,7 +111,7 @@
 				</local:SettingsCard>
 				<local:SettingsExpander x:Uid="Home_Toolbar_InitialState">
 					<local:SettingsExpander.HeaderIcon>
-						<FontIcon Glyph="&#xE840;" />
+						<FontIcon Glyph="&#xE890;" />
 					</local:SettingsExpander.HeaderIcon>
 					<local:SettingsExpander.Content>
 						<TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -193,12 +193,12 @@
 					<ToggleSwitch x:Uid="ToggleSwitch"
 					              IsOn="{x:Bind ViewModel.IsAllowScalingMaximized, Mode=TwoWay}" />
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Home_Advanced_InlineParams">
+				<local:SettingsCard x:Uid="Home_Advanced_KeepOnTop">
 					<local:SettingsCard.HeaderIcon>
-						<FontIcon Glyph="&#xE9E9;" />
+						<FontIcon Glyph="&#xE718;" />
 					</local:SettingsCard.HeaderIcon>
 					<ToggleSwitch x:Uid="ToggleSwitch"
-					              IsOn="{x:Bind ViewModel.IsInlineParams, Mode=TwoWay}" />
+					              IsOn="{x:Bind ViewModel.IsKeepOnTop, Mode=TwoWay}" />
 				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Home_Advanced_SimulateExclusiveFullscreen">
 					<local:SettingsCard.HeaderIcon>
@@ -211,6 +211,13 @@
 				              IsClosable="False"
 				              IsOpen="{x:Bind ViewModel.IsSimulateExclusiveFullscreen, Mode=OneWay}"
 				              Severity="Warning" />
+				<local:SettingsCard x:Uid="Home_Advanced_InlineParams">
+					<local:SettingsCard.HeaderIcon>
+						<FontIcon Glyph="&#xE9E9;" />
+					</local:SettingsCard.HeaderIcon>
+					<ToggleSwitch x:Uid="ToggleSwitch"
+					              IsOn="{x:Bind ViewModel.IsInlineParams, Mode=TwoWay}" />
+				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Home_Advanced_MinFrameRate"
 				                    IsWrapEnabled="True">
 					<local:SettingsCard.HeaderIcon>

--- a/src/Magpie/HomeViewModel.cpp
+++ b/src/Magpie/HomeViewModel.cpp
@@ -314,26 +314,33 @@ bool HomeViewModel::IsAllowScalingMaximized() const noexcept {
 }
 
 void HomeViewModel::IsAllowScalingMaximized(bool value) {
-	AppSettings::Get().IsAllowScalingMaximized(value);
+	AppSettings& settings = AppSettings::Get();
+
+	if (settings.IsAllowScalingMaximized() == value) {
+		return;
+	}
+
+	settings.IsAllowScalingMaximized(value);
+	RaisePropertyChanged(L"IsAllowScalingMaximized");
 
 	if (value) {
 		ScalingService::Get().CheckForeground();
 	}
 }
 
-bool HomeViewModel::IsInlineParams() const noexcept {
-	return AppSettings::Get().IsInlineParams();
+bool HomeViewModel::IsKeepOnTop() const noexcept {
+	return AppSettings::Get().IsKeepOnTop();
 }
 
-void HomeViewModel::IsInlineParams(bool value) {
+void HomeViewModel::IsKeepOnTop(bool value) {
 	AppSettings& settings = AppSettings::Get();
 
-	if (settings.IsInlineParams() == value) {
+	if (settings.IsKeepOnTop() == value) {
 		return;
 	}
 
-	settings.IsInlineParams(value);
-	RaisePropertyChanged(L"IsInlineParams");
+	settings.IsKeepOnTop(value);
+	RaisePropertyChanged(L"IsKeepOnTop");
 }
 
 bool HomeViewModel::IsSimulateExclusiveFullscreen() const noexcept {
@@ -349,6 +356,21 @@ void HomeViewModel::IsSimulateExclusiveFullscreen(bool value) {
 
 	settings.IsSimulateExclusiveFullscreen(value);
 	RaisePropertyChanged(L"IsSimulateExclusiveFullscreen");
+}
+
+bool HomeViewModel::IsInlineParams() const noexcept {
+	return AppSettings::Get().IsInlineParams();
+}
+
+void HomeViewModel::IsInlineParams(bool value) {
+	AppSettings& settings = AppSettings::Get();
+
+	if (settings.IsInlineParams() == value) {
+		return;
+	}
+
+	settings.IsInlineParams(value);
+	RaisePropertyChanged(L"IsInlineParams");
 }
 
 static constexpr std::array MIN_FRAME_RATE_OPTIONS{ 0,5,10,15,20,30,60 };

--- a/src/Magpie/HomeViewModel.h
+++ b/src/Magpie/HomeViewModel.h
@@ -63,11 +63,14 @@ struct HomeViewModel : HomeViewModelT<HomeViewModel>, wil::notify_property_chang
 	bool IsAllowScalingMaximized() const noexcept;
 	void IsAllowScalingMaximized(bool value);
 
-	bool IsInlineParams() const noexcept;
-	void IsInlineParams(bool value);
+	bool IsKeepOnTop() const noexcept;
+	void IsKeepOnTop(bool value);
 
 	bool IsSimulateExclusiveFullscreen() const noexcept;
 	void IsSimulateExclusiveFullscreen(bool value);
+
+	bool IsInlineParams() const noexcept;
+	void IsInlineParams(bool value);
 
 	static IVector<IInspectable> MinFrameRateOptions();
 

--- a/src/Magpie/HomeViewModel.idl
+++ b/src/Magpie/HomeViewModel.idl
@@ -28,8 +28,9 @@ namespace Magpie {
 		Boolean IsShowTouchSupportInfoBar { get; };
 
 		Boolean IsAllowScalingMaximized;
-		Boolean IsInlineParams;
+		Boolean IsKeepOnTop;
 		Boolean IsSimulateExclusiveFullscreen;
+		Boolean IsInlineParams;
 		static IVector<IInspectable> MinFrameRateOptions { get; };
 		Int32 MinFrameRateIndex;
 

--- a/src/Magpie/MainWindow.h
+++ b/src/Magpie/MainWindow.h
@@ -4,7 +4,7 @@
 
 namespace Magpie {
 
-class MainWindow : public XamlWindowT<MainWindow, winrt::com_ptr<winrt::Magpie::implementation::RootPage>> {
+class MainWindow final : public XamlWindowT<MainWindow, winrt::com_ptr<winrt::Magpie::implementation::RootPage>> {
 	using base_type = XamlWindowT<MainWindow, winrt::com_ptr<winrt::Magpie::implementation::RootPage>>;
 	friend WindowBaseT<MainWindow>;
 public:

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -184,6 +184,10 @@
 					          ItemsSource="{x:Bind ViewModel.CaptureMethods, Mode=OneTime}"
 					          SelectedIndex="{x:Bind ViewModel.CaptureMethod, Mode=TwoWay}" />
 				</local:SettingsCard>
+				<muxc:InfoBar x:Uid="Profile_General_DesktopDuplicationWarning"
+				              IsClosable="False"
+				              IsOpen="{x:Bind ViewModel.IsCaptureMethodDesktopDuplication, Mode=OneWay}"
+				              Severity="Warning" />
 				<local:SettingsCard x:Name="AutoScaleSettingsCard"
 				                    x:Uid="Profile_General_AutoScale"
 				                    x:Load="{x:Bind ViewModel.IsNotDefaultProfile, Mode=OneTime}"

--- a/src/Magpie/ProfileViewModel.cpp
+++ b/src/Magpie/ProfileViewModel.cpp
@@ -367,9 +367,14 @@ void ProfileViewModel::CaptureMethod(int value) {
 
 	_data->captureMethod = captureMethod;
 	RaisePropertyChanged(L"CaptureMethod");
+	RaisePropertyChanged(L"IsCaptureMethodDesktopDuplication");
 	RaisePropertyChanged(L"CanCaptureTitleBar");
 
 	AppSettings::Get().SaveAsync();
+}
+
+bool ProfileViewModel::IsCaptureMethodDesktopDuplication() const noexcept {
+	return _data->captureMethod == CaptureMethod::DesktopDuplication;
 }
 
 int ProfileViewModel::AutoScale() const noexcept {

--- a/src/Magpie/ProfileViewModel.h
+++ b/src/Magpie/ProfileViewModel.h
@@ -65,6 +65,8 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel>,
 	int CaptureMethod() const noexcept;
 	void CaptureMethod(int value);
 
+	bool IsCaptureMethodDesktopDuplication() const noexcept;
+
 	int AutoScale() const noexcept;
 	void AutoScale(int value);
 

--- a/src/Magpie/ProfileViewModel.idl
+++ b/src/Magpie/ProfileViewModel.idl
@@ -28,6 +28,7 @@ namespace Magpie {
 
 		IVector<IInspectable> CaptureMethods { get; };
 		Int32 CaptureMethod;
+		Boolean IsCaptureMethodDesktopDuplication { get; };
 
 		Int32 AutoScale;
 		Boolean Is3DGameMode;

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -601,7 +601,7 @@
     <value>Make effect parameters inline</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
-    <value>Notifications and pop-ups from certain applications will be blocked</value>
+    <value>Applies only to fullscreen scaling. Suppresses certain app notifications and pop-ups when enabled</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Simulate exclusive fullscreen when scaling</value>
@@ -872,7 +872,7 @@
     <value>Windowed scaling shortcut</value>
   </data>
   <data name="Home_Advanced_AllowScalingMaximized.Description" xml:space="preserve">
-    <value>Applies to fullscreen scaling only</value>
+    <value>Applies only to fullscreen scaling</value>
   </data>
   <data name="Home_Toolbar.Description" xml:space="preserve">
     <value>The toolbar appears at the top of the scaled window, providing features like FPS display and screenshot capture. In windowed mode, it also allows dragging the scaled window.</value>
@@ -999,5 +999,17 @@
   </data>
   <data name="Home_Advanced_DeveloperOptions_LocateLogs.Header" xml:space="preserve">
     <value>Open logs location</value>
+  </data>
+  <data name="Home_Advanced_KeepOnTop.Description" xml:space="preserve">
+    <value>Applies only to fullscreen scaling. When enabled, the scaled window stays on top while in the foreground to minimize distractions, though it may obscure menus and pop-ups. It also helps reduce latency on GPUs without Multi-Plane Overlay support</value>
+  </data>
+  <data name="Home_Advanced_KeepOnTop.Header" xml:space="preserve">
+    <value>Keep scaled window on top</value>
+  </data>
+  <data name="Message_WindowedDesktopDuplication" xml:space="preserve">
+    <value>Windowed scaling is not supported with Desktop Duplication capture.</value>
+  </data>
+  <data name="Profile_General_DesktopDuplicationWarning.Title" xml:space="preserve">
+    <value>This capture method is incompatible with windowed scaling.</value>
   </data>
 </root>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -601,7 +601,7 @@
     <value>内联效果参数</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
-    <value>可以阻止某些应用的通知和弹窗</value>
+    <value>仅适用于全屏模式缩放。启用后可以阻止某些应用的通知和弹窗</value>
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>缩放时模拟独占全屏</value>
@@ -999,5 +999,17 @@
   </data>
   <data name="Home_Advanced_DeveloperOptions_LocateLogs.Header" xml:space="preserve">
     <value>打开日志位置</value>
+  </data>
+  <data name="Home_Advanced_KeepOnTop.Description" xml:space="preserve">
+    <value>仅适用于全屏模式缩放。启用后当缩放窗口位于前台时将置顶以减少干扰，但可能会遮挡菜单和弹窗。如果显卡不支持多平面叠加（MPO），此选项也有助于降低延迟</value>
+  </data>
+  <data name="Home_Advanced_KeepOnTop.Header" xml:space="preserve">
+    <value>置顶缩放窗口</value>
+  </data>
+  <data name="Message_WindowedDesktopDuplication" xml:space="preserve">
+    <value>Desktop Duplication 捕获不支持窗口模式缩放。</value>
+  </data>
+  <data name="Profile_General_DesktopDuplicationWarning.Title" xml:space="preserve">
+    <value>此捕获方式和窗口模式缩放不兼容。</value>
   </data>
 </root>

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -167,6 +167,10 @@ static void ShowError(HWND hWnd, ScalingError error) noexcept {
 		key = L"Message_Windowed3DGameMode";
 		isFail = false;
 		break;
+	case ScalingError::WindowedDesktopDuplication:
+		key = L"Message_WindowedDesktopDuplication";
+		isFail = false;
+		break;
 	case ScalingError::InvalidSourceWindow:
 		key = L"Message_InvalidSourceWindow";
 		break;
@@ -434,6 +438,7 @@ ScalingError ScalingService::_StartScaleImpl(HWND hWnd, const Profile& profile, 
 	options.IsStatisticsForDynamicDetectionEnabled(settings.IsStatisticsForDynamicDetectionEnabled());
 	options.IsInlineParams(settings.IsInlineParams());
 	options.IsFP16Disabled(settings.IsFP16Disabled());
+	options.IsKeepOnTop(settings.IsKeepOnTop());
 
 	if (options.maxFrameRate) {
 		// 最小帧数不能大于最大帧数

--- a/src/Magpie/Shortcut.h
+++ b/src/Magpie/Shortcut.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <winrt/Magpie.h>
-#include <variant>
-#include "SmallVector.h"
 
 namespace Magpie {
 

--- a/src/Magpie/ToastPage.cpp
+++ b/src/Magpie/ToastPage.cpp
@@ -114,7 +114,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 	// 的 IL 更高或是 UWP 窗口就会发生这种情况。
 	SetLastError(0);
 	const bool isOwned = TrySetOwnder(_hwndToast, hwndTarget);
-	bool isTargetTopMost = GetWindowExStyle(_hwndToast) & WS_EX_TOPMOST;
+	bool isTargetTopMost = GetWindowExStyle(hwndTarget) & WS_EX_TOPMOST;
 	if (isOwned) {
 		// _hwndToast 的输入已被附加到了 hWnd 上，这是所有者窗口的默认行为，但我们不需要。
 		// 见 https://devblogs.microsoft.com/oldnewthing/20130412-00/?p=4683
@@ -249,7 +249,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 			co_return;
 		}
 
-		isTargetTopMost = GetWindowExStyle(_hwndToast) & WS_EX_TOPMOST;
+		isTargetTopMost = GetWindowExStyle(hwndTarget) & WS_EX_TOPMOST;
 		if (isTargetTopMost || (!isOwned && GetForegroundWindow() == (HWND)hwndTarget)) {
 			// 如果 hwndTarget 位于前台，定期将弹窗置顶
 			SetWindowPos(_hwndToast, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);


### PR DESCRIPTION
如果缩放窗口置顶会遮挡菜单和弹窗（主要是菜单，我们针对弹窗做了优化），收益却并不高。现在缩放窗口默认不再置顶，提供选项来恢复旧行为。

其他更改：

1. 窗口模式缩放不再支持模拟独占全屏
2. 使用 Desktop Duplication 捕获时禁止窗口模式缩放，旧行为是自动切换到 Graphics Capture
3. 修复消息弹窗会使窗口取消置顶的问题