### PR TITLE
Don't fail scaling on unreadable integrity level when elevated

### DIFF
--- a/src/Magpie.Core/SrcTracker.cpp
+++ b/src/Magpie.Core/SrcTracker.cpp
@@ -55,9 +55,17 @@ ScalingError SrcTracker::Set(HWND hWnd, const ScalingOptions& options, bool& isI
 
 	// 检查 integrity level
 	{
+		const DWORD currentIL = Win32Helper::GetCurrentProcessIntegrityLevel();
 		DWORD windowIL;
-		if (!Win32Helper::GetWindowIntegrityLevel(hWnd, windowIL) ||
-			windowIL > Win32Helper::GetCurrentProcessIntegrityLevel()) {
+		if (Win32Helper::GetWindowIntegrityLevel(hWnd, windowIL)) {
+			if (windowIL > currentIL) {
+				Logger::Get().Error("不支持缩放 IL 更高的窗口");
+				return ScalingError::LowIntegrityLevel;
+			}
+		} else if (currentIL >= SECURITY_MANDATORY_HIGH_RID &&
+			!Win32Helper::GetWindowProcessHandle(hWnd)) {
+			Logger::Get().Warn("Cannot read source window integrity level; process is elevated, proceeding anyway");
+		} else {
 			Logger::Get().Error("不支持缩放 IL 更高的窗口");
 			return ScalingError::LowIntegrityLevel;
 		}


### PR DESCRIPTION
## Description

`SrcTracker::Set` rejects scaling with `ScalingError:LowIntegrityLevel` and shows the run as administrator toast in two different scenarios, and treats them indetically:

1. When the source window has a higher integrity than Magpie
2. When Magpie can't determine the source window's integrity

The second scenario occurs when a handle to the source process can't be opened (`GetProcessHandleFromHwnd` returns `ERROR_ACCESS_DENIED`). This is common on games protected by anti-cheat driver.

When this happens, Magpie prompts the user saying that for it to scale the window it needs to be running as administrator, which can be misleading in case if it is already running as administrator.

## Change

When the integrity level can't be read because the process handle can't be opened and Magpie is running with elevated privileges, log a warning and proceed instead of failing.

This should be ok in most scenarios as `Windows.Graphics.Capture` operates at the compositor level and does not need the source process.

## Video

### Before the change


https://github.com/user-attachments/assets/45f6c181-cc46-4d6f-8ee1-bbabc3c7f6b4


### After the change

https://github.com/user-attachments/assets/def83eec-b95a-4e0f-b191-0d124bd9414d
