### PR TITLE
修复 SettingsCard 中的文本框无法键入空格

### DIFF
--- a/src/Magpie/SettingsCard.cpp
+++ b/src/Magpie/SettingsCard.cpp
@@ -192,6 +192,16 @@ void SettingsCard::OnPointerReleased(PointerRoutedEventArgs const& args) {
 	_isCursorCaptured = false;
 }
 
+void SettingsCard::OnKeyDown(KeyRoutedEventArgs const& args) {
+	// XAML Islands 中 ButtonBase 会吞掉空格和回车，UWP 却没有这个问题。这里使子树中的 TextBox
+	// 能正常工作。https://learn.microsoft.com/en-us/windows/apps/develop/input/keyboard-events
+	// 记录了按钮在 OnKeyDown 中处理空格和回车。
+	IInspectable focusedElem = FocusManager::GetFocusedElement(XamlRoot());
+	if (!focusedElem || !focusedElem.try_as<TextBox>()) {
+		base_type::OnKeyDown(args);
+	}
+}
+
 static bool IsNotEmpty(IInspectable const& value) noexcept {
 	if (!value) {
 		return false;

--- a/src/Magpie/SettingsCard.h
+++ b/src/Magpie/SettingsCard.h
@@ -48,6 +48,8 @@ struct SettingsCard : SettingsCardT<SettingsCard> {
 
 	void OnPointerReleased(Input::PointerRoutedEventArgs const& args);
 
+	void OnKeyDown(Input::KeyRoutedEventArgs const& args);
+
 private:
 	static DependencyProperty _headerProperty;
 	static DependencyProperty _descriptionProperty;


### PR DESCRIPTION
Close #1371 

SettingsCard 继承自 ButtonBase，ButtonBase 使用空格作为快捷键，因此冲突。奇怪的是 UWP 和 WinUI 3 没有这个问题，似乎是 XAML Islands 的 bug。