### PR TITLE
修复有时误报源窗口无响应

### DIFF
--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -207,7 +207,14 @@ bool SrcTracker::UpdateState(
 	// IsHungAppWindow 的另一个好处是它不如 Win32Helper::IsWindowHung 严
 	// 格，因此即使源窗口挂起一段时间，只要用户不做额外的操作就不会结束缩放，
 	// 直到源窗口被替换为幽灵窗口。
-	if (IsHungAppWindow(_hWnd)) {
+	// if (IsHungAppWindow(_hWnd)) {
+	// 	Logger::Get().Info("源窗口已挂起");
+	// 	return false;
+	// }
+	static const auto ghostWindowFromHungWindow =
+		Win32Helper::LoadSystemFunction<HWND WINAPI(HWND)>(
+			L"user32.dll", "GhostWindowFromHungWindow");
+	if (ghostWindowFromHungWindow && ghostWindowFromHungWindow(_hWnd)) {
 		Logger::Get().Info("源窗口已挂起");
 		return false;
 	}

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -203,14 +203,11 @@ bool SrcTracker::UpdateState(
 
 	isInvisibleOrMinimized = !IsWindowVisible(_hWnd);
 
-	// Win32Helper::IsWindowHung 更准确，但它会向源窗口发送消息，比较耗时。
-	// IsHungAppWindow 的另一个好处是它不如 Win32Helper::IsWindowHung 严
-	// 格，因此即使源窗口挂起一段时间，只要用户不做额外的操作就不会结束缩放，
-	// 直到源窗口被替换为幽灵窗口。
-	// if (IsHungAppWindow(_hWnd)) {
-	// 	Logger::Get().Info("源窗口已挂起");
-	// 	return false;
-	// }
+	// 缩放中途对源窗口响应性的检查更宽松，即使源窗口挂起一段时间，只要用户不做额
+	// 外的操作就不会终止缩放，直到源窗口被替换为幽灵窗口。
+	// 
+	// 不要使用 IsHungAppWindow，它有误报的情况，见 GH#1244。这里用了未记录函数
+	// GhostWindowFromHungWindow，它可以准确检查源窗口是否已被替换为幽灵窗口。
 	static const auto ghostWindowFromHungWindow =
 		Win32Helper::LoadSystemFunction<HWND WINAPI(HWND)>(
 			L"user32.dll", "GhostWindowFromHungWindow");

--- a/src/Magpie.Core/Win32Helper.cpp
+++ b/src/Magpie.Core/Win32Helper.cpp
@@ -290,8 +290,9 @@ int16_t Win32Helper::AdvancedWindowHitTest(HWND hWnd, POINT ptScreen, UINT timeo
 }
 
 bool Win32Helper::IsWindowHung(HWND hWnd) noexcept {
-	return 0 == SendMessageTimeout(hWnd, WM_NULL, 0, 0,
-		SMTO_ABORTIFHUNG | SMTO_ERRORONEXIT, 500, nullptr);
+	// 保险起见不使用 SMTO_ABORTIFHUNG。我不知道 OS 怎么判断线程是否处于无响应
+	// 状态，考虑到 IsHungAppWindow 有误报的情况 (GH#1244)，最好不要依赖。
+	return 0 == SendMessageTimeout(hWnd, WM_NULL, 0, 0, SMTO_ERRORONEXIT, 500, nullptr);
 }
 
 bool Win32Helper::ReadFile(const wchar_t* fileName, std::vector<uint8_t>& result) noexcept {

--- a/src/Magpie/ToastPage.cpp
+++ b/src/Magpie/ToastPage.cpp
@@ -50,7 +50,7 @@ void ToastPage::InitializeComponent() {
 
 static bool TrySetOwnder(HWND hwndToast, HWND hwndTarget) noexcept {
 	// 如果源窗口挂起，SetWindowLongPtr 会卡住
-	if (!Win32Helper::IsWindowHung(hwndTarget)) {
+	if (Win32Helper::IsWindowHung(hwndTarget)) {
 		return false;
 	}
 

--- a/tools/WindowCase/HungWindow.cpp
+++ b/tools/WindowCase/HungWindow.cpp
@@ -1,0 +1,107 @@
+#include "pch.h"
+#include "HungWindow.h"
+
+bool HungWindow::Create(HINSTANCE hInst) noexcept {
+	static const wchar_t* WINDOW_NAME = L"HungWindow";
+
+	WNDCLASSEXW wcex{
+		.cbSize = sizeof(WNDCLASSEX),
+		.style = CS_HREDRAW | CS_VREDRAW,
+		.lpfnWndProc = _WndProc,
+		.hInstance = hInst,
+		.hCursor = LoadCursor(nullptr, IDC_ARROW),
+		.hbrBackground = HBRUSH(COLOR_WINDOW + 1),
+		.lpszClassName = WINDOW_NAME
+	};
+	if (!RegisterClassEx(&wcex)) {
+		return false;
+	}
+
+	CreateWindow(
+		WINDOW_NAME,
+		WINDOW_NAME,
+		WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		CW_USEDEFAULT,
+		NULL,
+		NULL,
+		hInst,
+		this
+	);
+	if (!Handle()) {
+		return false;
+	}
+
+	SetWindowPos(Handle(), NULL, 0, 0, int(500 * DpiScale()), int(400 * DpiScale()),
+		SWP_NOMOVE | SWP_SHOWWINDOW);
+	return true;
+}
+
+LRESULT HungWindow::_MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noexcept {
+	switch (msg) {
+	case WM_CREATE:
+	{
+		const LRESULT ret = base_type::_MessageHandler(msg, wParam, lParam);
+
+		const HMODULE hInst = GetModuleHandle(nullptr);
+		_hwndBtn = CreateWindow(L"BUTTON", L"无响应 10 秒",
+			WS_CHILD | WS_VISIBLE, 0, 0, 0, 0, Handle(), (HMENU)1, hInst, 0);
+		_UpdateButtonPos();
+
+		_hUIFont = CreateFont(
+			std::lround(20 * DpiScale()),
+			0,
+			0,
+			0,
+			FW_NORMAL,
+			FALSE,
+			FALSE,
+			FALSE,
+			DEFAULT_CHARSET,
+			OUT_DEFAULT_PRECIS,
+			CLIP_DEFAULT_PRECIS,
+			DEFAULT_QUALITY,
+			DEFAULT_PITCH | FF_DONTCARE,
+			L"Microsoft YaHei UI"
+		);
+		SendMessage(_hwndBtn, WM_SETFONT, (WPARAM)_hUIFont, TRUE);
+
+		return ret;
+	}
+	case WM_SIZE:
+	{
+		_UpdateButtonPos();
+		break;
+	}
+	case WM_COMMAND:
+	{
+		if (HIWORD(wParam) == BN_CLICKED && LOWORD(wParam) == 1) {
+			Sleep(20000);
+		}
+		break;
+	}
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		break;
+	}
+
+	return base_type::_MessageHandler(msg, wParam, lParam);
+}
+
+void HungWindow::_UpdateButtonPos() noexcept {
+	RECT clientRect;
+	GetClientRect(Handle(), &clientRect);
+
+	SIZE btnSize = { std::lround(120 * DpiScale()),std::lround(50 * DpiScale()) };
+	SetWindowPos(
+		_hwndBtn,
+		NULL,
+		((clientRect.right - clientRect.left) - btnSize.cx) / 2,
+		((clientRect.bottom - clientRect.top) - btnSize.cy) / 2,
+		btnSize.cx,
+		btnSize.cy,
+		SWP_NOACTIVATE
+	);
+}

--- a/tools/WindowCase/HungWindow.h
+++ b/tools/WindowCase/HungWindow.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "WindowBase.h"
+
+class HungWindow : public WindowBaseT<HungWindow> {
+	using base_type = WindowBaseT<HungWindow>;
+	friend base_type;
+
+public:
+	bool Create(HINSTANCE hInst) noexcept;
+
+protected:
+	LRESULT _MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
+
+private:
+	void _UpdateButtonPos() noexcept;
+
+	HWND _hwndBtn = NULL;
+	HFONT _hUIFont = NULL;
+};

--- a/tools/WindowCase/KirikiriWindow.cpp
+++ b/tools/WindowCase/KirikiriWindow.cpp
@@ -60,7 +60,8 @@ bool KirikiriWindow::Create(HINSTANCE hInst) noexcept {
 	}
 
 	ShowWindow(_hwndOwner, SW_SHOWNORMAL);
-	ShowWindow(Handle(), SW_SHOWNORMAL);
+	SetWindowPos(Handle(), NULL, 0, 0, int(500 * DpiScale()), int(400 * DpiScale()),
+		SWP_NOMOVE | SWP_SHOWWINDOW);
 	return true;
 }
 
@@ -96,7 +97,7 @@ LRESULT KirikiriWindow::_OwnerWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 	return DefWindowProc(hWnd, msg, wParam, lParam);
 }
 
-LRESULT KirikiriWindow::_OwnerMessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) {
+LRESULT KirikiriWindow::_OwnerMessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noexcept {
 	switch (msg) {
 	case WM_ACTIVATE:
 	{

--- a/tools/WindowCase/KirikiriWindow.h
+++ b/tools/WindowCase/KirikiriWindow.h
@@ -14,7 +14,7 @@ protected:
 private:
 	static LRESULT CALLBACK _OwnerWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-	LRESULT _OwnerMessageHandler(UINT msg, WPARAM wParam, LPARAM lParam);
+	LRESULT _OwnerMessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
 
 	HWND _hwndOwner = NULL;
 };

--- a/tools/WindowCase/WindowCase.vcxproj
+++ b/tools/WindowCase/WindowCase.vcxproj
@@ -76,6 +76,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="HungWindow.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="KirikiriWindow.cpp" />
     <ClCompile Include="pch.cpp">
@@ -83,6 +84,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="HungWindow.h" />
     <ClInclude Include="KirikiriWindow.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="WindowBase.h" />

--- a/tools/WindowCase/WindowCase.vcxproj.filters
+++ b/tools/WindowCase/WindowCase.vcxproj.filters
@@ -2,15 +2,17 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="pch.cpp" />
+    <ClCompile Include="KirikiriWindow.cpp" />
+    <ClCompile Include="HungWindow.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="app.manifest" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="MainWindow.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="WindowBase.h" />
+    <ClInclude Include="KirikiriWindow.h" />
+    <ClInclude Include="HungWindow.h" />
   </ItemGroup>
 </Project>

--- a/tools/WindowCase/main.cpp
+++ b/tools/WindowCase/main.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "KirikiriWindow.h"
+#include "HungWindow.h"
 
 int APIENTRY wWinMain(
 	_In_ HINSTANCE hInstance,
@@ -7,7 +8,7 @@ int APIENTRY wWinMain(
 	_In_ LPWSTR /*lpCmdLine*/,
 	_In_ int /*nCmdShow*/
 ) {
-	KirikiriWindow window;
+	HungWindow window;
 	if (!window.Create(hInstance)) {
 		return false;
 	}

--- a/tools/WindowCase/pch.h
+++ b/tools/WindowCase/pch.h
@@ -18,6 +18,7 @@
 #include <string_view>
 #include <vector>
 #include <cassert>
+#include <cmath>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;


### PR DESCRIPTION
Close #1244

不知为何 [IsHungAppWindow](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-ishungappwindow) 可能会误报。从表现看，游戏可能因为 5 秒没有调用 PeekMessage 被 OS 标记为无响应窗口，但实际上依然处于响应状态，而且没被替换为幽灵窗口。无论原因为何，应避免使用 IsHungAppWindow。

这个 PR 将 IsHungAppWindow 替换为了未记录的函数 [GhostWindowFromHungWindow](https://undoc.airesoft.co.uk/user32.dll/GhostWindowFromHungWindow.php)，检查是否存在幽灵窗口，这也更符合原本的意图。

其他更改：

1. WindowCase 可以模拟无响应窗口
2. 修复了一个消息弹窗检测无响应窗口的 bug