### PR TITLE
修复源窗口被最小化时偶尔没有移出屏幕

### DIFF
--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -2084,7 +2084,7 @@ void ScalingWindow::_UpdateWindowRectFromWindowPos(const WINDOWPOS& windowPos) n
 void ScalingWindow::_DelayedStop(bool onSrcHung, bool onSrcRepositioning) const noexcept {
 	if (!onSrcHung) {
 		const HWND hwndSrc = _srcTracker.Handle();
-		if (!(IsWindow(hwndSrc) && Win32Helper::IsWindowHung(hwndSrc))) {
+		if (IsTopmostWindow(Handle()) && !(IsWindow(hwndSrc) && Win32Helper::IsWindowHung(hwndSrc))) {
 			// 提前取消置顶，这样销毁时出现问题不会影响和桌面环境交互
 			SetWindowPos(Handle(), HWND_NOTOPMOST, 0, 0, 0, 0,
 				SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -1888,31 +1888,17 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 			return;
 		}
 
-		const bool topmost = _CalcTopmostState();
-		if (IsTopmostWindow(Handle()) != topmost) {
-			// 由于同步问题可能需要尝试多次
-			for (int i = 0; i < 10; ++i) {
-				SetWindowPos(Handle(), topmost ? HWND_TOPMOST : HWND_NOTOPMOST,
-					0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
-
-				if (IsTopmostWindow(Handle()) == topmost) {
-					break;
-				}
-			}
+		if (bool topmost = _CalcTopmostState(); topmost != IsTopmostWindow(Handle())) {
+			// 切换到其他窗口时不要改变源窗口 Z 顺序，当前台窗口权限更高时需要依赖源窗口位置
+			SetWindowPos(Handle(), topmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+				SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
 		}
 
 		if (_srcTracker.IsFocused()) {
 			if (!_options.IsWindowedMode()) {
 				// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
 				// 活 DirectFlip。
-				HDWP hDwp = BeginDeferWindowPos(2);
-				if (hDwp) {
-					hDwp = DeferWindowPos(hDwp, _srcTracker.Handle(), HWND_TOP, 0, 0, 0, 0,
-						SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
-					hDwp = DeferWindowPos(hDwp, Handle(), HWND_TOP, 0, 0, 0, 0,
-						SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
-					EndDeferWindowPos(hDwp);
-				}
+				SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
 			}
 		} else {
 			if (const HWND hwndFore = GetForegroundWindow()) {

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -1891,9 +1891,16 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 		const bool oldTopmost = IsTopmostWindow(Handle());
 		const bool newTopmost = _CalcTopmostState();
 		if (oldTopmost != newTopmost) {
-			// 切换到其他窗口时不要改变源窗口 Z 顺序，当前台窗口权限更高时需要依赖源窗口位置
-			SetWindowPos(Handle(), newTopmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
-				SWP_NO_ACTIVATE_MOVE_SIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
+			// 由于同步问题可能需要尝试多次
+			for (int i = 0; i < 10; ++i) {
+				// 切换到其他窗口时不要改变源窗口 Z 顺序，当前台窗口权限更高时需要依赖源窗口位置
+				SetWindowPos(Handle(), newTopmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+					SWP_NO_ACTIVATE_MOVE_SIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
+
+				if (IsTopmostWindow(Handle()) == newTopmost) {
+					break;
+				}
+			}
 		}
 
 		if (_srcTracker.IsFocused()) {

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -1888,19 +1888,22 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 			return;
 		}
 
-		if (bool topmost = _CalcTopmostState(); topmost != IsTopmostWindow(Handle())) {
+		const bool oldTopmost = IsTopmostWindow(Handle());
+		const bool newTopmost = _CalcTopmostState();
+		if (oldTopmost != newTopmost) {
 			// 切换到其他窗口时不要改变源窗口 Z 顺序，当前台窗口权限更高时需要依赖源窗口位置
-			SetWindowPos(Handle(), topmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+			SetWindowPos(Handle(), newTopmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
 				SWP_NO_ACTIVATE_MOVE_SIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
 		}
 
 		if (_srcTracker.IsFocused()) {
-			if (!_options.IsWindowedMode()) {
-				// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
-				// 活 DirectFlip。
+			// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
+			// 活 DirectFlip。
+			if (!_options.IsWindowedMode() && newTopmost) {
 				SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 			}
-		} else {
+		} else if (oldTopmost && !newTopmost) {
+			// 如果缩放窗口之前是置顶的，此时会在前台窗口之上，应将前台窗口置于顶部
 			if (const HWND hwndFore = GetForegroundWindow()) {
 				if (!SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE)) {
 					// 如果前台窗口权限更高，SetWindowPos 会失败。这时用其他方法将缩放窗口放到

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -1219,7 +1219,7 @@ void ScalingWindow::_Show() noexcept {
 		Handle(),
 		NULL,
 		0, 0, 0, 0,
-		SWP_SHOWWINDOW | SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE
+		SWP_SHOWWINDOW | SWP_NO_ACTIVATE_MOVE_SIZE
 	);
 
 	// 广播开始缩放
@@ -1891,26 +1891,26 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 		if (bool topmost = _CalcTopmostState(); topmost != IsTopmostWindow(Handle())) {
 			// 切换到其他窗口时不要改变源窗口 Z 顺序，当前台窗口权限更高时需要依赖源窗口位置
 			SetWindowPos(Handle(), topmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
-				SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
+				SWP_NO_ACTIVATE_MOVE_SIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
 		}
 
 		if (_srcTracker.IsFocused()) {
 			if (!_options.IsWindowedMode()) {
 				// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
 				// 活 DirectFlip。
-				SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+				SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 			}
 		} else {
 			if (const HWND hwndFore = GetForegroundWindow()) {
-				if (!SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE)) {
+				if (!SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE)) {
 					// 如果前台窗口权限更高，SetWindowPos 会失败。这时用其他方法将缩放窗口放到
 					// 前台窗口之后，缺点是偶尔会有一瞬间源窗口出现在缩放窗口前。
 					HDWP hDwp = BeginDeferWindowPos(2);
 					if (hDwp) {
 						hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
-							0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
+							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
 						hDwp = DeferWindowPos(hDwp, _srcTracker.Handle(), Handle(),
-							0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
+							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
 						EndDeferWindowPos(hDwp);
 					}
 				}
@@ -2073,7 +2073,7 @@ void ScalingWindow::_DelayedStop(bool onSrcHung, bool onSrcRepositioning) const 
 		if (IsTopmostWindow(Handle()) && !(IsWindow(hwndSrc) && Win32Helper::IsWindowHung(hwndSrc))) {
 			// 提前取消置顶，这样销毁时出现问题不会影响和桌面环境交互
 			SetWindowPos(Handle(), HWND_NOTOPMOST, 0, 0, 0, 0,
-				SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
+				SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
 		}
 	}
 

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -234,7 +234,13 @@ bool SrcTracker::UpdateState(
 
 	RECT curWindowRect;
 	if (wp.showCmd == SW_SHOWMINIMIZED) {
-		isInvisibleOrMinimized = true;
+		// 窗口最小化有两步：先将窗口状态设为最小化，然后将窗口移出屏幕 (左上角坐标
+		// (-32000,-32000))。如果我们刚好在两步之间停止缩放，第二步将无法执行，这和缩
+		// 放窗口被源窗口所有有关，不确定是否是 OS 的 bug。
+		//
+		// 检查 wp.rcNormalPosition.left != wp.ptMinPosition.x 可以确保第二步完成后
+		// 再停止缩放。
+		isInvisibleOrMinimized = wp.rcNormalPosition.left != wp.ptMinPosition.x;
 
 		// rcNormalPosition 使用工作区坐标，应转换为屏幕坐标
 		HMONITOR hMon = MonitorFromWindow(_hWnd, MONITOR_DEFAULTTOPRIMARY);

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -236,9 +236,8 @@ bool SrcTracker::UpdateState(
 	if (wp.showCmd == SW_SHOWMINIMIZED) {
 		// 窗口最小化有两步：先将窗口状态设为最小化，然后将窗口移出屏幕 (左上角坐标
 		// (-32000,-32000))。如果我们刚好在两步之间停止缩放，第二步将无法执行，这和缩
-		// 放窗口被源窗口所有有关，不确定是否是 OS 的 bug。
-		//
-		// 这个检查确保第二步完成后再停止缩放。
+		// 放窗口被源窗口所有有关，不确定是否是 OS 的 bug。这个检查确保第二步完成后再
+		// 停止缩放。
 		if (wp.rcNormalPosition.left == wp.ptMinPosition.x) {
 			return true;
 		}

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -238,9 +238,12 @@ bool SrcTracker::UpdateState(
 		// (-32000,-32000))。如果我们刚好在两步之间停止缩放，第二步将无法执行，这和缩
 		// 放窗口被源窗口所有有关，不确定是否是 OS 的 bug。
 		//
-		// 检查 wp.rcNormalPosition.left != wp.ptMinPosition.x 可以确保第二步完成后
-		// 再停止缩放。
-		isInvisibleOrMinimized = wp.rcNormalPosition.left != wp.ptMinPosition.x;
+		// 这个检查确保第二步完成后再停止缩放。
+		if (wp.rcNormalPosition.left == wp.ptMinPosition.x) {
+			return true;
+		}
+
+		isInvisibleOrMinimized = true;
 
 		// rcNormalPosition 使用工作区坐标，应转换为屏幕坐标
 		HMONITOR hMon = MonitorFromWindow(_hWnd, MONITOR_DEFAULTTOPRIMARY);

--- a/src/Magpie/ToastPage.cpp
+++ b/src/Magpie/ToastPage.cpp
@@ -134,12 +134,10 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 	}
 
 	if (isTargetTopMost || !isOwned) {
-		SetWindowPos(_hwndToast, HWND_TOPMOST, 0, 0, 0, 0,
-			SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+		SetWindowPos(_hwndToast, HWND_TOPMOST, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 	}
 	if (!isTargetTopMost) {
-		SetWindowPos(_hwndToast, HWND_NOTOPMOST, 0, 0, 0, 0,
-			SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+		SetWindowPos(_hwndToast, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 	}
 
 	// 更改所有者后应更新 Z 轴顺序
@@ -268,11 +266,11 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 			// 如果 hwndTarget 位于前台，定期将弹窗置顶。SWP_NOOWNERZORDER 可以避免修改 hwndTarget
 			// 的 Z 顺序，理论上不需要这个标志，可能是 OS 的 bug。
 			SetWindowPos(_hwndToast, HWND_TOPMOST, 0, 0, 0, 0,
-				SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
+				SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
 		}
 		if (!isTargetTopMost) {
 			SetWindowPos(_hwndToast, HWND_NOTOPMOST, 0, 0, 0, 0,
-				SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOOWNERZORDER);
+				SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
 		}
 
 		// 窗口没有移动则无需更新

--- a/src/Magpie/ToastService.cpp
+++ b/src/Magpie/ToastService.cpp
@@ -85,8 +85,7 @@ void ToastService::_ToastThreadProc() noexcept {
 		wil::GetModuleInstanceHandle(),
 		nullptr
 	);
-	SetWindowPos(_hwndToast, NULL, 0, 0, 0, 0,
-		SWP_SHOWWINDOW | SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+	SetWindowPos(_hwndToast, NULL, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NO_ACTIVATE_MOVE_SIZE);
 
 	// DesktopWindowXamlSource 在控件之前创建则无需调用 WindowsXamlManager::InitializeForCurrentThread
 	DesktopWindowXamlSource xamlSource;

--- a/src/Shared/CommonDefines.h
+++ b/src/Shared/CommonDefines.h
@@ -19,6 +19,8 @@ using winrt::operator co_await;
 #define _STRING_HELPER(x) #x
 #define STRING(x) _STRING_HELPER(x)
 
+#define SWP_NO_ACTIVATE_MOVE_SIZE (SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE)
+
 struct Ignore {
 	constexpr Ignore() noexcept = default;
 


### PR DESCRIPTION
窗口最小化有两步：先将窗口状态设为最小化，然后将窗口移出屏幕 (左上角坐标 (-32000,-32000))。如果我们刚好在两步之间停止缩放，第二步将无法执行，这和缩放窗口被源窗口所有有关，不确定是否是 OS 的 bug。现在确保第二步完成后再停止缩放。
![动画](https://github.com/user-attachments/assets/3dc1edd3-1793-443c-a3dd-fd68d70c72f6)

还修复了切换窗口时偶尔源窗口不会被带到顶部的问题。