### PR TITLE
修复 Win10 中内存泄漏

### DIFF
--- a/src/Magpie/AdaptersService.cpp
+++ b/src/Magpie/AdaptersService.cpp
@@ -127,7 +127,7 @@ bool AdaptersService::_GatherAdapterInfos(
 		return info.idx == std::numeric_limits<uint32_t>::max();
 	});
 
-	App::Get().Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this, adapterInfos(std::move(adapterInfos))]() {
+	App::Get().Dispatcher().TryEnqueue([this, adapterInfos(std::move(adapterInfos))]() {
 		_adapterInfos = std::move(adapterInfos);
 		_UpdateProfiles();
 		AdaptersChanged.Invoke();

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -127,15 +127,17 @@ bool App::Initialize(const wchar_t* arguments) {
 	// 初始化 XAML 框架。退出时也不要关闭，如果正在播放动画会崩溃。文档中的清空消息队列的做法无用。
 	_windowsXamlManager = Hosting::WindowsXamlManager::InitializeForCurrentThread();
 
-	if (CoreWindow coreWindow = CoreWindow::GetForCurrentThread()) {
-		// Win10 中隐藏 DesktopWindowXamlSource 窗口
-		if (Win32Helper::GetOSVersion().IsWin10()) {
+	// CoreDispatcher.RunAsync 存在内存泄露，因此我们始终使用 DispatcherQueue。初始化
+	// WindowsXamlManager 时已经创建 DispatcherQueue。
+	_dispatcher = winrt::DispatcherQueue::GetForCurrentThread();
+
+	// Win10 中隐藏 DesktopWindowXamlSource 窗口
+	if (Win32Helper::GetOSVersion().IsWin10()) {
+		if (CoreWindow coreWindow = CoreWindow::GetForCurrentThread()) {
 			HWND hwndDWXS;
 			coreWindow.try_as<ICoreWindowInterop>()->get_WindowHandle(&hwndDWXS);
 			ShowWindow(hwndDWXS, SW_HIDE);
 		}
-
-		_dispatcher = coreWindow.Dispatcher();
 	}
 
 	LocalizationService::Get().EarlyInitialize();
@@ -193,7 +195,7 @@ bool App::Initialize(const wchar_t* arguments) {
 		// 再检查显卡的功能级别。
 		_mainWindow->Content()->Loaded([](const auto&, const auto&) {
 			// 低优先级回调确保在初始化完毕后执行
-			App::Get().Dispatcher().RunAsync(CoreDispatcherPriority::Low, []() {
+			App::Get().Dispatcher().TryEnqueue(DispatcherQueuePriority::Low, []() {
 				AdaptersService::Get().StartMonitor();
 			});
 		});
@@ -355,9 +357,7 @@ void App::_UpdateColorValuesChangedRevoker() {
 		_colorValuesChangedRevoker = _uiSettings.ColorValuesChanged(
 			auto_revoke,
 			[this](const auto&, const auto&) {
-				_dispatcher.RunAsync(CoreDispatcherPriority::Normal, [this] {
-					_UpdateTheme();
-				});
+				_dispatcher.TryEnqueue([this] { _UpdateTheme(); });
 			}
 		);
 	} else {

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -127,8 +127,8 @@ bool App::Initialize(const wchar_t* arguments) {
 	// 初始化 XAML 框架。退出时也不要关闭，如果正在播放动画会崩溃。文档中的清空消息队列的做法无用。
 	_windowsXamlManager = Hosting::WindowsXamlManager::InitializeForCurrentThread();
 
-	// CoreDispatcher.RunAsync 存在内存泄露，因此我们始终使用 DispatcherQueue。初始化
-	// WindowsXamlManager 时已经创建 DispatcherQueue。
+	// Win10 中 CoreDispatcher.RunAsync 存在内存泄露，因此我们始终使用 DispatcherQueue。
+	// 初始化 WindowsXamlManager 时已经创建 DispatcherQueue。
 	_dispatcher = winrt::DispatcherQueue::GetForCurrentThread();
 
 	// Win10 中隐藏 DesktopWindowXamlSource 窗口

--- a/src/Magpie/App.h
+++ b/src/Magpie/App.h
@@ -25,7 +25,7 @@ public:
 
 	int Run();
 
-	const CoreDispatcher& Dispatcher() const noexcept {
+	const DispatcherQueue& Dispatcher() const noexcept {
 		return _dispatcher;
 	}
 
@@ -74,7 +74,7 @@ private:
 
 	std::unique_ptr<::Magpie::MainWindow> _mainWindow;
 
-	CoreDispatcher _dispatcher{ nullptr };
+	DispatcherQueue _dispatcher{ nullptr };
 
 	::Magpie::Event<::Magpie::AppTheme>::EventRevoker _themeChangedRevoker;
 	Windows::UI::ViewManagement::UISettings _uiSettings;

--- a/src/Magpie/CandidateWindowItem.cpp
+++ b/src/Magpie/CandidateWindowItem.cpp
@@ -113,8 +113,7 @@ fire_and_forget CandidateWindowItem::_ResolveWindow(bool resolveIcon, bool resol
 			co_return;
 		}
 
-		App::Get().Dispatcher().RunAsync(
-			CoreDispatcherPriority::Normal,
+		App::Get().Dispatcher().TryEnqueue(
 			[this, defaultProfileName(std::move(defaultProfileName)), aumid(reader.AUMID())]() {
 				if (!defaultProfileName.empty()) {
 					_defaultProfileName = defaultProfileName;

--- a/src/Magpie/RootPage.cpp
+++ b/src/Magpie/RootPage.cpp
@@ -200,7 +200,7 @@ void RootPage::NavigationView_DisplayModeChanged(MUXC::NavigationView const& nv,
 	nv.IsPaneToggleButtonVisible(!isExpanded);
 	if (isExpanded) {
 		// 延迟设置 IsPaneOpen 才能起作用
-		Dispatcher().RunAsync(CoreDispatcherPriority::Low, [nv(MUXC::NavigationView(nv))]() {
+		App::Get().Dispatcher().TryEnqueue(DispatcherQueuePriority::Low, [nv(MUXC::NavigationView(nv))]() {
 			nv.IsPaneOpen(true);
 		});
 	}
@@ -219,7 +219,7 @@ void RootPage::NavigationView_ItemInvoked(MUXC::NavigationView const&, MUXC::Nav
 		_newProfileViewModel->PrepareForOpen();
 
 		// 同步调用 ShowAt 有时会失败
-		App::Get().Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [that(get_strong())]() {
+		App::Get().Dispatcher().TryEnqueue([that(get_strong())]() {
 			that->NewProfileFlyout().ShowAt(that->NewProfileNavigationViewItem());
 		});
 	}

--- a/src/Magpie/ScalingModesViewModel.cpp
+++ b/src/Magpie/ScalingModesViewModel.cpp
@@ -217,7 +217,7 @@ fire_and_forget ScalingModesViewModel::_AddScalingModes(bool isInitialExpanded) 
 
 void ScalingModesViewModel::_ScalingModesService_Added(EffectAddedWay way) {
 	// 不支持在事件回调中修改事件本身，因此延迟执行
-	App::Get().Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this, way]() {
+	App::Get().Dispatcher().TryEnqueue([this, way]() {
 		_AddScalingModes(way == EffectAddedWay::Add);
 	});
 }

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -16,7 +16,6 @@
 
 using namespace winrt::Magpie::implementation;
 using namespace winrt;
-using namespace Windows::System::Threading;
 
 using winrt::Magpie::ShortcutAction;
 
@@ -34,19 +33,22 @@ void ScalingService::Initialize() {
 	_scalingRuntime->StateChanged(
 		std::bind_front(&ScalingService::_ScalingRuntime_StateChanged, this));
 
+	const DispatcherQueue& dispatcher = App::Get().Dispatcher();
+
+	_countDownTimer = dispatcher.CreateTimer();
 	_countDownTimer.Interval(25ms);
 	_countDownTimer.Tick({ this, &ScalingService::_CountDownTimer_Tick });
 
-	_checkForegroundTimer = ThreadPoolTimer::CreatePeriodicTimer(
-		{ this, &ScalingService::_CheckForegroundTimer_Tick },
-		50ms
-	);
+	_checkForegroundTimer = dispatcher.CreateTimer();
+	_checkForegroundTimer.Interval(50ms);
+	_checkForegroundTimer.Tick({ this, &ScalingService::_CheckForegroundTimer_Tick });
+	_checkForegroundTimer.Start();
 	
 	_shortcutActivatedRevoker = ShortcutService::Get().ShortcutActivated(
 		auto_revoke, std::bind_front(&ScalingService::_ShortcutService_ShortcutPressed, this));
 
 	// 立即检查前台窗口
-	_CheckForegroundTimer_Tick(nullptr);
+	_CheckForegroundTimer_Tick(nullptr, nullptr);
 }
 
 void ScalingService::Uninitialize() {
@@ -54,10 +56,7 @@ void ScalingService::Uninitialize() {
 		return;
 	}
 
-	if (_checkForegroundTimer) {
-		_checkForegroundTimer.Cancel();
-	}
-	
+	_checkForegroundTimer.Stop();
 	_countDownTimer.Stop();
 	_scalingRuntime.reset();
 
@@ -103,7 +102,7 @@ bool ScalingService::IsScaling() const noexcept {
 
 void ScalingService::CheckForeground() {
 	_hwndChecked = NULL;
-	_CheckForegroundTimer_Tick(nullptr);
+	_CheckForegroundTimer_Tick(nullptr, nullptr);
 }
 
 void ScalingService::_ShortcutService_ShortcutPressed(ShortcutAction action) {
@@ -131,12 +130,7 @@ void ScalingService::_ShortcutService_ShortcutPressed(ShortcutAction action) {
 	}
 }
 
-void ScalingService::_CountDownTimer_Tick(winrt::IInspectable const&, winrt::IInspectable const&) {
-	// 以防在 Uninitialize 或取消计时后执行
-	if (!_scalingRuntime || !IsTimerOn()) {
-		return;
-	}
-
+void ScalingService::_CountDownTimer_Tick(winrt::DispatcherQueueTimer const&, winrt::IInspectable const&) {
 	const double timeLeft = SecondsLeft();
 
 	// 剩余时间在 10 ms 以内计时结束
@@ -253,20 +247,10 @@ static bool IsReadyForScaling(HWND hwndFore) noexcept {
 	return !Win32Helper::IsWindowHung(hwndFore);
 }
 
-fire_and_forget ScalingService::_CheckForegroundTimer_Tick(ThreadPoolTimer const& timer) {
-	if (timer) {
-		// ThreadPoolTimer 在后台线程触发
-		co_await App::Get().Dispatcher();
-	}
-
-	// ThreadPoolTimer 是异步的，Uninitialize 后仍可能执行
-	if (!_scalingRuntime) {
-		co_return;
-	}
-
+void ScalingService::_CheckForegroundTimer_Tick(winrt::DispatcherQueueTimer const&, winrt::IInspectable const&) {
 	const HWND hwndFore = GetForegroundWindow();
 	if (!hwndFore || hwndFore == _hwndChecked) {
-		co_return;
+		return;
 	}
 
 	if (hwndFore != _hwndCurSrc) {
@@ -276,7 +260,7 @@ fire_and_forget ScalingService::_CheckForegroundTimer_Tick(ThreadPoolTimer const
 		if (profile && !(_hwndCurSrc && IsPopupWindow(hwndFore, _hwndCurSrc))) {
 			// 如果窗口处于某种中间状态则跳过此次检查
 			if (!IsReadyForScaling(hwndFore)) {
-				co_return;
+				return;
 			}
 
 			// 自动缩放可以终止当前缩放
@@ -289,7 +273,7 @@ fire_and_forget ScalingService::_CheckForegroundTimer_Tick(ThreadPoolTimer const
 }
 
 void ScalingService::_ScalingRuntime_StateChanged(ScalingState value) {
-	App::Get().Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this, value]() {
+	App::Get().Dispatcher().TryEnqueue([this, value]() {
 		if (value == ScalingState::Scaling) {
 			StopTimer();
 		} else if (value == ScalingState::Idle) {
@@ -492,8 +476,7 @@ ScalingError ScalingService::_StartScaleImpl(HWND hWnd, const Profile& profile, 
 	options.showError = &ShowError;
 
 	options.save = [](const ScalingOptions& options, HWND /*hwndScaling*/) noexcept {
-		App::Get().Dispatcher().RunAsync(
-			CoreDispatcherPriority::Normal,
+		App::Get().Dispatcher().TryEnqueue(
 			[overlayOptions(options.overlayOptions)]() {
 				AppSettings::Get().OverlayOptions() = std::move(overlayOptions);
 				AppSettings::Get().SaveAsync();

--- a/src/Magpie/ScalingService.h
+++ b/src/Magpie/ScalingService.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "Event.h"
 #include "ScalingRuntime.h"
-#include <winrt/Magpie.h>
-#include <winrt/Windows.System.Threading.h>
 
 namespace Magpie {
 class ScalingRuntime;
@@ -57,9 +55,9 @@ private:
 
 	void _ShortcutService_ShortcutPressed(winrt::Magpie::ShortcutAction action);
 
-	void _CountDownTimer_Tick(winrt::IInspectable const&, winrt::IInspectable const&);
+	void _CountDownTimer_Tick(winrt::DispatcherQueueTimer const&, winrt::IInspectable const&);
 
-	winrt::fire_and_forget _CheckForegroundTimer_Tick(winrt::Threading::ThreadPoolTimer const& timer);
+	void _CheckForegroundTimer_Tick(winrt::DispatcherQueueTimer const&, winrt::IInspectable const&);
 
 	void _ScalingRuntime_StateChanged(ScalingState value);
 
@@ -71,9 +69,8 @@ private:
 
 	std::optional<ScalingRuntime> _scalingRuntime;
 
-	winrt::DispatcherTimer _countDownTimer;
-	// DispatcherTimer 在不显示主窗口时可能停滞，因此使用 ThreadPoolTimer
-	winrt::Threading::ThreadPoolTimer _checkForegroundTimer{ nullptr };
+	winrt::DispatcherQueueTimer _countDownTimer{ nullptr };
+	winrt::DispatcherQueueTimer _checkForegroundTimer{ nullptr };
 
 	Event<winrt::Magpie::ShortcutAction>::EventRevoker _shortcutActivatedRevoker;
 

--- a/src/Magpie/ShortcutService.cpp
+++ b/src/Magpie/ShortcutService.cpp
@@ -206,8 +206,7 @@ LRESULT CALLBACK ShortcutService::_LowLevelKeyboardProc(int nCode, WPARAM wParam
 				that._keyboardHookShortcutActivated = true;
 
 				// 延迟执行回调以缩短钩子的处理时间
-				App::Get().Dispatcher().RunAsync(
-					CoreDispatcherPriority::Normal,
+				App::Get().Dispatcher().TryEnqueue(
 					[action]() {
 						Logger::Get().Info(fmt::format("热键 {} 激活（Keyboard Hook）", ShortcutHelper::ToString(action)));
 						Get()._FireShortcut(action);

--- a/src/Magpie/TextBlockHelper.cpp
+++ b/src/Magpie/TextBlockHelper.cpp
@@ -37,8 +37,8 @@ void TextBlockHelper::_OnIsAutoTooltipEnabledChanged(DependencyObject const& sen
             TextBlock::TextProperty(),
             [](DependencyObject const& sender, DependencyProperty const&) {
                 // 等待布局更新
-                App::Get().Dispatcher().RunAsync(
-                    CoreDispatcherPriority::Low,
+                App::Get().Dispatcher().TryEnqueue(
+                    DispatcherQueuePriority::Low,
                     std::bind_front(&_SetTooltipBasedOnTrimmingState, sender.try_as<TextBlock>(), true)
                 );
             }

--- a/src/Magpie/ToastPage.cpp
+++ b/src/Magpie/ToastPage.cpp
@@ -40,11 +40,12 @@ ToastPage::ToastPage(uint64_t hwndToast) : _hwndToast((HWND)hwndToast) {
 void ToastPage::InitializeComponent() {
 	ToastPageT::InitializeComponent();
 
-	_appThemeChangedRevoker = App::Get().ThemeChanged(auto_revoke, [this](bool) {
-		Dispatcher().TryRunAsync(CoreDispatcherPriority::Normal, [this] {
-			_UpdateTheme();
-		});
-	});
+	_appThemeChangedRevoker = App::Get().ThemeChanged(
+		auto_revoke,
+		[this, dispatcher(DispatcherQueue::GetForCurrentThread())](bool) {
+			dispatcher.TryEnqueue([this] { _UpdateTheme(); });
+		}
+	);
 	_UpdateTheme();
 }
 
@@ -97,7 +98,7 @@ static void UpdateToastPosition(HWND hwndToast, const RECT& frameRect, bool upda
 }
 
 fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring message, HWND hwndTarget, bool showLogo) {
-	CoreDispatcher dispatcher = Dispatcher();
+	DispatcherQueue dispatcher = DispatcherQueue::GetForCurrentThread();
 
 	// !!! HACK !!!
 	// 重用 TeachingTip 有一个 bug: 前一个 Toast 正在消失时新的 Toast 不会显示。为了
@@ -107,7 +108,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 	if (oldTeachingTip) {
 		UnloadObject(oldTeachingTip);
 		// 确保卸载完成，防止弹出动画 bug
-		co_await resume_foreground(dispatcher, CoreDispatcherPriority::Low);
+		co_await resume_foreground(dispatcher, DispatcherQueuePriority::Low);
 	} else {
 		oldTeachingTip = std::move(_oldTeachingTip);
 	}
@@ -158,7 +159,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 	// !!! HACK !!!
 	// 移除关闭按钮和修复弹出动画。必须在模板加载完成后做，TeachingTip 没有 Opening 事件，但可以监听 
 	// MessageTextBlock 的 LayoutUpdated 事件，它在 TeachingTip 显示前必然会被引发。
-	MessageTextBlock().LayoutUpdated([this, weak(weak_ref(curTeachingTip))](IInspectable const&, IInspectable const&) {
+	MessageTextBlock().LayoutUpdated([this, weak(weak_ref(curTeachingTip)), dispatcher](IInspectable const&, IInspectable const&) {
 		auto teachingTip = weak.get();
 		if (!teachingTip) {
 			return;
@@ -183,7 +184,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 			if (XamlHelper::ContainsControl(popup.Child(), MessageTextBlock())) {
 				popup.Visibility(Visibility::Collapsed);
 
-				Dispatcher().RunAsync(CoreDispatcherPriority::Low, [popup]() {
+				dispatcher.TryEnqueue(DispatcherQueuePriority::Low, [popup]() {
 					popup.Visibility(Visibility::Visible);
 				});
 
@@ -202,7 +203,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 	// 第三个参数用于延长 oldTeachingTip 的生存期，确保关闭动画播放完毕后再析构。
 	// TeachingTip 的显示和隐藏动画总计 500ms，显示时长不应少于这个时间。
 	// https://github.com/Blinue/microsoft-ui-xaml/blob/75f7666f5907aad29de1cb2e49405cc06d433fba/dev/TeachingTip/TeachingTip.h#L239-L240
-	[](CoreDispatcher dispatcher, weak_ref<MUXC::TeachingTip> weakCurTeachingTip, MUXC::TeachingTip) -> fire_and_forget {
+	[](DispatcherQueue dispatcher, weak_ref<MUXC::TeachingTip> weakCurTeachingTip, MUXC::TeachingTip) -> fire_and_forget {
 		// 显示时长固定 2 秒
 		co_await 2s;
 		co_await dispatcher;
@@ -217,7 +218,7 @@ fire_and_forget ToastPage::ShowMessageOnWindow(std::wstring title, std::wstring 
 			curTeachingTip.IsOpen(false);
 
 			// 某些特殊情况下关闭会失败（比如被调试器暂停后），应等待一段时间后检查 IsOpen
-			co_await resume_foreground(dispatcher, CoreDispatcherPriority::Low);
+			co_await resume_foreground(dispatcher, DispatcherQueuePriority::Low);
 
 			if (!curTeachingTip.IsOpen()) {
 				co_return;

--- a/src/Magpie/ToastService.cpp
+++ b/src/Magpie/ToastService.cpp
@@ -42,13 +42,13 @@ void ToastService::Uninitialize() noexcept {
 }
 
 void ToastService::ShowMessageOnWindow(std::wstring_view title, std::wstring_view message, HWND hwndTarget) const noexcept {
-	_Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this, title(std::wstring(title)), message(std::wstring(message)), hwndTarget]() {
+	_Dispatcher().TryEnqueue([this, title(std::wstring(title)), message(std::wstring(message)), hwndTarget]() {
 		_toastPage->ShowMessageOnWindow(std::move(title), std::move(message), hwndTarget, true);
 	});
 }
 
 void ToastService::ShowMessageInApp(std::wstring_view title, std::wstring_view message) const noexcept {
-	_Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this, title(std::wstring(title)), message(std::wstring(message))]() {
+	_Dispatcher().TryEnqueue([this, title(std::wstring(title)), message(std::wstring(message))]() {
 		_toastPage->ShowMessageOnWindow(std::move(title), std::move(message), App::Get().MainWindow().Handle(), false);
 	});
 }
@@ -101,7 +101,7 @@ void ToastService::_ToastThreadProc() noexcept {
 	_toastPage = make_self<winrt::Magpie::implementation::ToastPage>((uint64_t)_hwndToast);
 	xamlSource.Content(*_toastPage);
 
-	_dispatcher = _toastPage->Dispatcher();
+	_dispatcher = winrt::DispatcherQueue::GetForCurrentThread();
 	// 如果主线程正在等待则唤醒主线程
 	_dispatcherInitialized.store(true, std::memory_order_release);
 	_dispatcherInitialized.notify_one();
@@ -167,7 +167,7 @@ LRESULT ToastService::_ToastWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 	return DefWindowProc(hWnd, msg, wParam, lParam);
 }
 
-const CoreDispatcher& ToastService::_Dispatcher() const noexcept {
+const DispatcherQueue& ToastService::_Dispatcher() const noexcept {
 	_dispatcherInitialized.wait(false, std::memory_order_acquire);
 	return _dispatcher;
 }

--- a/src/Magpie/ToastService.h
+++ b/src/Magpie/ToastService.h
@@ -29,11 +29,11 @@ private:
 	static LRESULT CALLBACK _ToastWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 	// 确保 _dispatcher 完成初始化
-	const winrt::CoreDispatcher& _Dispatcher() const noexcept;
+	const winrt::DispatcherQueue& _Dispatcher() const noexcept;
 
 	std::thread _toastThread;
 
-	winrt::CoreDispatcher _dispatcher{ nullptr };
+	winrt::DispatcherQueue _dispatcher{ nullptr };
 	std::atomic<bool> _dispatcherInitialized = false;
 
 	// 只能在 toast 线程访问

--- a/src/Magpie/XamlWindow.h
+++ b/src/Magpie/XamlWindow.h
@@ -55,6 +55,7 @@ protected:
 		using namespace winrt::Windows::UI::Xaml::Hosting;
 
 		_content = content;
+		_dispatcher = winrt::DispatcherQueue::GetForCurrentThread();
 
 		// 初始化 XAML Islands
 		_xamlSource = DesktopWindowXamlSource();
@@ -364,7 +365,7 @@ protected:
 						PostMessage(hwndDWXS, WM_SIZE, wParam, lParam);
 					}
 
-					_content->Dispatcher().RunAsync(winrt::CoreDispatcherPriority::Normal, [xamlRoot(_content->XamlRoot())]() {
+					_dispatcher.TryEnqueue([xamlRoot(_content->XamlRoot())]() {
 						XamlHelper::RepositionXamlPopups(xamlRoot, true);
 					});
 				}
@@ -511,6 +512,7 @@ private:
 	winrt::com_ptr<IDesktopWindowXamlSourceNative2> _xamlSourceNative2;
 
 	C _content{ nullptr };
+	winrt::DispatcherQueue _dispatcher{ nullptr };
 
 	uint32_t _currentDpi = USER_DEFAULT_SCREEN_DPI;
 	uint32_t _nativeTopBorderThickness = 1;


### PR DESCRIPTION
Close #1354

Win11 修复了大量 XAML Islands bug，但没移植回 Win10。比如：

1. 任务栏出现 DesktopWindowXamlSource 窗口
2. 关闭 DesktopWindowXamlSource 时内存泄漏
3. Tooltip 和 Popup 不响应应用主题更改

现在又发现了 CoreDispatcher.RunAsync 的内存泄漏问题，Win11 中也不存在。这个 PR 将 CoreDispatcher 换成 DispatcherQueue 以规避内存泄漏。

Win10 中仍有 XAML Islands 内部的内存泄漏无法修复。每次关闭主窗口会泄漏约 70KB 内存，每次弹出消息框会有微量内存泄漏，不过这些影响不大。