### PR TITLE
开机启动始终最小化到系统托盘

### DIFF
--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -380,13 +380,12 @@ void AppSettings::IsAlwaysRunAsAdmin(bool value) noexcept {
 	}
 
 	_isAlwaysRunAsAdmin = value;
-	std::wstring arguments;
-	if (AutoStartHelper::IsAutoStartEnabled(arguments)) {
-		// 更新启动任务
-		AutoStartHelper::EnableAutoStart(value, _isShowNotifyIcon ? arguments.c_str() : nullptr);
-	}
-
 	SaveAsync();
+
+	// 更新启动任务
+	if (AutoStartHelper::IsAutoStartEnabled()) {
+		AutoStartHelper::EnableAutoStart(value);
+	}
 }
 
 void AppSettings::IsShowNotifyIcon(bool value) noexcept {

--- a/src/Magpie/AutoStartHelper.h
+++ b/src/Magpie/AutoStartHelper.h
@@ -3,9 +3,9 @@
 namespace Magpie {
 
 struct AutoStartHelper {
-	static bool EnableAutoStart(bool runElevated, const wchar_t* arguments) noexcept;
+	static bool EnableAutoStart(bool runElevated) noexcept;
 	static bool DisableAutoStart() noexcept;
-	static bool IsAutoStartEnabled(std::wstring& arguments) noexcept;
+	static bool IsAutoStartEnabled() noexcept;
 };
 
 }

--- a/src/Magpie/Resources.language-de.resw
+++ b/src/Magpie/Resources.language-de.resw
@@ -291,12 +291,6 @@
   <data name="Profile_Performance_GraphicsCard.Header" xml:space="preserve">
     <value>Grafikkarte</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Um diese Einstellung zu verwenden, müssen Sie die Option "Anwendung in der Taskleiste anzeigen" aktivieren</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Beim Starten in die Taskleiste minimieren</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Fehler</value>
   </data>

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -606,12 +606,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Simulate exclusive fullscreen when scaling</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>You need to turn on "Display the app on the system tray" to use this setting</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Minimize to system tray at startup</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Error</value>
   </data>

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -1006,4 +1006,7 @@
   <data name="Profile_General_DesktopDuplicationWarning.Title" xml:space="preserve">
     <value>This capture method is incompatible with windowed scaling.</value>
   </data>
+  <data name="Settings_Launch_RunAtStartup.Description" xml:space="preserve">
+    <value>The main window will not appear if "Display the app on the system tray" is enabled</value>
+  </data>
 </root>

--- a/src/Magpie/Resources.language-es.resw
+++ b/src/Magpie/Resources.language-es.resw
@@ -645,9 +645,6 @@
   <data name="Profile_Cursor_DrawCursor_ScaleFactor_NoScaling.Content" xml:space="preserve">
     <value>Sin escalado</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Debe activar "Mostrar la aplicación en la bandeja del sistema" para usar esta configuración</value>
-  </data>
   <data name="Profile_SourceWindow_CustomCropping_Right.Header" xml:space="preserve">
     <value>Derecha</value>
   </data>
@@ -656,9 +653,6 @@
   </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
     <value>Se bloquearán las notificaciones y ventanas emergentes de ciertas aplicaciones</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Minimizar a la bandeja del sistema al inicio</value>
   </data>
   <data name="Home_Advanced_DeveloperOptions.Description" xml:space="preserve">
     <value>Esta configuración es solo para uso de desarrollo</value>

--- a/src/Magpie/Resources.language-fr.resw
+++ b/src/Magpie/Resources.language-fr.resw
@@ -343,9 +343,6 @@
   <data name="Home_Advanced_DeveloperOptions.Description" xml:space="preserve">
     <value>Ces paramètres sont destinés à être utilisés pour le développement uniquement</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Vous devez activer l'option "Afficher l'application dans la barre d'état système" pour utiliser ce paramètre</value>
-  </data>
   <data name="About_OtherLinks_Repository.Text" xml:space="preserve">
     <value>Dépôt Github</value>
   </data>
@@ -369,9 +366,6 @@
   </data>
   <data name="Dialog_ExeFile" xml:space="preserve">
     <value>Fichier exécutable</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Minimiser dans la barre d'état au démarrage</value>
   </data>
   <data name="Home_UpdateCard_RemindMeLater.Content" xml:space="preserve">
     <value>Me le rappeler plus tard</value>

--- a/src/Magpie/Resources.language-id.resw
+++ b/src/Magpie/Resources.language-id.resw
@@ -606,14 +606,8 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Mensimulasikan layar penuh eksklusif saat melakukan penskalaan</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Anda harus mengaktifkan "Tampilkan aplikasi pada system tray" untuk menggunakan pengaturan ini</value>
-  </data>
   <data name="Home_Advanced_DeveloperOptions.Description" xml:space="preserve">
     <value>Pengaturan ini hanya untuk penggunaan pengembangan</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Meminimalkan ke baki sistem di startup</value>
   </data>
   <data name="AppSettings_Dialog_Exit" xml:space="preserve">
     <value>Keluar</value>

--- a/src/Magpie/Resources.language-it.resw
+++ b/src/Magpie/Resources.language-it.resw
@@ -453,12 +453,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
     <value>Le notifiche e i popup di determinate applicazioni verranno bloccati</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Devi attivare "Visualizza l'app nell'area notifiche" per utilizzare questa impostazione</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Riduci a icona nella barra delle notifiche all'avvio</value>
-  </data>
   <data name="Home_Advanced_InlineParams.Header" xml:space="preserve">
     <value>Mette i parametri dell'effetto in linea</value>
   </data>

--- a/src/Magpie/Resources.language-ja.resw
+++ b/src/Magpie/Resources.language-ja.resw
@@ -474,9 +474,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
     <value>特定アプリからの通知とポップアップをブロックできます</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>起動時、システムトレイに最小化</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>エラー</value>
   </data>
@@ -522,9 +519,6 @@
   </data>
   <data name="Profile_Cursor_DrawCursor_ScaleFactor.Header" xml:space="preserve">
     <value>スケーリング倍率</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>この項目を使用するには、「システムトレイにアプリを表示する」をオンにする必要があります</value>
   </data>
   <data name="Profile_Cursor_DrawCursor_ScaleFactor_SameAsSourceWindow.Content" xml:space="preserve">
     <value>ソースウィンドウと同じ</value>

--- a/src/Magpie/Resources.language-ko.resw
+++ b/src/Magpie/Resources.language-ko.resw
@@ -417,9 +417,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>스케일링 할 때 단독 전체 화면 시뮬레이션</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>이 설정을 사용하려면 "시스템 트레이에 앱 표시"를 켜야 합니다</value>
-  </data>
   <data name="Profile_Cursor_DrawCursor_ScaleFactor_SameAsSourceWindow.Content" xml:space="preserve">
     <value>소스 창과 동일</value>
   </data>
@@ -651,9 +648,6 @@
   </data>
   <data name="Home_Advanced_DeveloperOptions.Description" xml:space="preserve">
     <value>이 설정은 개발 전용입니다</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>부팅 시 시스템 트레이로 최소화</value>
   </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>오류</value>

--- a/src/Magpie/Resources.language-pl.resw
+++ b/src/Magpie/Resources.language-pl.resw
@@ -247,12 +247,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Symuluj wyłączny pełny ekran podczas skalowania</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Aby korzystać z tego ustawienia, należy włączyć opcję "Wyświetlaj aplikację w zasobniku systemowym"</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Minimalizuj do zasobnika systemowego przy starcie</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Błąd</value>
   </data>

--- a/src/Magpie/Resources.language-pt-BR.resw
+++ b/src/Magpie/Resources.language-pt-BR.resw
@@ -543,14 +543,8 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
     <value>Notificações e pop-ups de determinados aplicativos serão bloqueados</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Minimizar para a área de notificação na inicialização</value>
-  </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Simular tela cheia exclusiva durante o redimensionamento</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Você precisa ativar a opção "Exibir o aplicativo na área de notificação" para usar essa configuração</value>
   </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Erro</value>

--- a/src/Magpie/Resources.language-ru.resw
+++ b/src/Magpie/Resources.language-ru.resw
@@ -615,12 +615,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Симуляция эксклюзивного полного экрана при масштабировании</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Для использования этой настройки, включите "Отображать приложение в панели задач"</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Сворачивать на панель задач при запуске</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Ошибка</value>
   </data>

--- a/src/Magpie/Resources.language-ta.resw
+++ b/src/Magpie/Resources.language-ta.resw
@@ -657,12 +657,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>அளவிடும்போது பிரத்யேக முழுத்திரனை உருவகப்படுத்துங்கள்</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>இந்த அமைப்பைப் பயன்படுத்த நீங்கள் "கணினி தட்டில் பயன்பாட்டைக் காண்பி" இயக்க வேண்டும்</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>தொடக்கத்தில் கணினி தட்டில் குறைக்கவும்</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>பிழை</value>
   </data>

--- a/src/Magpie/Resources.language-tr.resw
+++ b/src/Magpie/Resources.language-tr.resw
@@ -570,12 +570,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>Ölçekleme sırasında orjinal tam ekranı taklit edin</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Bu ayarı kullanmak için "Uygulamayı sistem tepsisinde görüntüle" özelliğini açmanız gerekir</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Başlangıçta sistem tepsisine küçült</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Hata</value>
   </data>

--- a/src/Magpie/Resources.language-uk.resw
+++ b/src/Magpie/Resources.language-uk.resw
@@ -480,12 +480,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Description" xml:space="preserve">
     <value>Сповіщення та спливаючі вікна певних застосунків будуть заблоковані</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Для використання цього параметра потрібно ввімкнути "Відображати застосунок в системному треї"</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Згортання в системний трей під час запуску</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>Помилка</value>
   </data>

--- a/src/Magpie/Resources.language-vi.resw
+++ b/src/Magpie/Resources.language-vi.resw
@@ -691,12 +691,6 @@
   <data name="Settings_Launch_RunAtStartup.Header" xml:space="preserve">
     <value>Chạy khi khởi động</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>Bạn cần bật "Hiển thị trên thanh tác vụ" để sử dụng cài đặt này</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>Thu nhỏ về thanh tác vụ khi khởi động</value>
-  </data>
   <data name="ShortcutDialog_Cancel" xml:space="preserve">
     <value>Hủy</value>
   </data>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -606,12 +606,6 @@
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>缩放时模拟独占全屏</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>启用了“在系统托盘上显示应用程序”时才能使用此选项</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>启动时最小化到系统托盘</value>
-  </data>
   <data name="AppSettings_Dialog_Error" xml:space="preserve">
     <value>错误</value>
   </data>

--- a/src/Magpie/Resources.language-zh-Hans.resw
+++ b/src/Magpie/Resources.language-zh-Hans.resw
@@ -1006,4 +1006,7 @@
   <data name="Profile_General_DesktopDuplicationWarning.Title" xml:space="preserve">
     <value>此捕获方式和窗口模式缩放不兼容。</value>
   </data>
+  <data name="Settings_Launch_RunAtStartup.Description" xml:space="preserve">
+    <value>启用了“在系统托盘上显示应用程序”时将不会显示主窗口</value>
+  </data>
 </root>

--- a/src/Magpie/Resources.language-zh-Hant.resw
+++ b/src/Magpie/Resources.language-zh-Hant.resw
@@ -525,12 +525,6 @@
   <data name="Home_Advanced_InlineParams.Header" xml:space="preserve">
     <value>內聯效果參數</value>
   </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Description" xml:space="preserve">
-    <value>啟用了“工具列圖示”時才能使用此選項</value>
-  </data>
-  <data name="Settings_Launch_RunAtStartup_MinimizeAtStartup.Header" xml:space="preserve">
-    <value>啟動時最小化到工具列圖示</value>
-  </data>
   <data name="Home_Advanced_SimulateExclusiveFullscreen.Header" xml:space="preserve">
     <value>縮放時模擬獨占全螢幕</value>
   </data>

--- a/src/Magpie/SettingsPage.xaml
+++ b/src/Magpie/SettingsPage.xaml
@@ -63,23 +63,13 @@
 				</local:SettingsCard>
 			</local:SettingsGroup>
 			<local:SettingsGroup x:Uid="Settings_Launch">
-				<local:SettingsExpander x:Uid="Settings_Launch_RunAtStartup"
-				                        IsExpanded="{x:Bind ViewModel.IsRunAtStartup, Mode=OneWay}">
-					<local:SettingsExpander.HeaderIcon>
+				<local:SettingsCard x:Uid="Settings_Launch_RunAtStartup">
+					<local:SettingsCard.HeaderIcon>
 						<FontIcon Glyph="&#xE7B5;" />
-					</local:SettingsExpander.HeaderIcon>
-					<local:SettingsExpander.Content>
-						<ToggleSwitch x:Uid="ToggleSwitch"
-						              IsOn="{x:Bind ViewModel.IsRunAtStartup, Mode=TwoWay}" />
-					</local:SettingsExpander.Content>
-					<local:SettingsExpander.Items>
-						<local:SettingsCard x:Uid="Settings_Launch_RunAtStartup_MinimizeAtStartup"
-						                    IsEnabled="{x:Bind ViewModel.IsMinimizeAtStartupEnabled, Mode=OneWay}">
-							<ToggleSwitch x:Uid="ToggleSwitch"
-							              IsOn="{x:Bind ViewModel.IsMinimizeAtStartup, Mode=TwoWay}" />
-						</local:SettingsCard>
-					</local:SettingsExpander.Items>
-				</local:SettingsExpander>
+					</local:SettingsCard.HeaderIcon>
+					<ToggleSwitch x:Uid="ToggleSwitch"
+					              IsOn="{x:Bind ViewModel.IsRunAtStartup, Mode=TwoWay}" />
+				</local:SettingsCard>
 				<local:SettingsCard x:Uid="Settings_Launch_AlwaysRunAsAdmin"
 				                    IsEnabled="{x:Bind ViewModel.IsProcessElevated, Mode=OneTime}">
 					<local:SettingsCard.HeaderIcon>

--- a/src/Magpie/SettingsViewModel.h
+++ b/src/Magpie/SettingsViewModel.h
@@ -5,8 +5,6 @@ namespace winrt::Magpie::implementation {
 
 struct SettingsViewModel : SettingsViewModelT<SettingsViewModel>,
                            wil::notify_property_changed_base<SettingsViewModel> {
-	SettingsViewModel();
-
 	IVector<IInspectable> Languages() const;
 
 	int Language() const noexcept;
@@ -18,19 +16,8 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel>,
 	int Theme() const noexcept;
 	void Theme(int value);
 
-	bool IsRunAtStartup() const noexcept {
-		return _isRunAtStartup;
-	}
-
+	bool IsRunAtStartup() const noexcept;
 	void IsRunAtStartup(bool value);
-
-	bool IsMinimizeAtStartup() const noexcept {
-		return _isMinimizeAtStartup;
-	}
-
-	void IsMinimizeAtStartup(bool value);
-
-	bool IsMinimizeAtStartupEnabled() const noexcept;
 
 	bool IsPortableMode() const noexcept;
 	void IsPortableMode(bool value);
@@ -44,12 +31,6 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel>,
 
 	bool IsAlwaysRunAsAdmin() const noexcept;
 	void IsAlwaysRunAsAdmin(bool value);
-
-private:
-	void _UpdateStartupOptions();
-
-	bool _isRunAtStartup = false;
-	bool _isMinimizeAtStartup = false;
 };
 
 }

--- a/src/Magpie/SettingsViewModel.idl
+++ b/src/Magpie/SettingsViewModel.idl
@@ -7,8 +7,6 @@ namespace Magpie {
 
 		Int32 Theme;
 		Boolean IsRunAtStartup;
-		Boolean IsMinimizeAtStartup;
-		Boolean IsMinimizeAtStartupEnabled { get; };
 		Boolean IsPortableMode;
 		void OpenConfigLocation();
 		Boolean IsShowNotifyIcon;


### PR DESCRIPTION
删除了“启动时最小化到系统托盘”选项，相当于始终启用这个选项。没人喜欢开机后蹦出几个窗口。