### PR TITLE
优化自动缩放机制

### DIFF
--- a/Magpie.sln
+++ b/Magpie.sln
@@ -13,7 +13,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Magpie", "src\Magpie\Magpie
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{00AB63C3-0CD3-4944-B8E6-58C86138618D}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
 		src\BuildOptions.props = src\BuildOptions.props
 		src\Common.Post.props = src\Common.Post.props
 		src\Common.Pre.props = src\Common.Pre.props

--- a/src/Magpie.Core/AdaptivePresenter.cpp
+++ b/src/Magpie.Core/AdaptivePresenter.cpp
@@ -47,7 +47,7 @@ bool AdaptivePresenter::_Initialize(HWND hwndAttach) noexcept {
 	};
 
 	ID3D11Device5* d3dDevice = _deviceResources->GetD3DDevice();
-	winrt::com_ptr<IDXGISwapChain1> dxgiSwapChain = nullptr;
+	winrt::com_ptr<IDXGISwapChain1> dxgiSwapChain;
 	HRESULT hr = _deviceResources->GetDXGIFactory()->CreateSwapChainForHwnd(
 		d3dDevice,
 		hwndAttach,

--- a/src/Magpie.Core/OverlayDrawer.cpp
+++ b/src/Magpie.Core/OverlayDrawer.cpp
@@ -824,7 +824,7 @@ bool OverlayDrawer::_DrawToolbar(uint32_t fps) noexcept {
 				isWindowedMode ? L"Overlay_Toolbar_SwitchToFullscreen" : L"Overlay_Toolbar_SwitchToWindowed");
 			if (drawButton(icon, switchScalingStr.c_str())) {
 				ScalingWindow::Dispatcher().TryEnqueue([]() {
-					ScalingWindow::Get().SwitchScalingState(!ScalingWindow::Get().Options().IsWindowedMode());
+					ScalingWindow::Get().ToggleScaling(!ScalingWindow::Get().Options().IsWindowedMode());
 				});
 			}
 		}

