### PR TITLE
源窗口有弹窗时不再置顶缩放窗口

### DIFF
--- a/src/Magpie.Core/AdaptivePresenter.cpp
+++ b/src/Magpie.Core/AdaptivePresenter.cpp
@@ -157,7 +157,7 @@ void AdaptivePresenter::EndFrame(bool waitForGpu) noexcept {
 		_WaitForGpu();
 
 		// 等待 DWM 开始合成新一帧
-		_WaitForDwmComposition();
+		Win32Helper::WaitForDwmComposition();
 	}
 
 	if (_isDCompPresenting) {
@@ -175,7 +175,7 @@ void AdaptivePresenter::EndFrame(bool waitForGpu) noexcept {
 
 			// 等待交换链呈现新帧
 			_WaitForGpu();
-			_WaitForDwmComposition();
+			Win32Helper::WaitForDwmComposition();
 
 			// 清除 DirectCompostion 内容
 			_dcompVisual->SetContent(nullptr);

--- a/src/Magpie.Core/CompSwapchainPresenter.cpp
+++ b/src/Magpie.Core/CompSwapchainPresenter.cpp
@@ -234,7 +234,7 @@ void CompSwapchainPresenter::EndFrame(bool waitForGpu) noexcept {
 		_WaitForGpu();
 
 		// 等待 DWM 开始合成新一帧
-		_WaitForDwmComposition();
+		Win32Helper::WaitForDwmComposition();
 	}
 
 	_presentationManager->Present();

--- a/src/Magpie.Core/PresenterBase.cpp
+++ b/src/Magpie.Core/PresenterBase.cpp
@@ -30,58 +30,6 @@ bool PresenterBase::Initialize(HWND hwndAttach, const DeviceResources& deviceRes
 	return _Initialize(hwndAttach);
 }
 
-void PresenterBase::_WaitForDwmComposition() noexcept {
-	// Win11 可以使用准确的 DCompositionWaitForCompositorClock
-	if (Win32Helper::GetOSVersion().IsWin11()) {
-		static const auto dCompositionWaitForCompositorClock =
-			Win32Helper::LoadSystemFunction<decltype(DCompositionWaitForCompositorClock)>(
-			L"dcomp.dll", "DCompositionWaitForCompositorClock");
-		if (dCompositionWaitForCompositorClock) {
-			dCompositionWaitForCompositorClock(0, nullptr, INFINITE);
-			return;
-		}
-	}
-
-	LARGE_INTEGER qpf;
-	QueryPerformanceFrequency(&qpf);
-	qpf.QuadPart /= 10000000;
-
-	DWM_TIMING_INFO info{};
-	info.cbSize = sizeof(info);
-	DwmGetCompositionTimingInfo(NULL, &info);
-
-	LARGE_INTEGER time;
-	QueryPerformanceCounter(&time);
-
-	if (time.QuadPart >= (LONGLONG)info.qpcCompose) {
-		return;
-	}
-
-	// 提前 1ms 结束然后忙等待
-	time.QuadPart += 10000;
-	if (time.QuadPart < (LONGLONG)info.qpcCompose) {
-		LARGE_INTEGER liDueTime{
-			.QuadPart = -((LONGLONG)info.qpcCompose - time.QuadPart) / qpf.QuadPart
-		};
-		static HANDLE timer = CreateWaitableTimerEx(nullptr, nullptr,
-			CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
-		SetWaitableTimerEx(timer, &liDueTime, 0, NULL, NULL, 0, 0);
-		WaitForSingleObject(timer, INFINITE);
-	} else {
-		Sleep(0);
-	}
-
-	while (true) {
-		QueryPerformanceCounter(&time);
-
-		if (time.QuadPart >= (LONGLONG)info.qpcCompose) {
-			return;
-		}
-
-		Sleep(0);
-	}
-}
-
 uint32_t PresenterBase::_CalcBufferCount() noexcept {
 	// 缓冲区数量取决于 ScalingRuntime::_ScalingThreadProc 中检查光标移动的频率
 	return ScalingWindow::Get().Options().Is3DGameMode() ? 4 : 8;

--- a/src/Magpie.Core/PresenterBase.cpp
+++ b/src/Magpie.Core/PresenterBase.cpp
@@ -3,9 +3,6 @@
 #include "DeviceResources.h"
 #include "Logger.h"
 #include "ScalingWindow.h"
-#include "Win32Helper.h"
-#include <dcomp.h>
-#include <dwmapi.h>
 
 namespace Magpie {
 

--- a/src/Magpie.Core/PresenterBase.h
+++ b/src/Magpie.Core/PresenterBase.h
@@ -29,9 +29,6 @@ protected:
 
 	void _WaitForGpu() noexcept;
 
-	// 和 DwmFlush 效果相同但更准确
-	static void _WaitForDwmComposition() noexcept;
-
 	static uint32_t _CalcBufferCount() noexcept;
 
 	const DeviceResources* _deviceResources = nullptr;

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -403,6 +403,7 @@ void ScalingWindow::Render() noexcept {
 		_Show();
 	}
 
+	// 可能较慢，因此渲染之后执行
 	if (srcFocusedChanged) {
 		_UpdateFocusState();
 	}
@@ -1920,6 +1921,7 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 			} else {
 				HWND hwndFore = GetForegroundWindow();
 				if (!hwndFore) {
+					// 切换窗口时有一个瞬间无前台窗口，这里等待切换完成
 					Sleep(1);
 					hwndFore = GetForegroundWindow();
 				}
@@ -1986,9 +1988,9 @@ bool ScalingWindow::_CalcTopmostState() const noexcept {
 		return true;
 	}
 
-	// 源窗口位于前台时一般将缩放窗口置顶，这是为了防止有些窗口突破 OS 维护的所有者关
-	// 系顺序，如 GH#1232，除非源窗口有弹窗。除了常规弹窗，还应检查模拟模态弹窗（见
-	// ScalingService.cpp 的 IsPopupWindow）。
+	// 源窗口位于前台时一般将缩放窗口置顶，这是为了防止有些窗口突破 OS 维护的所有者关系
+	// 顺序，如 GH#1232。一个例外是源窗口有弹窗时缩放窗口应在弹窗下方，除了常规弹窗，还
+	// 应检查模拟模态弹窗（见 ScalingService.cpp 的 IsPopupWindow）。
 	return !_options.IsTopmostDisabled() &&
 		_srcTracker.IsFocused() &&
 		!GetWindow(_srcTracker.Handle(), GW_ENABLEDPOPUP) &&

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -392,6 +392,10 @@ void ScalingWindow::Render() noexcept {
 		return;
 	}
 
+	if (srcFocusedChanged) {
+		_UpdateFocusStateAsync();
+	}
+
 	// 虽然可以在第一帧渲染完成后再隐藏系统光标，但某些设备上显示窗口时光标状态会变成忙，
 	// 提前隐藏光标可以提高观感。缩放窗口显示后再隐藏光标还可能造成光标闪烁两次，第一次是
 	// 创建 D3D 设备后（可能是 OS bug），第二次是我们隐藏系统光标。
@@ -401,11 +405,6 @@ void ScalingWindow::Render() noexcept {
 		_isFirstFrame = false;
 		// 第一帧渲染完成后显示缩放窗口
 		_Show();
-	}
-
-	// 可能较慢，因此渲染之后执行
-	if (srcFocusedChanged) {
-		_UpdateFocusState();
 	}
 }
 
@@ -1239,7 +1238,7 @@ void ScalingWindow::_Show() noexcept {
 
 	// 如果源窗口位于前台则将缩放窗口置顶
 	if (_srcTracker.IsFocused()) {
-		_UpdateFocusState();
+		_UpdateFocusStateAsync();
 	}
 
 	if (_options.IsTouchSupportEnabled()) {
@@ -1880,7 +1879,7 @@ void ScalingWindow::_UpdateFrameMargins() const noexcept {
 	DwmExtendFrameIntoClientArea(Handle(), &margins);
 }
 
-void ScalingWindow::_UpdateFocusState() const noexcept {
+winrt::fire_and_forget ScalingWindow::_UpdateFocusStateAsync() const noexcept {
 	if (_options.IsWindowedMode()) {
 		// 根据源窗口状态绘制非客户区，我们必须自己控制非客户区是绘制成焦点状态还是非焦点
 		// 状态，因为缩放窗口实际上永远不会得到焦点。
@@ -1891,7 +1890,7 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 		if (Win32Helper::IsWindowHung(_srcTracker.Handle())) {
 			Logger::Get().Error("源窗口已挂起");
 			_DelayedStop();
-			return;
+			co_return;
 		}
 
 		// 这里搞得很复杂，是我反复实验得到的，若要修改应测试下列情形：
@@ -1919,10 +1918,14 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 					SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 				}
 			} else {
+				const uint32_t runId = ScalingWindow::RunId();
+				bool isInBackground = false;
+
 				HWND hwndFore = GetForegroundWindow();
 				if (!hwndFore) {
 					// 切换窗口时有一个瞬间无前台窗口，这里等待切换完成
-					Sleep(1);
+					co_await winrt::resume_after(1ms);
+					isInBackground = true;
 					hwndFore = GetForegroundWindow();
 				}
 				
@@ -1934,8 +1937,22 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 				}
 				
 				if (!isForeMovable) {
+					if (!isInBackground) {
+						co_await winrt::resume_background();
+						isInBackground = true;
+					}
+
 					// 等待 DWM 开始合成新帧以避免显示中间状态
 					Win32Helper::WaitForDwmComposition();
+				}
+
+				if (isInBackground) {
+					co_await ScalingWindow::Get().Dispatcher();
+
+					// 等待时源窗口重新回到前台了应放弃后续操作
+					if (runId != ScalingWindow::RunId() || _srcTracker.IsFocused()) {
+						co_return;
+					}
 				}
 
 				for (int i = 0; i < 10; ++i) {

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -1984,7 +1984,7 @@ winrt::fire_and_forget ScalingWindow::_UpdateFocusStateAsync() const noexcept {
 					}
 				}
 
-				if (isForeMovable && hwndFore) {
+				if (isForeMovable && hwndFore && GetForegroundWindow() == hwndFore) {
 					SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 				}
 			}

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -1893,41 +1893,54 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 			return;
 		}
 
+		// 这里搞得很复杂，是我反复实验得到的，若要修改应测试下列情形：
+		// 1. 缩放 WindowCase 中的 TopmostWindow 和 PopupHostWindow
+		// 2. 缩放常规窗口然后切换到管理员身份的窗口。测试这一条时应直接运行，不要调试，因
+		// 为调试状态下 SetWindowPos 的行为有变化
+		// 3. 缩放时将任意窗口最小化然后还原
+
 		const bool oldTopmost = IsTopmostWindow(Handle());
 		const bool newTopmost = _CalcTopmostState();
 		if (oldTopmost != newTopmost) {
 			// 由于同步问题可能需要尝试多次
 			for (int i = 0; i < 10; ++i) {
-				// 切换到其他窗口时不要改变源窗口 Z 顺序，当前台窗口权限更高时需要依赖源窗口位置
-				SetWindowPos(Handle(), newTopmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
-					SWP_NO_ACTIVATE_MOVE_SIZE | (_srcTracker.IsFocused() ? 0 : SWP_NOOWNERZORDER));
+				HDWP hDwp = BeginDeferWindowPos(newTopmost ? 2 : 3);
 
-				if (IsTopmostWindow(Handle()) == newTopmost) {
+				if (newTopmost) {
+					hDwp = DeferWindowPos(hDwp, Handle(), HWND_TOPMOST,
+						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+					// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
+					// 活 DirectFlip。
+					if (!_options.IsWindowedMode()) {
+						hDwp = DeferWindowPos(hDwp, Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+					}
+				} else {
+					hDwp = DeferWindowPos(hDwp, Handle(), HWND_NOTOPMOST,
+						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+					
+					hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
+						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
+					hDwp = DeferWindowPos(hDwp, _srcTracker.Handle(), Handle(),
+						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
+					// hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
+					//     0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+				}
+				
+				EndDeferWindowPos(hDwp);
+
+				if (IsTopmostWindow(Handle()) == newTopmost &&
+					(newTopmost || GetWindow(_srcTracker.Handle(), GW_HWNDPREV) == Handle())) {
 					break;
 				}
-			}
-		}
 
-		if (_srcTracker.IsFocused()) {
-			// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
-			// 活 DirectFlip。
-			if (!_options.IsWindowedMode() && newTopmost) {
-				SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+				OutputDebugString(L"t");
 			}
-		} else if (oldTopmost && !newTopmost) {
-			// 如果缩放窗口之前是置顶的，此时会在前台窗口之上，应将前台窗口置于顶部
-			if (const HWND hwndFore = GetForegroundWindow()) {
-				if (!SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE)) {
-					// 如果前台窗口权限更高，SetWindowPos 会失败。这时用其他方法将缩放窗口放到
-					// 前台窗口之后，缺点是偶尔会有一瞬间源窗口出现在缩放窗口前。
-					HDWP hDwp = BeginDeferWindowPos(2);
-					if (hDwp) {
-						hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
-							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
-						hDwp = DeferWindowPos(hDwp, _srcTracker.Handle(), Handle(),
-							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
-						EndDeferWindowPos(hDwp);
-					}
+
+			if (!newTopmost) {
+				// 确保前台窗口在最前
+				if (const HWND hwndFore = GetForegroundWindow()) {
+					SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0,
+						SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
 				}
 			}
 		}
@@ -1942,10 +1955,18 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 }
 
 bool ScalingWindow::_CalcTopmostState() const noexcept {
-	// 源窗口位于前台时应将缩放窗口置顶，这是为了防止有些窗口突破 OS 维护的所有者关系顺
-	// 序，如 GH#1232；如果源窗口不在前台则取消置顶（除非源窗口是置顶的）。
-	return (_srcTracker.IsFocused() && !_options.IsTopmostDisabled()) ||
-		IsTopmostWindow(_srcTracker.Handle());
+	// 源窗口置顶时缩放窗口必须置顶
+	if (IsTopmostWindow(_srcTracker.Handle())) {
+		return true;
+	}
+
+	// 源窗口位于前台时一般将缩放窗口置顶，这是为了防止有些窗口突破 OS 维护的所有者关
+	// 系顺序，如 GH#1232，除非源窗口有弹窗。除了常规弹窗，还应检查模拟模态弹窗（见
+	// ScalingService.cpp 的 IsPopupWindow）。
+	return !_options.IsTopmostDisabled() &&
+		_srcTracker.IsFocused() &&
+		!GetWindow(_srcTracker.Handle(), GW_ENABLEDPOPUP) &&
+		IsWindowEnabled(_srcTracker.Handle());
 }
 
 bool ScalingWindow::_IsBorderless() const noexcept {

--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -392,10 +392,6 @@ void ScalingWindow::Render() noexcept {
 		return;
 	}
 
-	if (srcFocusedChanged) {
-		_UpdateFocusState();
-	} 
-
 	// 虽然可以在第一帧渲染完成后再隐藏系统光标，但某些设备上显示窗口时光标状态会变成忙，
 	// 提前隐藏光标可以提高观感。缩放窗口显示后再隐藏光标还可能造成光标闪烁两次，第一次是
 	// 创建 D3D 设备后（可能是 OS bug），第二次是我们隐藏系统光标。
@@ -405,6 +401,10 @@ void ScalingWindow::Render() noexcept {
 		_isFirstFrame = false;
 		// 第一帧渲染完成后显示缩放窗口
 		_Show();
+	}
+
+	if (srcFocusedChanged) {
+		_UpdateFocusState();
 	}
 }
 
@@ -1898,49 +1898,75 @@ void ScalingWindow::_UpdateFocusState() const noexcept {
 		// 2. 缩放常规窗口然后切换到管理员身份的窗口。测试这一条时应直接运行，不要调试，因
 		// 为调试状态下 SetWindowPos 的行为有变化
 		// 3. 缩放时将任意窗口最小化然后还原
+		// 4. 缩放时拖动任意窗口
 
 		const bool oldTopmost = IsTopmostWindow(Handle());
 		const bool newTopmost = _CalcTopmostState();
 		if (oldTopmost != newTopmost) {
-			// 由于同步问题可能需要尝试多次
-			for (int i = 0; i < 10; ++i) {
-				HDWP hDwp = BeginDeferWindowPos(newTopmost ? 2 : 3);
+			if (newTopmost) {
+				for (int i = 0; i < 10; ++i) {
+					SetWindowPos(Handle(), HWND_TOPMOST, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 
-				if (newTopmost) {
-					hDwp = DeferWindowPos(hDwp, Handle(), HWND_TOPMOST,
-						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
-					// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
-					// 活 DirectFlip。
-					if (!_options.IsWindowedMode()) {
-						hDwp = DeferWindowPos(hDwp, Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+					if (IsTopmostWindow(Handle()) == newTopmost) {
+						break;
 					}
-				} else {
-					hDwp = DeferWindowPos(hDwp, Handle(), HWND_NOTOPMOST,
-						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
-					
-					hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
-						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
-					hDwp = DeferWindowPos(hDwp, _srcTracker.Handle(), Handle(),
-						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
-					// hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
-					//     0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+				}
+
+				// 全屏模式缩放时确保缩放窗口在所有置顶窗口之上，这使不支持 MPO 的显卡更容易激
+				// 活 DirectFlip。
+				if (!_options.IsWindowedMode()) {
+					SetWindowPos(Handle(), HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+				}
+			} else {
+				HWND hwndFore = GetForegroundWindow();
+				if (!hwndFore) {
+					Sleep(1);
+					hwndFore = GetForegroundWindow();
 				}
 				
-				EndDeferWindowPos(hDwp);
-
-				if (IsTopmostWindow(Handle()) == newTopmost &&
-					(newTopmost || GetWindow(_srcTracker.Handle(), GW_HWNDPREV) == Handle())) {
-					break;
+				bool isForeMovable = true;
+				if (hwndFore) {
+					DWORD windowIL;
+					isForeMovable = Win32Helper::GetWindowIntegrityLevel(hwndFore, windowIL) &&
+						windowIL <= Win32Helper::GetCurrentProcessIntegrityLevel();
+				}
+				
+				if (!isForeMovable) {
+					// 等待 DWM 开始合成新帧以避免显示中间状态
+					Win32Helper::WaitForDwmComposition();
 				}
 
-				OutputDebugString(L"t");
-			}
+				for (int i = 0; i < 10; ++i) {
+					HDWP hDwp = BeginDeferWindowPos(isForeMovable ? 2 : 3);
 
-			if (!newTopmost) {
-				// 确保前台窗口在最前
-				if (const HWND hwndFore = GetForegroundWindow()) {
-					SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0,
-						SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+					// 改变置顶状态
+					hDwp = DeferWindowPos(hDwp, Handle(), HWND_NOTOPMOST,
+						0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+
+					// 将缩放窗口恰好置于源窗口前
+					if (isForeMovable) {
+						// 这个方式没有中间状态，但会导致源窗口遮挡前台窗口，之后会手动将前台窗口移到顶部
+						hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
+							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
+					} else {
+						// 这个方式不会移动源窗口，但有中间状态。如果前台窗口 IL 更高，这是唯一的办法
+						hDwp = DeferWindowPos(hDwp, Handle(), _srcTracker.Handle(),
+							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
+						hDwp = DeferWindowPos(hDwp, _srcTracker.Handle(), Handle(),
+							0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE | SWP_NOOWNERZORDER);
+					}
+
+					EndDeferWindowPos(hDwp);
+
+					// 确保缩放窗口刚好在源窗口前
+					if (IsTopmostWindow(Handle()) == newTopmost &&
+						GetWindow(_srcTracker.Handle(), GW_HWNDPREV) == Handle()) {
+						break;
+					}
+				}
+
+				if (isForeMovable && hwndFore) {
+					SetWindowPos(hwndFore, HWND_TOP, 0, 0, 0, 0, SWP_NO_ACTIVATE_MOVE_SIZE);
 				}
 			}
 		}

--- a/src/Magpie.Core/ScalingWindow.h
+++ b/src/Magpie.Core/ScalingWindow.h
@@ -151,7 +151,7 @@ private:
 
 	void _UpdateFrameMargins() const noexcept;
 
-	void _UpdateFocusState() const noexcept;
+	winrt::fire_and_forget _UpdateFocusStateAsync() const noexcept;
 
 	bool _CalcTopmostState() const noexcept;
 

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -11,12 +11,6 @@
 
 namespace Magpie {
 
-static bool CheckIL(HWND hwndSrc) noexcept {
-	DWORD windowIL;
-	return Win32Helper::GetWindowIntegrityLevel(hwndSrc, windowIL) &&
-		windowIL <= Win32Helper::GetCurrentProcessIntegrityLevel();
-}
-
 static bool IsWindowMoving(HWND hWnd) noexcept {
 	GUITHREADINFO guiThreadInfo{ .cbSize = sizeof(GUITHREADINFO) };
 	if (GetGUIThreadInfo(GetWindowThreadProcessId(hWnd, nullptr), &guiThreadInfo)) {

--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -11,30 +11,10 @@
 
 namespace Magpie {
 
-static bool GetWindowIntegrityLevel(HWND hWnd, DWORD& integrityLevel) noexcept {
-	wil::unique_process_handle hProc = Win32Helper::GetWindowProcessHandle(hWnd);
-	if (!hProc) {
-		Logger::Get().Error("GetWindowProcessHandle 失败");
-		return false;
-	}
-
-	wil::unique_handle hQueryToken;
-	if (!OpenProcessToken(hProc.get(), TOKEN_QUERY, hQueryToken.put())) {
-		Logger::Get().Win32Error("OpenProcessToken 失败");
-		return false;
-	}
-
-	return Win32Helper::GetProcessIntegrityLevel(hQueryToken.get(), integrityLevel);
-}
-
 static bool CheckIL(HWND hwndSrc) noexcept {
-	static DWORD thisIL = []() -> DWORD {
-		DWORD il;
-		return Win32Helper::GetProcessIntegrityLevel(NULL, il) ? il : 0;
-	}();
-
 	DWORD windowIL;
-	return GetWindowIntegrityLevel(hwndSrc, windowIL) && windowIL <= thisIL;
+	return Win32Helper::GetWindowIntegrityLevel(hwndSrc, windowIL) &&
+		windowIL <= Win32Helper::GetCurrentProcessIntegrityLevel();
 }
 
 static bool IsWindowMoving(HWND hWnd) noexcept {
@@ -79,9 +59,14 @@ ScalingError SrcTracker::Set(HWND hWnd, const ScalingOptions& options, bool& isI
 		return ScalingError::InvalidSourceWindow;
 	}
 
-	if (!CheckIL(hWnd)) {
-		Logger::Get().Error("不支持缩放 IL 更高的窗口");
-		return ScalingError::LowIntegrityLevel;
+	// 检查 integrity level
+	{
+		DWORD windowIL;
+		if (!Win32Helper::GetWindowIntegrityLevel(hWnd, windowIL) ||
+			windowIL > Win32Helper::GetCurrentProcessIntegrityLevel()) {
+			Logger::Get().Error("不支持缩放 IL 更高的窗口");
+			return ScalingError::LowIntegrityLevel;
+		}
 	}
 
 	// 已在 ScalingService 中阻止

--- a/src/Magpie.Core/Win32Helper.cpp
+++ b/src/Magpie.Core/Win32Helper.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "Win32Helper.h"
 #include "StrHelper.h"
+#include <dcomp.h>
 #include <dwmapi.h>
 #include <io.h>
 #pragma push_macro("ShellExecute")
@@ -697,6 +698,30 @@ bool Win32Helper::GetProcessIntegrityLevel(HANDLE hQueryToken, DWORD& integrityL
 	return true;
 }
 
+DWORD Win32Helper::GetCurrentProcessIntegrityLevel() noexcept {
+	static DWORD result = []() -> DWORD {
+		DWORD il;
+		return Win32Helper::GetProcessIntegrityLevel(NULL, il) ? il : 0;
+	}();
+	return result;
+}
+
+bool Win32Helper::GetWindowIntegrityLevel(HWND hWnd, DWORD& integrityLevel) noexcept {
+	wil::unique_process_handle hProc = GetWindowProcessHandle(hWnd);
+	if (!hProc) {
+		Logger::Get().Error("GetWindowProcessHandle 失败");
+		return false;
+	}
+
+	wil::unique_handle hQueryToken;
+	if (!OpenProcessToken(hProc.get(), TOKEN_QUERY, hQueryToken.put())) {
+		Logger::Get().Win32Error("OpenProcessToken 失败");
+		return false;
+	}
+
+	return GetProcessIntegrityLevel(hQueryToken.get(), integrityLevel);
+}
+
 static winrt::com_ptr<IShellView> FindDesktopFolderView() noexcept {
 	winrt::com_ptr<IShellWindows> shellWindows =
 		winrt::try_create_instance<IShellWindows>(CLSID_ShellWindows, CLSCTX_LOCAL_SERVER);
@@ -854,6 +879,58 @@ const std::filesystem::path& Win32Helper::GetExePath() noexcept {
 		return std::filesystem::path(std::move(exePath));
 	}();
 	return result;
+}
+
+void Win32Helper::WaitForDwmComposition() noexcept {
+	// Win11 可以使用准确的 DCompositionWaitForCompositorClock
+	if (Win32Helper::GetOSVersion().IsWin11()) {
+		static const auto dCompositionWaitForCompositorClock =
+			Win32Helper::LoadSystemFunction<decltype(DCompositionWaitForCompositorClock)>(
+				L"dcomp.dll", "DCompositionWaitForCompositorClock");
+		if (dCompositionWaitForCompositorClock) {
+			dCompositionWaitForCompositorClock(0, nullptr, INFINITE);
+			return;
+		}
+	}
+
+	LARGE_INTEGER qpf;
+	QueryPerformanceFrequency(&qpf);
+	qpf.QuadPart /= 10000000;
+
+	DWM_TIMING_INFO info{};
+	info.cbSize = sizeof(info);
+	DwmGetCompositionTimingInfo(NULL, &info);
+
+	LARGE_INTEGER time;
+	QueryPerformanceCounter(&time);
+
+	if (time.QuadPart >= (LONGLONG)info.qpcCompose) {
+		return;
+	}
+
+	// 提前 1ms 结束然后忙等待
+	time.QuadPart += 10000;
+	if (time.QuadPart < (LONGLONG)info.qpcCompose) {
+		LARGE_INTEGER liDueTime{
+			.QuadPart = -((LONGLONG)info.qpcCompose - time.QuadPart) / qpf.QuadPart
+		};
+		static HANDLE timer = CreateWaitableTimerEx(nullptr, nullptr,
+			CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+		SetWaitableTimerEx(timer, &liDueTime, 0, NULL, NULL, 0, 0);
+		WaitForSingleObject(timer, INFINITE);
+	} else {
+		Sleep(0);
+	}
+
+	while (true) {
+		QueryPerformanceCounter(&time);
+
+		if (time.QuadPart >= (LONGLONG)info.qpcCompose) {
+			return;
+		}
+
+		Sleep(0);
+	}
 }
 
 }

--- a/src/Magpie.Core/include/Win32Helper.h
+++ b/src/Magpie.Core/include/Win32Helper.h
@@ -117,6 +117,10 @@ struct Win32Helper {
 
 	static bool GetProcessIntegrityLevel(HANDLE hQueryToken, DWORD& integrityLevel) noexcept;
 
+	static DWORD GetCurrentProcessIntegrityLevel() noexcept;
+
+	static bool GetWindowIntegrityLevel(HWND hWnd, DWORD& integrityLevel) noexcept;
+
 	// VARIANT 封装，自动管理生命周期，比 WIL 提供更多功能
 	struct Variant : public VARIANT {
 		Variant() noexcept {
@@ -210,6 +214,9 @@ struct Win32Helper {
 		// 先转成 void* 以避免警告
 		return reinterpret_cast<T*>(reinterpret_cast<void*>(address));
 	}
+
+	// 和 DwmFlush 效果相同但更准确
+	static void WaitForDwmComposition() noexcept;
 };
 
 }


### PR DESCRIPTION
优化了切换窗口的逻辑，进行了全面测试，希望是最后一次修改这里了。

测试了以下场景：
1. 缩放 WindowCase 中的 TopmostWindow 和 PopupHostWindow
2. 缩放常规窗口然后切换到管理员身份的窗口。测试这一条时应直接运行，不要调试，因为调试状态下 SetWindowPos 的行为有变化
3. 缩放时将任意窗口最小化然后还原
4. 缩放时拖动任意窗口