--- a/src/Magpie.Core/ScalingRuntime.cpp
+++ b/src/Magpie.Core/ScalingRuntime.cpp
@@ -55,6 +55,11 @@ bool ScalingRuntime::Start(HWND hwndSrc, ScalingOptions&& options) {
 
 	_Dispatcher().TryEnqueue([this, hwndSrc, options(std::move(options))]() mutable {
 		ScalingWindow& scalingWindow = ScalingWindow::Get();
+		// 如果正在缩放不做任何处理
+		if (scalingWindow) {
+			return;
+		}
+
 		if (scalingWindow.IsSrcRepositioning()) {
 			scalingWindow.CleanAfterSrcRepositioned();
 		}

--- a/src/Magpie.Core/ScalingRuntime.cpp
+++ b/src/Magpie.Core/ScalingRuntime.cpp
@@ -48,19 +48,17 @@ ScalingRuntime::~ScalingRuntime() {
 	}
 }
 
-bool ScalingRuntime::Start(HWND hwndSrc, ScalingOptions&& options) {
+bool ScalingRuntime::Start(HWND hwndSrc, ScalingOptions&& options, bool force) {
 	assert(!options.screenshotsDir.empty() && options.showToast && options.showError && options.save);
 
-	_Dispatcher().TryEnqueue([this, hwndSrc, options(std::move(options))]() mutable {
+	_Dispatcher().TryEnqueue([this, hwndSrc, options(std::move(options)), force]() mutable {
 		ScalingWindow& scalingWindow = ScalingWindow::Get();
-		// 如果正在缩放则忽略
-		if (scalingWindow) {
+		// 如果正在缩放且 force 为假则忽略
+		if (scalingWindow && !force) {
 			return;
 		}
 
-		if (scalingWindow.IsSrcRepositioning()) {
-			scalingWindow.CleanAfterSrcRepositioned();
-		}
+		scalingWindow.Stop();
 
 		// 初始化时视为处于缩放状态
 		_State(ScalingState::Scaling);

--- a/src/Magpie.Core/ScalingRuntime.cpp
+++ b/src/Magpie.Core/ScalingRuntime.cpp
@@ -55,7 +55,7 @@ bool ScalingRuntime::Start(HWND hwndSrc, ScalingOptions&& options) {
 
 	_Dispatcher().TryEnqueue([this, hwndSrc, options(std::move(options))]() mutable {
 		ScalingWindow& scalingWindow = ScalingWindow::Get();
-		// 如果正在缩放不做任何处理
+		// 如果正在缩放则放弃处理
 		if (scalingWindow) {
 			return;
 		}
@@ -203,7 +203,8 @@ void ScalingRuntime::_ScalingThreadProc() noexcept {
 					// 等待调整完成
 					MsgWaitForMultipleObjectsEx(0, nullptr, 10, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
 				} else {
-					// 重新缩放
+					// 重新缩放。初始化时视为处于缩放状态
+					_IsScaling(true);
 					ScalingWindow::Get().RestartAfterSrcRepositioned();
 				}
 			} else {

--- a/src/Magpie.Core/ScalingRuntime.cpp
+++ b/src/Magpie.Core/ScalingRuntime.cpp
@@ -70,10 +70,10 @@ bool ScalingRuntime::Start(HWND hwndSrc, ScalingOptions&& options) {
 	return true;
 }
 
-void ScalingRuntime::SwitchScalingState(bool isWindowedMode) {
+void ScalingRuntime::ToggleScaling(bool isWindowedMode) {
 	_Dispatcher().TryEnqueue([isWindowedMode]() {
 		if (ScalingWindow& scalingWindow = ScalingWindow::Get()) {
-			scalingWindow.SwitchScalingState(isWindowedMode);
+			scalingWindow.ToggleScaling(isWindowedMode);
 		};
 	});
 }

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -322,10 +322,7 @@ ScalingError ScalingWindow::_StartImpl(HWND hwndSrc) noexcept {
 }
 
 void ScalingWindow::Start(HWND hwndSrc, ScalingOptions&& options) noexcept {
-	if (Handle()) {
-		options.showError(hwndSrc, ScalingError::ScalingFailedGeneral);
-		return;
-	}
+	assert(!Handle());
 
 	options.Log();
 	// 缩放结束后失效

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -342,7 +342,7 @@ void ScalingWindow::Stop() noexcept {
 	CleanAfterSrcRepositioned();
 }
 
-void ScalingWindow::SwitchScalingState(bool isWindowedMode) noexcept {
+void ScalingWindow::ToggleScaling(bool isWindowedMode) noexcept {
 	assert(Handle());
 
 	if (_options.IsWindowedMode() == isWindowedMode || !_srcTracker.IsFocused()) {

--- a/src/Magpie.Core/ScalingWindow.h
+++ b/src/Magpie.Core/ScalingWindow.h
@@ -34,7 +34,7 @@ public:
 
 	void Stop() noexcept;
 
-	void SwitchScalingState(bool isWindowedMode) noexcept;
+	void ToggleScaling(bool isWindowedMode) noexcept;
 
 	void SwitchToolbarState() noexcept;
 

--- a/src/Magpie.Core/include/ScalingRuntime.h
+++ b/src/Magpie.Core/include/ScalingRuntime.h
@@ -16,7 +16,7 @@ public:
 
 	bool Start(HWND hwndSrc, struct ScalingOptions&& options);
 
-	void SwitchScalingState(bool isWindowedMode);
+	void ToggleScaling(bool isWindowedMode);
 
 	void SwitchToolbarState();
 

--- a/src/Magpie.Core/include/ScalingRuntime.h
+++ b/src/Magpie.Core/include/ScalingRuntime.h
@@ -14,7 +14,7 @@ public:
 	ScalingRuntime();
 	~ScalingRuntime();
 
-	bool Start(HWND hwndSrc, struct ScalingOptions&& options);
+	bool Start(HWND hwndSrc, struct ScalingOptions&& options, bool force);
 
 	void ToggleScaling(bool isWindowedMode);
 

--- a/src/Magpie.Core/include/ScalingRuntime.h
+++ b/src/Magpie.Core/include/ScalingRuntime.h
@@ -3,6 +3,12 @@
 
 namespace Magpie {
 
+enum class ScalingState {
+	Idle,
+	Scaling,
+	Waiting
+};
+
 class ScalingRuntime {
 public:
 	ScalingRuntime();
@@ -16,12 +22,12 @@ public:
 
 	void Stop();
 
-	bool IsScaling() const noexcept {
-		return _isScaling.load(std::memory_order_relaxed);
+	ScalingState State() const noexcept {
+		return _state.load(std::memory_order_relaxed);
 	}
 
 	// 调用者应处理线程同步
-	MultithreadEvent<bool> IsScalingChanged;
+	MultithreadEvent<ScalingState> StateChanged;
 
 private:
 	void _ScalingThreadProc() noexcept;
@@ -29,7 +35,7 @@ private:
 	// 确保 _dispatcher 完成初始化
 	const winrt::DispatcherQueue& _Dispatcher() noexcept;
 
-	void _IsScaling(bool value);
+	void _State(ScalingState value);
 
 	std::thread _scalingThread;
 
@@ -38,7 +44,7 @@ private:
 	// 只能在主线程访问，省下检查 _dispatcherInitialized 的开销
 	bool _dispatcherInitializedCache = false;
 
-	std::atomic<bool> _isScaling = false;
+	std::atomic<ScalingState> _state = ScalingState::Idle;
 };
 
 }

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -113,7 +113,7 @@ void ScalingService::_ShortcutService_ShortcutPressed(ShortcutAction action) {
 		const bool isWindowdMode = action == ShortcutAction::WindowedModeScale;
 
 		if (_scalingRuntime->State() == ScalingState::Scaling) {
-			_scalingRuntime->SwitchScalingState(isWindowdMode);
+			_scalingRuntime->ToggleScaling(isWindowdMode);
 		} else {
 			_ScaleForegroundWindow(isWindowdMode);
 		}

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -125,6 +125,8 @@ void ScalingService::_ShortcutService_ShortcutPressed(ShortcutAction action) {
 		_scalingRuntime->SwitchToolbarState();
 		break;
 	}
+	default:
+		break;
 	}
 }
 

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -296,10 +296,6 @@ void ScalingService::_ScaleForegroundWindow(bool windowedMode) {
 void ScalingService::_StartScale(HWND hWnd, const Profile& profile, bool windowedMode) {
 	assert(hWnd);
 
-	if (_scalingRuntime->IsScaling()) {
-		return;
-	}
-
 	const ScalingError error = _StartScaleImpl(hWnd, profile, windowedMode);
 	if (error != ScalingError::NoError) {
 		ShowError(hWnd, error);
@@ -307,8 +303,12 @@ void ScalingService::_StartScale(HWND hWnd, const Profile& profile, bool windowe
 }
 
 ScalingError ScalingService::_StartScaleImpl(HWND hWnd, const Profile& profile, bool windowedMode) {
+	// ScalingRuntime::Start 会检查是否正在缩放，这里提前检查以跳过无效操作
+	if (_scalingRuntime->IsScaling()) {
+		return ScalingError::NoError;
+	}
+
 	if (WindowHelper::IsForbiddenSystemWindow(hWnd)) {
-		// 不显示错误
 		return ScalingError::NoError;
 	}
 

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -245,6 +245,7 @@ fire_and_forget ScalingService::_CheckForegroundTimer_Tick(ThreadPoolTimer const
 	}
 
 	const HWND hwndFore = GetForegroundWindow();
+	// 检查 _hwndCurSrc 使得缩放或等待状态下避免再次缩放源窗口
 	if (!hwndFore || hwndFore == _hwndChecked || hwndFore == _hwndCurSrc) {
 		co_return;
 	}

--- a/src/Magpie/ScalingService.h
+++ b/src/Magpie/ScalingService.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Event.h"
+#include "ScalingRuntime.h"
 #include <winrt/Magpie.h>
 #include <winrt/Windows.System.Threading.h>
 
@@ -56,7 +57,9 @@ private:
 
 	winrt::fire_and_forget _CheckForegroundTimer_Tick(winrt::Threading::ThreadPoolTimer const& timer);
 
-	void _ScalingRuntime_IsScalingChanged(bool isRunning);
+	void _CreateCheckForegroundTimer();
+
+	void _ScalingRuntime_StateChanged(ScalingState value);
 
 	void _ScaleForegroundWindow(bool windowedMode);
 
@@ -64,7 +67,7 @@ private:
 
 	ScalingError _StartScaleImpl(HWND hWnd, const Profile& profile, bool windowedMode);
 
-	std::unique_ptr<ScalingRuntime> _scalingRuntime;
+	std::optional<ScalingRuntime> _scalingRuntime;
 
 	winrt::DispatcherTimer _countDownTimer;
 	// DispatcherTimer 在不显示主窗口时可能停滞，因此使用 ThreadPoolTimer

--- a/src/Magpie/ScalingService.h
+++ b/src/Magpie/ScalingService.h
@@ -57,8 +57,6 @@ private:
 
 	winrt::fire_and_forget _CheckForegroundTimer_Tick(winrt::Threading::ThreadPoolTimer const& timer);
 
-	void _CreateCheckForegroundTimer();
-
 	void _ScalingRuntime_StateChanged(ScalingState value);
 
 	void _ScaleForegroundWindow(bool windowedMode);

--- a/src/Magpie/ScalingService.h
+++ b/src/Magpie/ScalingService.h
@@ -61,9 +61,9 @@ private:
 
 	void _ScaleForegroundWindow(bool windowedMode);
 
-	void _StartScale(HWND hWnd, const Profile& profile, bool windowedMode);
+	void _StartScale(HWND hWnd, const Profile& profile, bool windowedMode, bool force);
 
-	ScalingError _StartScaleImpl(HWND hWnd, const Profile& profile, bool windowedMode);
+	ScalingError _StartScaleImpl(HWND hWnd, const Profile& profile, bool windowedMode, bool force);
 
 	std::optional<ScalingRuntime> _scalingRuntime;
 


### PR DESCRIPTION
Close #1225

缩放有多种渠道（包括快捷键、自动缩放、最小化的窗口还原后自动缩放等），而且位于两个线程，存在着同步问题。尝试后我认为同步机制会使代码复杂得难以维护，不是实用的方案。这个 PR 并未解决同步问题，而是采取措施把影响最小化：

1. 把不同步的窗口期尽可能缩小，常规用户操作很难触发
2. 遇到同步问题将静默忽略无效的操作，不会报错

此外现在自动缩放可以打断当前缩放了，比如缩放 A 时切换到 B，如果 B 启用了自动缩放，将终止缩放 A 转而缩放 B。