### PR TITLE
ONNX/TensorRT upscaling: port to dev, in-app configuration, and fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,82 @@ jobs:
         path: ~/.conan2/p
         key: Conan-${{ hashFiles('src/**/conanfile.txt') }}-${{ matrix.compiler }}-${{ matrix.platform }}
 
+    # ---- ONNX upscaling SDKs (x64 only; there is no ARM64 TensorRT/CUDA) ----
+
+    # TensorRTInferenceBackend.cpp calls the CUDA runtime and includes
+    # <cuda_d3d11_interop.h>; Magpie links cudart.lib.
+    - name: Install CUDA Toolkit
+      if: matrix.platform == 'x64'
+      uses: Jimver/cuda-toolkit@v0.2.24
+      with:
+        cuda: '12.8.0'
+        method: 'network'
+        sub-packages: '["nvcc", "cudart"]'
+
+    - name: Fetch onnxruntime + DirectML
+      if: matrix.platform == 'x64'
+      shell: pwsh
+      run: |
+        $ver = "1.21.0"
+        curl.exe -fsSL -o ort.zip "https://github.com/microsoft/onnxruntime/releases/download/v$ver/onnxruntime-win-x64-gpu-$ver.zip"
+        Expand-Archive ort.zip -DestinationPath C:\sdk -Force
+        Move-Item "C:\sdk\onnxruntime-win-x64-gpu-$ver" C:\sdk\onnxruntime
+
+        # Upstream ORT builds TensorRT and DirectML into one binary; Microsoft's
+        # prebuilts split them. The GPU package has neither the DirectML EP header
+        # nor its export, so take the header from source and the import lib from
+        # the DirectML package. TensorRT/CUDA go through the OrtApi function table
+        # and need no link-time symbol.
+        $dst = "C:\sdk\onnxruntime\include\onnxruntime\core\providers\dml"
+        New-Item -ItemType Directory -Force $dst | Out-Null
+        curl.exe -fsSL -o "$dst\dml_provider_factory.h" `
+          "https://raw.githubusercontent.com/microsoft/onnxruntime/v$ver/include/onnxruntime/core/providers/dml/dml_provider_factory.h"
+
+        curl.exe -fsSL -o ortdml.zip "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.DirectML/$ver"
+        Expand-Archive ortdml.zip -DestinationPath C:\sdk\ort-dml -Force
+        # x64 explicitly - the package ships x86/arm64 alongside and picking the
+        # first match leaves every ORT symbol (OrtGetApiBase) unresolved.
+        $dmlLib = Get-ChildItem C:\sdk\ort-dml -Recurse -Filter onnxruntime.lib |
+          Where-Object { $_.FullName -match '(win-)?x64' -and $_.FullName -notmatch 'arm' } |
+          Select-Object -First 1
+        if (-not $dmlLib) { throw "no x64 onnxruntime.lib in the DirectML package" }
+        Copy-Item $dmlLib.FullName C:\sdk\onnxruntime\lib -Force
+
+        # DirectML.h + DirectML.lib
+        curl.exe -fsSL -o dml.zip "https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML"
+        Expand-Archive dml.zip -DestinationPath C:\sdk\dml-pkg -Force
+        New-Item -ItemType Directory -Force C:\sdk\dml\include, C:\sdk\dml\lib | Out-Null
+        Copy-Item C:\sdk\dml-pkg\include\* C:\sdk\dml\include -Recurse -Force
+        Copy-Item C:\sdk\dml-pkg\bin\x64-win\*.lib C:\sdk\dml\lib -Force
+
+    # nvinfer1 is only referenced in a comment and nothing links nvinfer, so the
+    # open-source headers are enough - no NVIDIA login needed.
+    - name: Fetch TensorRT headers
+      if: matrix.platform == 'x64'
+      shell: pwsh
+      run: |
+        git clone --depth 1 --branch release/10.8 https://github.com/NVIDIA/TensorRT.git C:\trt-oss
+        New-Item -ItemType Directory -Force C:\sdk\TensorRT\include | Out-Null
+        Copy-Item C:\trt-oss\include\* C:\sdk\TensorRT\include -Recurse -Force
+
     - name: Build
       if: github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/main'
+      env:
+        OrtDir: C:\sdk\onnxruntime
+        OrtIncludeDir: C:\sdk\onnxruntime\include
+        OrtLibDir: C:\sdk\onnxruntime\lib
+        TrtDir: C:\sdk\TensorRT
+        DmlDir: C:\sdk\dml
       run: python scripts/publish.py --compiler=${{ matrix.compiler }} --platform=${{ matrix.platform }}
 
     - name: Build and sign
       if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
+      env:
+        OrtDir: C:\sdk\onnxruntime
+        OrtIncludeDir: C:\sdk\onnxruntime\include
+        OrtLibDir: C:\sdk\onnxruntime\lib
+        TrtDir: C:\sdk\TensorRT
+        DmlDir: C:\sdk\dml
       run: python scripts/publish.py --compiler=${{ matrix.compiler }} --platform=${{ matrix.platform }} --pfx-path=certs\Magpie.pfx --pfx-password="${{ secrets.MAGPIE_PFX_PASSWORD }}"
 
     - name: Save hash

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Magpie is a lightweight window upscaling tool that comes equipped with a variety
 
 * Supports both fullscreen and windowed scaling
 * Includes a variety of built-in algorithms and filters, including [Anime4K](https://github.com/bloc97/Anime4K), [FSR](https://github.com/GPUOpen-Effects/FidelityFX-FSR), CRT shaders, and more
+* Optional AI upscaling with ONNX models, via DirectML or TensorRT
 * WinUI-based user interface with support for light and dark themes
 * Multi-monitor support
 
@@ -38,6 +39,24 @@ Magpie is a lightweight window upscaling tool that comes equipped with a variety
   <img src="img/main-window.png" alt= "Main window" height="300">
   <img src="img/screenshot.png" alt= "Main window" height="300">
 </div>
+
+## AI upscaling
+
+Magpie can run an ONNX super-resolution model before the scaling mode's effects, using either DirectML or TensorRT. It is entirely optional — everything else works without it.
+
+**Getting started**
+
+1. Open **Settings → AI upscaling** and click **Download**. This fetches the runtime (about 1 GB compressed, 2.4 GB on disk) from the release assets. It is not bundled because of its size.
+2. Restart Magpie. The runtime is loaded during startup, so a fresh install only takes effect on the next launch.
+3. Put `.onnx` models in the `models` folder next to `Magpie.exe`. None are bundled; **Settings → AI upscaling models** links to [OpenModelDB](https://openmodeldb.info/) and opens the folder. Check each model's own licence before using it — many community models are non-commercial and some prohibit redistribution.
+4. Pick a model per game in its profile, or in **Defaults** for everything.
+
+**Notes**
+
+* **Set "AI model scale" to the model's real factor.** A mismatch produces a broken image with no error.
+* **TensorRT builds an engine on first use**, which can take several minutes. Progress is reported through the tray icon. Engines are cached per model and resolution, so this is a one-time cost per size.
+* **"Render at lower resolution first"** downscales before the model runs and lets the effect chain scale the result back up. This is what makes a native-resolution fullscreen window worth upscaling, and it cuts inference cost substantially.
+* AI upscaling requires a 64-bit build. TensorRT additionally requires an NVIDIA GPU.
 
 ## Hints
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -29,6 +29,7 @@ Magpie 是一个轻量级的窗口超分辨率工具，内置众多高效的算�
 
 * 支持全屏和窗口模式缩放
 * 众多内置算法和滤镜，如 [Anime4K](https://github.com/bloc97/Anime4K)、[FSR](https://github.com/GPUOpen-Effects/FidelityFX-FSR)、CRT 着色器等
+* 可选的 AI 放大：通过 DirectML 或 TensorRT 运行 ONNX 模型
 * 基于 WinUI 的用户界面，支持浅色和深色主题
 * 支持多屏幕
 
@@ -38,6 +39,24 @@ Magpie 是一个轻量级的窗口超分辨率工具，内置众多高效的算�
   <img src="img/main-window-zh.png" alt= "Main window" height="300">
   <img src="img/screenshot.png" alt= "Main window" height="300">
 </div>
+
+## AI 放大
+
+Magpie 可以在缩放模式的效果之前运行 ONNX 超分辨率模型，后端可选 DirectML 或 TensorRT。该功能完全可选，不启用时其余功能一切照常。
+
+**开始使用**
+
+1. 打开 **设置 → AI 放大**，点击 **下载**。这会从 release 资源获取运行时（压缩后约 1 GB，解压后 2.4 GB）。由于体积过大，它不随程序分发。
+2. 重启 Magpie。运行时在启动阶段加载，因此新安装的运行时要到下次启动才生效。
+3. 把 `.onnx` 模型放进 `Magpie.exe` 旁边的 `models` 目录。程序不附带任何模型；**设置 → AI 放大模型** 提供了 [OpenModelDB](https://openmodeldb.info/) 的链接，也可以直接打开该目录。使用前请查看每个模型自己的许可协议——不少社区模型是非商业授权，其中一些禁止再分发。
+4. 在每个游戏的配置文件中选择模型，或在 **默认** 中为所有窗口设置。
+
+**注意事项**
+
+* **“AI 模型缩放倍数”必须和模型的实际倍数一致。** 不匹配会得到错乱的画面，且没有任何报错。
+* **TensorRT 首次使用时需要构建引擎**，可能耗时数分钟，进度通过托盘图标提示。引擎按模型和分辨率缓存，因此每种尺寸只需构建一次。
+* **“先降采样再放大”** 会在模型运行前降低分辨率，再由效果链放大回去。这正是原生分辨率的全屏窗口值得放大的原因，同时能显著降低推理开销。
+* AI 放大需要 64 位版本，TensorRT 还需要 NVIDIA 显卡。
 
 ## 使用提示
 

--- a/src/Common.Post.props
+++ b/src/Common.Post.props
@@ -112,10 +112,12 @@
     <CudaDir Condition="'$(CudaDir)'==''">C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8</CudaDir>
     <DmlDir Condition="'$(DmlDir)'==''">$(OrtDir)</DmlDir>
   </PropertyGroup>
-  <ItemDefinitionGroup>
+  <!-- TensorRT and the CUDA runtime are x64-only on Windows, so the whole
+       ONNX feature is compiled out elsewhere. -->
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
     <ClCompile>
       <!-- Suppress ONNX Runtime's pre-main static init; see main.cpp. -->
-      <PreprocessorDefinitions>ORT_API_MANUAL_INIT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MAGPIE_ONNX_ENABLED;ORT_API_MANUAL_INIT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OrtIncludeDir);$(OrtIncludeDir)\onnxruntime;$(OrtIncludeDir)\onnxruntime\core\session;$(CudaDir)\include;$(TrtDir)\include;$(DmlDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/src/Common.Post.props
+++ b/src/Common.Post.props
@@ -102,4 +102,24 @@
   <Target Name="FixWriteLog" BeforeTargets="_AppendToWriteTlogFile">
     <Delete Files="$(TLogLocation)$(ProjectName).write.1u.tlog" />
   </Target>
+  <!-- onnxruntime / TensorRT / CUDA / DirectML.
+       Overridable so CI can point them at its own layout. -->
+  <PropertyGroup>
+    <OrtDir Condition="'$(OrtDir)'==''">S:\onnxruntime</OrtDir>
+    <OrtIncludeDir Condition="'$(OrtIncludeDir)'==''">$(OrtDir)\include</OrtIncludeDir>
+    <OrtLibDir Condition="'$(OrtLibDir)'==''">$(OrtDir)\build\Windows\Release\Release</OrtLibDir>
+    <TrtDir Condition="'$(TrtDir)'==''">S:\TensorRT-10.8.0.43</TrtDir>
+    <CudaDir Condition="'$(CudaDir)'==''">C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8</CudaDir>
+    <DmlDir Condition="'$(DmlDir)'==''">$(OrtDir)</DmlDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <!-- Suppress ONNX Runtime's pre-main static init; see main.cpp. -->
+      <PreprocessorDefinitions>ORT_API_MANUAL_INIT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(OrtIncludeDir);$(OrtIncludeDir)\onnxruntime;$(OrtIncludeDir)\onnxruntime\core\session;$(CudaDir)\include;$(TrtDir)\include;$(DmlDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OrtLibDir);$(CudaDir)\lib\x64;$(TrtDir)\lib;$(DmlDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
 </Project>

--- a/src/Magpie.Core/DirectMLInferenceBackend.cpp
+++ b/src/Magpie.Core/DirectMLInferenceBackend.cpp
@@ -1,0 +1,615 @@
+#include "pch.h"
+#include "DirectMLInferenceBackend.h"
+#include "OnnxHelper.h"
+#include "DeviceResources.h"
+#include "DirectXHelper.h"
+#include "shaders/TensorToTextureCS.h"
+#include "shaders/TextureToTensorCS.h"
+#include "Logger.h"
+#include "OnnxStatus.h"
+#include <onnxruntime/core/providers/dml/dml_provider_factory.h>
+#include "Win32Helper.h"
+
+namespace Magpie {
+
+static winrt::com_ptr<ID3D12Device> CreateD3D12Device(IDXGIAdapter4* adapter) noexcept {
+#ifdef _DEBUG
+	// 启用 D3D12 调试层
+	{
+		winrt::com_ptr<ID3D12Debug> debugController;
+		HRESULT hr = D3D12GetDebugInterface(IID_PPV_ARGS(&debugController));
+		if (SUCCEEDED(hr)) {
+			debugController->EnableDebugLayer();
+		}
+	}
+#endif
+
+	winrt::com_ptr<ID3D12Device> d3d12Device;
+	HRESULT hr = D3D12CreateDevice(
+		adapter,
+		D3D_FEATURE_LEVEL_11_0,
+		IID_PPV_ARGS(&d3d12Device)
+	);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("D3D12CreateDevice 失败", hr);
+		return d3d12Device;
+	}
+
+	return d3d12Device;
+}
+
+static winrt::com_ptr<IDMLDevice> CreateDMLDevice(ID3D12Device* d3d12Device) noexcept {
+	winrt::com_ptr<IDMLDevice> dmlDevice;
+	HRESULT hr = DMLCreateDevice1(
+		d3d12Device,
+#ifdef _DEBUG
+		DML_CREATE_DEVICE_FLAG_DEBUG,
+#else
+		DML_CREATE_DEVICE_FLAG_NONE,
+#endif
+		// https://github.com/microsoft/onnxruntime/blob/554fb4ad1fcf808304d4758d73d93a8ecc362bf6/onnxruntime/core/providers/dml/dml_provider_factory.cc#L519
+		DML_FEATURE_LEVEL_5_0,
+		IID_PPV_ARGS(&dmlDevice)
+	);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("DMLCreateDevice1 失败", hr);
+		return dmlDevice;
+	}
+
+	return dmlDevice;
+}
+
+static winrt::com_ptr<ID3D12Resource> ShareTextureWithD3D12(ID3D11Texture2D* texture, ID3D12Device* d3d12Device, DWORD access) noexcept {
+	winrt::com_ptr<ID3D12Resource> result;
+
+	winrt::com_ptr<IDXGIResource1> dxgiResource;
+	HRESULT hr = texture->QueryInterface<IDXGIResource1>(dxgiResource.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("获取 IDXGIResource1 失败", hr);
+		return result;
+	}
+
+	wil::unique_handle sharedHandle;
+	hr = dxgiResource->CreateSharedHandle(nullptr, access, nullptr, sharedHandle.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateSharedHandle 失败", hr);
+		return result;
+	}
+
+	hr = d3d12Device->OpenSharedHandle(sharedHandle.get(), IID_PPV_ARGS(&result));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("OpenSharedHandle 失败", hr);
+		return result;
+	}
+
+	return result;
+}
+
+static winrt::com_ptr<IUnknown> AllocateD3D12Resource(const OrtDmlApi* ortDmlApi, ID3D12Resource* buffer) {
+	void* dmlResource;
+	Ort::ThrowOnError(ortDmlApi->CreateGPUAllocationFromD3DResource(buffer, &dmlResource));
+
+	winrt::com_ptr<IUnknown> allocatedBuffer;
+	allocatedBuffer.copy_from((IUnknown*)dmlResource);
+
+	Ort::ThrowOnError(ortDmlApi->FreeGPUAllocation(dmlResource));
+
+	return allocatedBuffer;
+}
+
+bool DirectMLInferenceBackend::Initialize(
+	const wchar_t* modelPath,
+	uint32_t scale,
+	DeviceResources& deviceResources,
+	BackendDescriptorStore& /*descriptorStore*/,
+	ID3D11Texture2D* input,
+	ID3D11Texture2D** output
+) noexcept {
+	ID3D11Device5* d3d11Device = deviceResources.GetD3DDevice();
+	_d3d11DC = deviceResources.GetD3DDC();
+
+	const SIZE inputSize = OnnxHelper::GetTextureSize(input);
+	const SIZE outputSize{ inputSize.cx * (LONG)scale, inputSize.cy * (LONG)scale };
+
+	// 创建输出纹理
+	_outputTex = DirectXHelper::CreateTexture2D(
+		d3d11Device,
+		DXGI_FORMAT_R8G8B8A8_UNORM,
+		outputSize.cx,
+		outputSize.cy,
+		D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS,
+		D3D11_USAGE_DEFAULT,
+		D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_NTHANDLE
+	);
+	if (!_outputTex) {
+		Logger::Get().Error("创建输出纹理失败");
+		return false;
+	}
+	*output = _outputTex.get();
+
+	const uint32_t inputElemCount = uint32_t(inputSize.cx * inputSize.cy * 3);
+	const uint32_t outputElemCount = uint32_t(outputSize.cx * outputSize.cy * 3);
+
+	winrt::com_ptr<ID3D12Device> d3d12Device = CreateD3D12Device(deviceResources.GetGraphicsAdapter());
+	if (!d3d12Device) {
+		Logger::Get().Error("CreateD3D12Device 失败");
+		return false;
+	}
+
+	{
+		D3D12_COMMAND_QUEUE_DESC desc{
+			.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE,
+			.Flags = D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT
+		};
+
+		HRESULT hr = d3d12Device->CreateCommandQueue(&desc, IID_PPV_ARGS(&_commandQueue));
+		if (FAILED(hr)) {
+			return false;
+		}
+	}
+
+	bool isFP16Data = false;
+
+	try {
+		const OrtApi& ortApi = Ort::GetApi();
+
+		_env = Ort::Env(ORT_LOGGING_LEVEL_INFO, "", _OrtLog, nullptr);
+
+		const OrtDmlApi* ortDmlApi = nullptr;
+		// 必须检查返回值：运行库没有 DirectML EP 时 ortDmlApi 会保持为空
+		// The status must be checked - without the DirectML EP in the runtime,
+		// ortDmlApi stays null and the call below would dereference it.
+		// Microsoft's prebuilt packages split the providers: the GPU build ships
+		// CUDA and TensorRT but no DirectML.
+		Ort::ThrowOnError(ortApi.GetExecutionProviderApi(
+			"DML", ORT_API_VERSION, (const void**)&ortDmlApi));
+		if (!ortDmlApi) {
+			Logger::Get().Error(
+				"DirectML EP 不可用 / the DirectML execution provider is not present "
+				"in third_party\\onnxruntime.dll - use the TensorRT backend, or "
+				"replace it with an onnxruntime build that includes DirectML.");
+			OnnxStatus::Report(L"DirectML unavailable",
+				L"This onnxruntime build has no DirectML provider. Switch the "
+				L"backend to TensorRT.");
+			return false;
+		}
+
+		Ort::SessionOptions sessionOptions;
+		sessionOptions.SetIntraOpNumThreads(1);
+		sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
+		sessionOptions.DisableMemPattern();
+
+		Ort::ThrowOnError(ortApi.AddFreeDimensionOverride(sessionOptions, "DATA_BATCH", 1));
+
+		winrt::com_ptr<IDMLDevice> dmlDevice = CreateDMLDevice(d3d12Device.get());
+		if (!dmlDevice) {
+			Logger::Get().Error("CreateDMLDevice 失败");
+			return false;
+		}
+
+		Ort::ThrowOnError(ortDmlApi->SessionOptionsAppendExecutionProvider_DML1(
+			sessionOptions, dmlDevice.get(), _commandQueue.get()));
+
+		_session = Ort::Session(_env, modelPath, sessionOptions);
+
+		if (!_IsModelValid(_session, isFP16Data)) {
+			Logger::Get().Error("不支持此模型");
+			return false;
+		}
+
+		// 创建张量缓冲区
+		{
+			D3D12_HEAP_PROPERTIES heapDesc{
+				.Type = D3D12_HEAP_TYPE_DEFAULT
+			};
+			D3D12_RESOURCE_DESC resDesc{
+				.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER,
+				.Width = (inputElemCount * (isFP16Data ? 2 : 4) + 3) & ~3,
+				.Height = 1,
+				.DepthOrArraySize = 1,
+				.MipLevels = 1,
+				.SampleDesc{
+					.Count = 1
+				},
+				.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+				.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
+			};
+			HRESULT hr = d3d12Device->CreateCommittedResource(
+				&heapDesc,
+				D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
+				&resDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&_inputBuffer)
+			);
+			if (FAILED(hr)) {
+				return false;
+			}
+
+			resDesc.Width = UINT64((outputElemCount * (isFP16Data ? 2 : 4) + 3) & ~3);
+			hr = d3d12Device->CreateCommittedResource(
+				&heapDesc,
+				D3D12_HEAP_FLAG_CREATE_NOT_ZEROED,
+				&resDesc,
+				D3D12_RESOURCE_STATE_COMMON,
+				nullptr,
+				IID_PPV_ARGS(&_outputBuffer)
+			);
+			if (FAILED(hr)) {
+				return false;
+			}
+		}
+
+		// 创建 IOBinding
+		_ioBinding = Ort::IoBinding(_session);
+
+		// DmlExecutionProvider 的 device_id 始终为 0，传其他值会出错。
+		// 见 https://github.com/microsoft/onnxruntime/blob/89f8206ba4f1c22c39e0297fb55272e8ce8cd7d0/onnxruntime/core/providers/dml/DmlExecutionProvider/src/ExecutionProvider.cpp#L77
+		// WinML 也始终使用 0: https://github.com/microsoft/onnxruntime/blob/89f8206ba4f1c22c39e0297fb55272e8ce8cd7d0/winml/lib/Api.Ort/OnnxruntimeEngine.cpp#L654
+		Ort::MemoryInfo memoryInfo(
+			"DML",
+			OrtAllocatorType::OrtDeviceAllocator,
+			0,
+			OrtMemType::OrtMemTypeDefault
+		);
+
+		const ONNXTensorElementDataType dataType =
+			isFP16Data ? ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 : ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+
+		const int64_t inputShape[]{ 1,3,inputSize.cy,inputSize.cx };
+		_allocatedInput = AllocateD3D12Resource(ortDmlApi, _inputBuffer.get());
+		_ioBinding.BindInput("input", Ort::Value::CreateTensor(
+			memoryInfo,
+			_allocatedInput.get(),
+			size_t(inputElemCount * (isFP16Data ? 2 : 4)),
+			inputShape,
+			std::size(inputShape),
+			dataType
+		));
+
+		const int64_t outputShape[]{ 1,3,outputSize.cy,outputSize.cx };
+		_allocatedOutput = AllocateD3D12Resource(ortDmlApi, _outputBuffer.get());
+		_ioBinding.BindOutput("output", Ort::Value::CreateTensor(
+			memoryInfo,
+			_allocatedOutput.get(),
+			size_t(outputElemCount * (isFP16Data ? 2 : 4)),
+			outputShape,
+			std::size(outputShape),
+			dataType
+		));
+	} catch (const Ort::Exception& e) {
+		Logger::Get().Error(e.what());
+		return false;
+	}
+
+	if (!_CreateFence(d3d11Device, d3d12Device.get())) {
+		Logger::Get().Error("_CreateFence 失败");
+		return false;
+	}
+
+	_d3d12InputTex = ShareTextureWithD3D12(input, d3d12Device.get(), DXGI_SHARED_RESOURCE_READ);
+	_d3d12OutputTex = ShareTextureWithD3D12(_outputTex.get(), d3d12Device.get(),
+		DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE);
+	if (!_d3d12InputTex || !_d3d12OutputTex) {
+		Logger::Get().Error("ShareTextureWithD3D12 失败");
+		return false;
+	}
+
+	UINT descriptorSize;
+	if (!_CreateCBVHeap(d3d12Device.get(), inputElemCount, outputElemCount, isFP16Data, descriptorSize)) {
+		Logger::Get().Error("_CreateCBVHeap 失败");
+		return false;
+	}
+
+	if (!_CreatePipelineStates(d3d12Device.get())) {
+		Logger::Get().Error("_CreatePipelineStates 失败");
+		return false;
+	}
+
+	if (!_CalcCommandLists(d3d12Device.get(), inputSize, outputSize, descriptorSize)) {
+		Logger::Get().Error("_CalcCommandLists 失败");
+		return false;
+	}
+
+	return true;
+}
+
+void DirectMLInferenceBackend::Evaluate() noexcept {
+	HRESULT hr = _d3d11DC->Signal(_d3d11Fence.get(), ++_fenceValue);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("Signal 失败", hr);
+		return;
+	}
+	_d3d11DC->Flush();
+
+	hr = _commandQueue->Wait(_d3d12Fence.get(), _fenceValue);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("Wait 失败", hr);
+		return;
+	}
+
+	// 输入纹理 -> 输入张量
+	{
+		ID3D12CommandList* t = _tex2TensorCommandList.get();
+		_commandQueue->ExecuteCommandLists(1, &t);
+	}
+
+	try {
+		_session.Run(Ort::RunOptions{ nullptr }, _ioBinding);
+	} catch (const Ort::Exception& e) {
+		Logger::Get().Error(e.what());
+		return;
+	}
+	
+	// 输出张量 -> 输出纹理
+	{
+		ID3D12CommandList* t = _tensor2TexCommandList.get();
+		_commandQueue->ExecuteCommandLists(1, &t);
+	}
+
+	hr = _commandQueue->Signal(_d3d12Fence.get(), ++_fenceValue);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("Signal 失败", hr);
+		return;
+	}
+
+	hr = _d3d11DC->Wait(_d3d11Fence.get(), _fenceValue);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("Wait 失败", hr);
+		return;
+	}
+}
+
+bool DirectMLInferenceBackend::_CreateFence(ID3D11Device5* d3d11Device, ID3D12Device* d3d12Device) noexcept {
+	HRESULT hr = d3d11Device->CreateFence(
+		_fenceValue, D3D11_FENCE_FLAG_SHARED, IID_PPV_ARGS(&_d3d11Fence));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateFence 失败", hr);
+		return false;
+	}
+
+	wil::unique_handle sharedHandle;
+	hr = _d3d11Fence->CreateSharedHandle(nullptr, GENERIC_ALL, nullptr, sharedHandle.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateSharedHandle 失败", hr);
+		return false;
+	}
+
+	hr = d3d12Device->OpenSharedHandle(sharedHandle.get(), IID_PPV_ARGS(&_d3d12Fence));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("OpenSharedHandle 失败", hr);
+		return false;
+	}
+
+	return true;
+}
+
+bool DirectMLInferenceBackend::_CreateCBVHeap(
+	ID3D12Device* d3d12Device,
+	uint32_t inputElemCount,
+	uint32_t outputElemCount,
+	bool isFP16Data, 
+	UINT& descriptorSize
+) noexcept {
+	{
+		D3D12_DESCRIPTOR_HEAP_DESC desc{
+			.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
+			.NumDescriptors = 4,
+			.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE
+		};
+
+		HRESULT hr = d3d12Device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&_cbvHeap));
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateDescriptorHeap 失败", hr);
+			return false;
+		}
+	}
+
+	descriptorSize = d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+
+	D3D12_CPU_DESCRIPTOR_HANDLE cbvHandle = _cbvHeap->GetCPUDescriptorHandleForHeapStart();
+
+	d3d12Device->CreateShaderResourceView(_d3d12InputTex.get(), nullptr, cbvHandle);
+	cbvHandle.ptr += descriptorSize;
+
+	{
+		D3D12_UNORDERED_ACCESS_VIEW_DESC desc{
+			.Format = isFP16Data ? DXGI_FORMAT_R16_FLOAT : DXGI_FORMAT_R32_FLOAT,
+			.ViewDimension = D3D12_UAV_DIMENSION_BUFFER,
+			.Buffer{
+				.NumElements = inputElemCount
+			}
+		};
+		d3d12Device->CreateUnorderedAccessView(_inputBuffer.get(), nullptr, &desc, cbvHandle);
+	}
+	cbvHandle.ptr += descriptorSize;
+
+	{
+		D3D12_SHADER_RESOURCE_VIEW_DESC desc{
+			.Format = isFP16Data ? DXGI_FORMAT_R16_FLOAT : DXGI_FORMAT_R32_FLOAT,
+			.ViewDimension = D3D12_SRV_DIMENSION_BUFFER,
+			.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
+			.Buffer{
+				.NumElements = outputElemCount
+			}
+		};
+		d3d12Device->CreateShaderResourceView(_outputBuffer.get(), &desc, cbvHandle);
+	}
+	cbvHandle.ptr += descriptorSize;
+
+	d3d12Device->CreateUnorderedAccessView(_d3d12OutputTex.get(), nullptr, nullptr, cbvHandle);
+	return true;
+}
+
+bool DirectMLInferenceBackend::_CreatePipelineStates(ID3D12Device* d3d12Device) noexcept {
+	{
+		D3D12_DESCRIPTOR_RANGE ranges[]{
+			D3D12_DESCRIPTOR_RANGE{
+				.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV,
+				.NumDescriptors = 1,
+				.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND
+			},
+			D3D12_DESCRIPTOR_RANGE{
+				.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV,
+				.NumDescriptors = 1,
+				.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND
+			},
+		};
+
+		D3D12_ROOT_PARAMETER rootParam{
+			D3D12_ROOT_PARAMETER{
+				.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+				.DescriptorTable{
+					.NumDescriptorRanges = (UINT)std::size(ranges),
+					.pDescriptorRanges = ranges
+				}
+			}
+		};
+
+		D3D12_STATIC_SAMPLER_DESC samDesc{
+			.Filter = D3D12_FILTER_MIN_MAG_MIP_POINT,
+			.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+			.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+			.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+			.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER
+		};
+
+		D3D12_VERSIONED_ROOT_SIGNATURE_DESC desc{
+			.Version = D3D_ROOT_SIGNATURE_VERSION_1_0,
+			.Desc_1_0{
+				.NumParameters = 1,
+				.pParameters = &rootParam,
+				.NumStaticSamplers = 1,
+				.pStaticSamplers = &samDesc
+			}
+		};
+
+		winrt::com_ptr<ID3DBlob> blob;
+		HRESULT hr = D3D12SerializeVersionedRootSignature(&desc, blob.put(), nullptr);
+		if (FAILED(hr)) {
+			Logger::Get().ComError("D3D12SerializeVersionedRootSignature 失败", hr);
+			return false;
+		}
+
+		hr = d3d12Device->CreateRootSignature(
+			0,
+			blob->GetBufferPointer(),
+			blob->GetBufferSize(),
+			IID_PPV_ARGS(&_rootSignature)
+		);
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateRootSignature 失败", hr);
+			return false;
+		}
+	}
+
+	D3D12_COMPUTE_PIPELINE_STATE_DESC desc{
+		.pRootSignature = _rootSignature.get(),
+		.CS{
+			.pShaderBytecode = TextureToTensorCS,
+			.BytecodeLength = std::size(TextureToTensorCS)
+		}
+	};
+	HRESULT hr = d3d12Device->CreateComputePipelineState(&desc, IID_PPV_ARGS(&_tex2TensorPipelineState));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateComputePipelineState 失败", hr);
+		return false;
+	}
+
+	desc.CS.pShaderBytecode = TensorToTextureCS;
+	desc.CS.BytecodeLength = std::size(TensorToTextureCS);
+	hr = d3d12Device->CreateComputePipelineState(&desc, IID_PPV_ARGS(&_tensor2TexPipelineState));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateComputePipelineState 失败", hr);
+		return false;
+	}
+
+	return true;
+}
+
+bool DirectMLInferenceBackend::_CalcCommandLists(
+	ID3D12Device* d3d12Device,
+	SIZE inputSize,
+	SIZE outputSize,
+	UINT descriptorSize
+) noexcept {
+	winrt::com_ptr<ID3D12CommandAllocator> d3d12CommandAllocator;
+	HRESULT hr = d3d12Device->CreateCommandAllocator(
+		D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&d3d12CommandAllocator));
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateCommandAllocator 失败", hr);
+		return false;
+	}
+
+	// 输入纹理 -> 输入张量
+	hr = d3d12Device->CreateCommandList(
+		0,
+		D3D12_COMMAND_LIST_TYPE_COMPUTE,
+		d3d12CommandAllocator.get(),
+		_tex2TensorPipelineState.get(),
+		IID_PPV_ARGS(&_tex2TensorCommandList)
+	);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateCommandList 失败", hr);
+		return false;
+	}
+
+	_tex2TensorCommandList->SetComputeRootSignature(_rootSignature.get());
+	{
+		ID3D12DescriptorHeap* t = _cbvHeap.get();
+		_tex2TensorCommandList->SetDescriptorHeaps(1, &t);
+	}
+	_tex2TensorCommandList->SetComputeRootDescriptorTable(0, _cbvHeap->GetGPUDescriptorHandleForHeapStart());
+
+	static constexpr std::pair<uint32_t, uint32_t> TEX_TO_TENSOR_BLOCK_SIZE{ 16, 16 };
+	_tex2TensorCommandList->Dispatch(
+		(inputSize.cx + TEX_TO_TENSOR_BLOCK_SIZE.first - 1) / TEX_TO_TENSOR_BLOCK_SIZE.first,
+		(inputSize.cy + TEX_TO_TENSOR_BLOCK_SIZE.second - 1) / TEX_TO_TENSOR_BLOCK_SIZE.second,
+		1
+	);
+	hr = _tex2TensorCommandList->Close();
+	if (FAILED(hr)) {
+		Logger::Get().ComError("Close 失败", hr);
+		return false;
+	}
+
+	// 输出张量 -> 输出纹理
+	hr = d3d12Device->CreateCommandList(
+		0,
+		D3D12_COMMAND_LIST_TYPE_COMPUTE,
+		d3d12CommandAllocator.get(),
+		_tensor2TexPipelineState.get(),
+		IID_PPV_ARGS(&_tensor2TexCommandList)
+	);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateCommandList 失败", hr);
+		return false;
+	}
+
+	_tensor2TexCommandList->SetComputeRootSignature(_rootSignature.get());
+	{
+		ID3D12DescriptorHeap* t = _cbvHeap.get();
+		_tensor2TexCommandList->SetDescriptorHeaps(1, &t);
+	}
+	{
+		D3D12_GPU_DESCRIPTOR_HANDLE gpuHandle = _cbvHeap->GetGPUDescriptorHandleForHeapStart();
+		gpuHandle.ptr += 2 * static_cast<UINT64>(descriptorSize);
+		_tensor2TexCommandList->SetComputeRootDescriptorTable(0, gpuHandle);
+	}
+
+	static constexpr std::pair<uint32_t, uint32_t> TENSOR_TO_TEX_BLOCK_SIZE{ 8, 8 };
+	_tensor2TexCommandList->Dispatch(
+		(outputSize.cx + TENSOR_TO_TEX_BLOCK_SIZE.first - 1) / TENSOR_TO_TEX_BLOCK_SIZE.first,
+		(outputSize.cy + TENSOR_TO_TEX_BLOCK_SIZE.second - 1) / TENSOR_TO_TEX_BLOCK_SIZE.second,
+		1
+	);
+	hr = _tensor2TexCommandList->Close();
+	if (FAILED(hr)) {
+		Logger::Get().ComError("Close 失败", hr);
+		return false;
+	}
+
+	return true;
+}
+
+}

--- a/src/Magpie.Core/DirectMLInferenceBackend.h
+++ b/src/Magpie.Core/DirectMLInferenceBackend.h
@@ -1,0 +1,77 @@
+#pragma once
+#include "InferenceBackendBase.h"
+#include <d3d12.h>
+
+struct OrtDmlApi;
+
+namespace Magpie {
+
+class DirectMLInferenceBackend : public InferenceBackendBase {
+public:
+	DirectMLInferenceBackend() = default;
+	DirectMLInferenceBackend(const DirectMLInferenceBackend&) = delete;
+	DirectMLInferenceBackend(DirectMLInferenceBackend&&) = default;
+
+	bool Initialize(
+		const wchar_t* modelPath,
+		uint32_t scale,
+		DeviceResources& deviceResources,
+		BackendDescriptorStore& descriptorStore,
+		ID3D11Texture2D* input,
+		ID3D11Texture2D** output
+	) noexcept override;
+
+	void Evaluate() noexcept override;
+
+private:
+	bool _CreateFence(ID3D11Device5* d3d11Device, ID3D12Device* d3d12Device) noexcept;
+
+	bool _CreateCBVHeap(
+		ID3D12Device* d3d12Device,
+		uint32_t inputElemCount,
+		uint32_t outputElemCount,
+		bool isFP16Data,
+		UINT& descriptorSize
+	) noexcept;
+
+	bool _CreatePipelineStates(ID3D12Device* d3d12Device) noexcept;
+
+	bool _CalcCommandLists(
+		ID3D12Device* d3d12Device,
+		SIZE inputSize,
+		SIZE outputSize,
+		UINT descriptorSize
+	) noexcept;
+
+	ID3D11DeviceContext4* _d3d11DC = nullptr;
+
+	winrt::com_ptr<ID3D11Texture2D> _outputTex;
+
+	winrt::com_ptr<ID3D11Fence> _d3d11Fence;
+	winrt::com_ptr<ID3D12Fence> _d3d12Fence;
+	UINT64 _fenceValue = 0;
+
+	winrt::com_ptr<ID3D12Resource> _d3d12InputTex;
+	winrt::com_ptr<ID3D12Resource> _d3d12OutputTex;
+	winrt::com_ptr<ID3D12Resource> _inputBuffer;
+	winrt::com_ptr<ID3D12Resource> _outputBuffer;
+
+	winrt::com_ptr<ID3D12DescriptorHeap> _cbvHeap;
+	winrt::com_ptr<ID3D12RootSignature> _rootSignature;
+	winrt::com_ptr<ID3D12PipelineState> _tex2TensorPipelineState;
+	winrt::com_ptr<ID3D12PipelineState> _tensor2TexPipelineState;
+
+	winrt::com_ptr<ID3D12CommandQueue> _commandQueue;
+	winrt::com_ptr<ID3D12GraphicsCommandList> _tex2TensorCommandList;
+	winrt::com_ptr<ID3D12GraphicsCommandList> _tensor2TexCommandList;
+
+	Ort::Env _env{ nullptr };
+	Ort::Session _session{ nullptr };
+
+	winrt::com_ptr<IUnknown> _allocatedInput;
+	winrt::com_ptr<IUnknown> _allocatedOutput;
+
+	Ort::IoBinding _ioBinding{ nullptr };
+};
+
+}

--- a/src/Magpie.Core/HashHelper.cpp
+++ b/src/Magpie.Core/HashHelper.cpp
@@ -1,0 +1,29 @@
+#include "pch.h"
+#include "HashHelper.h"
+
+namespace Magpie {
+
+// FNV-1a. 仅用于缓存键，不需要密码学强度，但必须稳定
+// FNV-1a. Only used as a cache key - no cryptographic strength needed, but it
+// must stay stable across runs or every engine would rebuild.
+uint64_t HashHelper::Hash64(std::span<const uint8_t> data) noexcept {
+	uint64_t hash = 14695981039346656037ULL;
+	for (uint8_t b : data) {
+		hash ^= (uint64_t)b;
+		hash *= 1099511628211ULL;
+	}
+	return hash;
+}
+
+std::wstring HashHelper::HexHash(std::span<const uint8_t> data) noexcept {
+	const uint64_t hash = Hash64(data);
+
+	std::wstring result(16, L'0');
+	for (int i = 15; i >= 0; --i) {
+		const uint8_t nibble = (uint8_t)((hash >> ((15 - i) * 4)) & 0xF);
+		result[i] = nibble < 10 ? (wchar_t)(L'0' + nibble) : (wchar_t)(L'a' + nibble - 10);
+	}
+	return result;
+}
+
+}

--- a/src/Magpie.Core/HashHelper.h
+++ b/src/Magpie.Core/HashHelper.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace Magpie {
+
+// 上游移除了 Utils::HashData，这里自带实现以免依赖已删除的头文件
+// Upstream removed Utils::HashData, so this carries its own implementation
+// rather than depending on a header that no longer exists.
+struct HashHelper {
+	static uint64_t Hash64(std::span<const uint8_t> data) noexcept;
+
+	static std::wstring HexHash(std::span<const uint8_t> data) noexcept;
+};
+
+}

--- a/src/Magpie.Core/InferenceBackendBase.cpp
+++ b/src/Magpie.Core/InferenceBackendBase.cpp
@@ -1,0 +1,87 @@
+#include "pch.h"
+#include "InferenceBackendBase.h"
+#include "StrHelper.h"
+#include "Logger.h"
+#include "OnnxStatus.h"
+
+namespace Magpie {
+
+void ORT_API_CALL InferenceBackendBase::_OrtLog(
+	void* /*param*/,
+	OrtLoggingLevel severity,
+	const char* /*category*/,
+	const char* /*logid*/,
+	const char* /*code_location*/,
+	const char* message
+) {
+	const char* SEVERITIES[] = {
+		"verbose",
+		"info",
+		"warning",
+		"error",
+		"fatal"
+	};
+
+	std::string log = StrHelper::Concat("[", SEVERITIES[severity], "] ", message);
+	if (severity == ORT_LOGGING_LEVEL_INFO) {
+		Logger::Get().Info(log);
+		OutputDebugStringA((log + "\n").c_str());
+	} else if (severity == ORT_LOGGING_LEVEL_WARNING) {
+		Logger::Get().Warn(log);
+	} else {
+		Logger::Get().Error(log);
+	}
+}
+
+static bool IsTensorShapeValid(const Ort::ConstTensorTypeAndShapeInfo& tensorInfo) {
+	// 输入输出维度应是 [-1,3,-1,-1]
+	std::vector<int64_t> dimensions = tensorInfo.GetShape();
+	return dimensions.size() == 4 && dimensions[0] == -1 &&
+		dimensions[1] == 3 && dimensions[2] == -1 && dimensions[3] == -1;
+}
+
+bool InferenceBackendBase::_IsModelValid(const Ort::Session& session, bool& isFP16Data) {
+	if (session.GetInputCount() != 1 || session.GetOutputCount() != 1) {
+		Logger::Get().Error("不支持有多个输入/输出的模型");
+		return false;
+	}
+
+	// 必须在 inputTypeInfo 的生命周期内使用 inputTensorInfo
+	Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
+	Ort::ConstTensorTypeAndShapeInfo inputTensorInfo = inputTypeInfo.GetTensorTypeAndShapeInfo();
+
+	ONNXTensorElementDataType dataType = inputTensorInfo.GetElementType();
+	if (dataType != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 && dataType != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+		Logger::Get().Error("不支持 float16 和 float 之外的输入数据类型");
+		return false;
+	}
+
+	isFP16Data = dataType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+
+	Ort::TypeInfo outputInfo = session.GetOutputTypeInfo(0);
+	Ort::ConstTensorTypeAndShapeInfo outputTensorInfo = outputInfo.GetTensorTypeAndShapeInfo();
+	if (outputInfo.GetTensorTypeAndShapeInfo().GetElementType() != dataType) {
+		Logger::Get().Error("不支持输入和输出数据类型不同的模型");
+		return false;
+	}
+
+	if (!IsTensorShapeValid(inputTensorInfo)) {
+		Logger::Get().Error("不支持的输入数据格式");
+		return false;
+	}
+
+	if (!IsTensorShapeValid(outputTensorInfo)) {
+		Logger::Get().Error("不支持的输出数据格式");
+		return false;
+	}
+	
+	return true;
+}
+
+
+void OnnxStatus::InitOrtApi() noexcept {
+	Ort::InitApi();
+	IsOrtAvailable = true;
+}
+
+}

--- a/src/Magpie.Core/InferenceBackendBase.h
+++ b/src/Magpie.Core/InferenceBackendBase.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <onnxruntime_cxx_api.h>
+
+namespace Magpie {
+
+class DeviceResources;
+class BackendDescriptorStore;
+
+class InferenceBackendBase {
+public:
+	InferenceBackendBase() = default;
+	virtual ~InferenceBackendBase() noexcept {}
+
+	InferenceBackendBase(const InferenceBackendBase&) = delete;
+	InferenceBackendBase(InferenceBackendBase&&) = default;
+
+	virtual bool Initialize(
+		const wchar_t* modelPath,
+		uint32_t scale,
+		DeviceResources& deviceResources,
+		BackendDescriptorStore& descriptorStore,
+		ID3D11Texture2D* input,
+		ID3D11Texture2D** output
+	) noexcept = 0;
+
+	virtual void Evaluate() noexcept = 0;
+
+protected:
+	static void ORT_API_CALL _OrtLog(
+		void* /*param*/,
+		OrtLoggingLevel severity,
+		const char* /*category*/,
+		const char* /*logid*/,
+		const char* /*code_location*/,
+		const char* message
+	);
+
+	static bool _IsModelValid(const Ort::Session& session, bool& isFP16Data);
+};
+
+}

--- a/src/Magpie.Core/Magpie.Core.vcxproj
+++ b/src/Magpie.Core/Magpie.Core.vcxproj
@@ -76,12 +76,12 @@
     <ClInclude Include="include\Event.h" />
     <ClInclude Include="OverlayDrawer.h" />
     <ClInclude Include="PresenterBase.h" />
-    <ClInclude Include="DirectMLInferenceBackend.h" />
-    <ClInclude Include="InferenceBackendBase.h" />
+    <ClInclude Include="DirectMLInferenceBackend.h" Condition="'$(Platform)'=='x64'" />
+    <ClInclude Include="InferenceBackendBase.h" Condition="'$(Platform)'=='x64'" />
     <ClInclude Include="HashHelper.h" />
-    <ClInclude Include="OnnxEffectDrawer.h" />
-    <ClInclude Include="OnnxHelper.h" />
-    <ClInclude Include="TensorRTInferenceBackend.h" />
+    <ClInclude Include="OnnxEffectDrawer.h" Condition="'$(Platform)'=='x64'" />
+    <ClInclude Include="OnnxHelper.h" Condition="'$(Platform)'=='x64'" />
+    <ClInclude Include="TensorRTInferenceBackend.h" Condition="'$(Platform)'=='x64'" />
     <ClInclude Include="Renderer.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ScalingWindow.h" />
@@ -119,11 +119,11 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="PresenterBase.cpp" />
-    <ClCompile Include="DirectMLInferenceBackend.cpp" />
-    <ClCompile Include="InferenceBackendBase.cpp" />
+    <ClCompile Include="DirectMLInferenceBackend.cpp" Condition="'$(Platform)'=='x64'" />
+    <ClCompile Include="InferenceBackendBase.cpp" Condition="'$(Platform)'=='x64'" />
     <ClCompile Include="HashHelper.cpp" />
-    <ClCompile Include="OnnxEffectDrawer.cpp" />
-    <ClCompile Include="TensorRTInferenceBackend.cpp" />
+    <ClCompile Include="OnnxEffectDrawer.cpp" Condition="'$(Platform)'=='x64'" />
+    <ClCompile Include="TensorRTInferenceBackend.cpp" Condition="'$(Platform)'=='x64'" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="ScalingOptions.cpp" />
     <ClCompile Include="ScalingRuntime.cpp" />
@@ -137,13 +137,13 @@
     <ClCompile Include="WindowHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <FxCompile Include="shaders\DownscaleCS.hlsl">
+    <FxCompile Include="shaders\DownscaleCS.hlsl" Condition="'$(Platform)'=='x64'">
       <ShaderType>Compute</ShaderType>
     </FxCompile>
-    <FxCompile Include="shaders\TextureToTensorCS.hlsl">
+    <FxCompile Include="shaders\TextureToTensorCS.hlsl" Condition="'$(Platform)'=='x64'">
       <ShaderType>Compute</ShaderType>
     </FxCompile>
-    <FxCompile Include="shaders\TensorToTextureCS.hlsl">
+    <FxCompile Include="shaders\TensorToTextureCS.hlsl" Condition="'$(Platform)'=='x64'">
       <ShaderType>Compute</ShaderType>
     </FxCompile>
     <FxCompile Include="shaders\DuplicateFrameCS.hlsl">

--- a/src/Magpie.Core/Magpie.Core.vcxproj
+++ b/src/Magpie.Core/Magpie.Core.vcxproj
@@ -76,6 +76,12 @@
     <ClInclude Include="include\Event.h" />
     <ClInclude Include="OverlayDrawer.h" />
     <ClInclude Include="PresenterBase.h" />
+    <ClInclude Include="DirectMLInferenceBackend.h" />
+    <ClInclude Include="InferenceBackendBase.h" />
+    <ClInclude Include="HashHelper.h" />
+    <ClInclude Include="OnnxEffectDrawer.h" />
+    <ClInclude Include="OnnxHelper.h" />
+    <ClInclude Include="TensorRTInferenceBackend.h" />
     <ClInclude Include="Renderer.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ScalingWindow.h" />
@@ -113,6 +119,11 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="PresenterBase.cpp" />
+    <ClCompile Include="DirectMLInferenceBackend.cpp" />
+    <ClCompile Include="InferenceBackendBase.cpp" />
+    <ClCompile Include="HashHelper.cpp" />
+    <ClCompile Include="OnnxEffectDrawer.cpp" />
+    <ClCompile Include="TensorRTInferenceBackend.cpp" />
     <ClCompile Include="Renderer.cpp" />
     <ClCompile Include="ScalingOptions.cpp" />
     <ClCompile Include="ScalingRuntime.cpp" />
@@ -126,6 +137,15 @@
     <ClCompile Include="WindowHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <FxCompile Include="shaders\DownscaleCS.hlsl">
+      <ShaderType>Compute</ShaderType>
+    </FxCompile>
+    <FxCompile Include="shaders\TextureToTensorCS.hlsl">
+      <ShaderType>Compute</ShaderType>
+    </FxCompile>
+    <FxCompile Include="shaders\TensorToTextureCS.hlsl">
+      <ShaderType>Compute</ShaderType>
+    </FxCompile>
     <FxCompile Include="shaders\DuplicateFrameCS.hlsl">
       <ShaderType>Compute</ShaderType>
     </FxCompile>

--- a/src/Magpie.Core/OnnxEffectDrawer.cpp
+++ b/src/Magpie.Core/OnnxEffectDrawer.cpp
@@ -1,0 +1,281 @@
+#include "pch.h"
+#include "OnnxEffectDrawer.h"
+#include "Logger.h"
+#include "OnnxStatus.h"
+#include "DirectMLInferenceBackend.h"
+#include "TensorRTInferenceBackend.h"
+#include "Win32Helper.h"
+#include <rapidjson/document.h>
+#include "StrHelper.h"
+#include "ScalingWindow.h"
+#include "ScalingOptions.h"
+#include "OnnxHelper.h"
+#include "DeviceResources.h"
+#include "DirectXHelper.h"
+#include "BackendDescriptorStore.h"
+#include "shaders/DownscaleCS.h"
+
+namespace Magpie {
+
+OnnxEffectDrawer::OnnxEffectDrawer() {}
+
+OnnxEffectDrawer::~OnnxEffectDrawer() {}
+
+static bool ReadJson(
+	const rapidjson::Document& doc,
+	std::string& modelPath,
+	uint32_t& scale,
+	std::string& backend
+) noexcept {
+	if (!doc.IsObject()) {
+		Logger::Get().Error("根元素不是 Object");
+		return false;
+	}
+
+	auto root = ((const rapidjson::Document&)doc).GetObj();
+
+	{
+		auto node = root.FindMember("path");
+		if (node == root.MemberEnd() || !node->value.IsString()) {
+			Logger::Get().Error("解析 path 失败");
+			return false;
+		}
+
+		modelPath = node->value.GetString();
+	}
+	
+	{
+		auto node = root.FindMember("scale");
+		if (node == root.MemberEnd() || !node->value.IsUint()) {
+			Logger::Get().Error("解析 scale 失败");
+			return false;
+		}
+
+		scale = node->value.GetUint();
+	}
+
+	{
+		auto node = root.FindMember("backend");
+		if (node == root.MemberEnd() || !node->value.IsString()) {
+			Logger::Get().Error("解析 backend 失败");
+			return false;
+		}
+
+		backend = node->value.GetString();
+	}
+
+	return true;
+}
+
+bool OnnxEffectDrawer::Initialize(
+	DeviceResources& deviceResources,
+	BackendDescriptorStore& descriptorStore,
+	ID3D11Texture2D** inOutTexture
+) noexcept {
+	// 可能被重复调用（_BuildEffects 和 _ResizeEffects），先彻底重置
+	// Called from both _BuildEffects and _ResizeEffects, so wipe any previous
+	// session first. Destroy the backend before anything else: it owns CUDA
+	// external memory and semaphores tied to the old textures.
+	_inferenceBackend.reset();
+	_downscaleShader = nullptr;
+	_downscaledTex = nullptr;
+	_downscaledUav = nullptr;
+	_srcSrv = nullptr;
+	_sampler = nullptr;
+	_d3dDC = nullptr;
+	_downscaleDispatch = {};
+
+	std::string modelPath;
+	uint32_t scale = 1;
+	std::string backend;
+
+	// The profile wins. Magpie's default profile doubles as the global
+	// setting and named profiles override it, so this gives both global and
+	// per-game config. model.json stays as a fallback for existing setups.
+	if (!OnnxStatus::IsOrtAvailable) {
+		// onnxruntime.dll 未加载，跳过（不是错误）
+		// onnxruntime.dll never loaded; skip without failing the scale.
+		return true;
+	}
+
+	const ScalingOptions& onnxOptions = ScalingWindow::Get().Options();
+	const bool fromProfile = !onnxOptions.onnxModel.empty();
+	if (fromProfile) {
+		modelPath = StrHelper::UTF16ToUTF8(onnxOptions.onnxModel);
+		scale = onnxOptions.onnxScale;
+		backend = onnxOptions.onnxBackend == 1 ? "tensorrt" : "directml";
+	}
+
+	const wchar_t* jsonPath = L"model.json";
+	if (!fromProfile && !Win32Helper::FileExists(jsonPath)) {
+		// Relative path -> resolved against the working directory, not the exe
+		// folder. Launched with the wrong cwd this silently disables ONNX, so
+		// name the directory we actually looked in.
+		wchar_t cwd[MAX_PATH]{};
+		GetCurrentDirectoryW(MAX_PATH, cwd);
+		Logger::Get().Info(StrHelper::Concat(
+			"model.json not found in ", StrHelper::UTF16ToUTF8(cwd),
+			" - ONNX upscaling disabled for this scale"));
+		return true;
+	}
+	
+	std::string json;
+	if (!fromProfile) {
+		if (!Win32Helper::ReadTextFile(jsonPath, json)) {
+			Logger::Get().Error("Win32Helper::ReadTextFile 失败");
+			return false;
+		}
+
+		{
+		rapidjson::Document doc;
+		doc.ParseInsitu(json.data());
+		if (doc.HasParseError()) {
+			Logger::Get().Error(fmt::format(
+				"解析 json 失败 / model.json is not valid JSON (error {} at offset {}). "
+				"A UTF-8 BOM is the usual cause - save it as UTF-8 without BOM.",
+				uint32_t(doc.GetParseError()), doc.GetErrorOffset()));
+			return false;
+		}
+		
+		if (!ReadJson(doc, modelPath, scale, backend)) {
+			Logger::Get().Error("ReadJson 失败");
+			return false;
+		}
+		}
+	}
+	
+	StrHelper::ToLowerCase(backend);
+	if (backend == "directml" || backend == "dml" || backend == "d") {
+		_inferenceBackend = std::make_unique<DirectMLInferenceBackend>();
+	} else if (backend == "tensorrt" || backend == "trt" || backend == "t") {
+		_inferenceBackend = std::make_unique<TensorRTInferenceBackend>();
+	} else {
+		Logger::Get().Error(StrHelper::Concat(
+			"未知 backend '", backend,
+			"' - expected one of: directml|dml|d, tensorrt|trt|t"));
+		return false;
+	}
+
+	Logger::Get().Info(fmt::format(
+		"ONNX model: path='{}' scale=x{} backend={} (from {})",
+		modelPath, scale, backend, fromProfile ? "profile" : "model.json"));
+
+	std::wstring modelPathW = StrHelper::UTF8ToUTF16(modelPath);
+	// 预降采样：模型在更低分辨率上运行，然后由它放大回去
+	// Pre-downscale: run the model at a lower resolution and let it scale back
+	// up. Without this a native-resolution window has nothing to upscale.
+	// 部分模型（如 Real-CUGAN）要求输入尺寸对齐，否则输出不是整数倍
+	// Some models - Real-CUGAN among them - only produce an exact integer scale
+	// when the input dimensions are aligned; odd sizes fail outright. Magpie
+	// feeds arbitrary window sizes, which is why CUGAN was considered
+	// unsupported. Rounding the model's input down to a multiple of 4 costs at
+	// most 3 px and reuses the pre-downscale pass, so there is no extra work.
+	constexpr uint32_t ONNX_INPUT_ALIGN = 4;
+
+	ID3D11Texture2D* backendInput = *inOutTexture;
+	{
+		const SIZE srcSize = OnnxHelper::GetTextureSize(*inOutTexture);
+
+		uint32_t dstWidth = (uint32_t)srcSize.cx;
+		uint32_t dstHeight = (uint32_t)srcSize.cy;
+		if (onnxOptions.onnxRenderWidth != 0 && onnxOptions.onnxRenderHeight != 0) {
+			dstWidth = std::min(dstWidth, onnxOptions.onnxRenderWidth);
+			dstHeight = std::min(dstHeight, onnxOptions.onnxRenderHeight);
+		}
+
+		// 向下对齐，绝不放大 / round down, never upscale here
+		dstWidth = std::max(ONNX_INPUT_ALIGN, dstWidth / ONNX_INPUT_ALIGN * ONNX_INPUT_ALIGN);
+		dstHeight = std::max(ONNX_INPUT_ALIGN, dstHeight / ONNX_INPUT_ALIGN * ONNX_INPUT_ALIGN);
+
+		if (dstWidth != (uint32_t)srcSize.cx || dstHeight != (uint32_t)srcSize.cy) {
+			_d3dDC = deviceResources.GetD3DDC();
+
+			_downscaledTex = DirectXHelper::CreateTexture2D(
+				deviceResources.GetD3DDevice(),
+				DXGI_FORMAT_R8G8B8A8_UNORM,
+				dstWidth,
+				dstHeight,
+				D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS
+			);
+			if (!_downscaledTex) {
+				Logger::Get().Error("创建预降采样纹理失败 / failed to create the downscale texture");
+				return false;
+			}
+
+			_srcSrv = descriptorStore.GetShaderResourceView(*inOutTexture);
+			_downscaledUav = descriptorStore.GetUnorderedAccessView(_downscaledTex.get());
+			// 线性采样 = 双线性缩小 / linear sampling gives a bilinear downscale
+			_sampler = deviceResources.GetSampler(
+				D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_TEXTURE_ADDRESS_CLAMP);
+			if (!_srcSrv || !_downscaledUav || !_sampler) {
+				Logger::Get().Error("创建预降采样视图失败 / failed to create downscale views");
+				return false;
+			}
+
+			HRESULT hr = deviceResources.GetD3DDevice()->CreateComputeShader(
+				DownscaleCS, std::size(DownscaleCS), nullptr, _downscaleShader.put());
+			if (FAILED(hr)) {
+				Logger::Get().ComError("CreateComputeShader 失败", hr);
+				return false;
+			}
+
+			_downscaleDispatch = { (dstWidth + 7) / 8, (dstHeight + 7) / 8 };
+			backendInput = _downscaledTex.get();
+
+			Logger::Get().Info(fmt::format(
+				"ONNX input resample: {}x{} -> {}x{} ({})",
+				srcSize.cx, srcSize.cy, dstWidth, dstHeight,
+				(onnxOptions.onnxRenderWidth != 0 && onnxOptions.onnxRenderHeight != 0)
+					? "pre-downscale" : "alignment only"));
+		}
+	}
+
+	if (!_inferenceBackend->Initialize(modelPathW.c_str(), scale, deviceResources, descriptorStore, backendInput, inOutTexture)) {
+		// 不要留下半初始化的后端，也不要留下预降采样状态
+		// Drop the half-initialized backend and the pre-downscale state, or Draw
+		// keeps calling into them.
+		_inferenceBackend.reset();
+		_downscaleShader = nullptr;
+		_downscaledTex = nullptr;
+		_downscaledUav = nullptr;
+		_srcSrv = nullptr;
+		_sampler = nullptr;
+		_d3dDC = nullptr;
+
+		Logger::Get().Error(
+			"初始化推理后端失败 / inference backend failed to initialize. Usual "
+			"causes: the scale does not match the model, or the model is not a "
+			"supported [-1,3,-1,-1] NCHW fp16/fp32 upscaler.");
+		OnnxStatus::Report(L"AI upscaling failed",
+			L"The model could not be initialized, so scaling continues without it. "
+			L"Check that the scale matches the model, then see logs\\magpie.log.");
+
+		// 继续缩放，只是不带 AI —— 比整个缩放失败要好
+		// Carry on scaling without the model: losing the AI pass beats losing
+		// the ability to scale at all.
+		return true;
+	}
+
+	return true;
+}
+
+void OnnxEffectDrawer::Draw(EffectsProfiler& /*profiler*/) const noexcept {
+	if (_downscaleShader) {
+		_d3dDC->CSSetShader(_downscaleShader.get(), nullptr, 0);
+		_d3dDC->CSSetShaderResources(0, 1, &_srcSrv);
+		_d3dDC->CSSetSamplers(0, 1, &_sampler);
+		_d3dDC->CSSetUnorderedAccessViews(0, 1, &_downscaledUav, nullptr);
+		_d3dDC->Dispatch(_downscaleDispatch.first, _downscaleDispatch.second, 1);
+
+		// 解绑 UAV，否则后续把它作为 SRV 绑定会失败
+		// Unbind, or binding it as an SRV afterwards silently fails.
+		ID3D11UnorderedAccessView* nullUav = nullptr;
+		_d3dDC->CSSetUnorderedAccessViews(0, 1, &nullUav, nullptr);
+	}
+
+	if (_inferenceBackend) {
+		_inferenceBackend->Evaluate();
+	}
+}
+
+}

--- a/src/Magpie.Core/OnnxEffectDrawer.h
+++ b/src/Magpie.Core/OnnxEffectDrawer.h
@@ -7,6 +7,8 @@ class EffectsProfiler;
 class InferenceBackendBase;
 class BackendDescriptorStore;
 
+#ifdef MAGPIE_ONNX_ENABLED
+
 class OnnxEffectDrawer {
 public:
 	OnnxEffectDrawer();
@@ -36,5 +38,30 @@ private:
 	ID3D11DeviceContext4* _d3dDC = nullptr;
 	std::pair<uint32_t, uint32_t> _downscaleDispatch{};
 };
+
+#else
+
+// ONNX 只在 x64 上编译；其他平台上这是一个空壳，调用方无需条件编译
+// The feature is x64-only. Everywhere else this is an inert stub so callers
+// need no conditional compilation: Initialize succeeds and Draw does nothing,
+// which is exactly the behaviour when no model is configured.
+class OnnxEffectDrawer {
+public:
+	OnnxEffectDrawer() = default;
+	OnnxEffectDrawer(const OnnxEffectDrawer&) = delete;
+	OnnxEffectDrawer(OnnxEffectDrawer&&) = default;
+
+	bool Initialize(
+		DeviceResources&,
+		BackendDescriptorStore&,
+		ID3D11Texture2D**
+	) noexcept {
+		return true;
+	}
+
+	void Draw(EffectsProfiler&) const noexcept {}
+};
+
+#endif
 
 }

--- a/src/Magpie.Core/OnnxEffectDrawer.h
+++ b/src/Magpie.Core/OnnxEffectDrawer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace Magpie {
+
+class DeviceResources;
+class EffectsProfiler;
+class InferenceBackendBase;
+class BackendDescriptorStore;
+
+class OnnxEffectDrawer {
+public:
+	OnnxEffectDrawer();
+	OnnxEffectDrawer(const OnnxEffectDrawer&) = delete;
+	OnnxEffectDrawer(OnnxEffectDrawer&&) = default;
+
+	~OnnxEffectDrawer();
+
+	bool Initialize(
+		DeviceResources& deviceResources,
+		BackendDescriptorStore& descriptorStore,
+		ID3D11Texture2D** inOutTexture
+	) noexcept;
+
+	void Draw(EffectsProfiler& profiler) const noexcept;
+
+
+private:
+	std::unique_ptr<InferenceBackendBase> _inferenceBackend;
+
+	// 可选的预降采样 / optional pre-downscale before inference
+	winrt::com_ptr<ID3D11Texture2D> _downscaledTex;
+	winrt::com_ptr<ID3D11ComputeShader> _downscaleShader;
+	ID3D11UnorderedAccessView* _downscaledUav = nullptr;
+	ID3D11ShaderResourceView* _srcSrv = nullptr;
+	ID3D11SamplerState* _sampler = nullptr;
+	ID3D11DeviceContext4* _d3dDC = nullptr;
+	std::pair<uint32_t, uint32_t> _downscaleDispatch{};
+};
+
+}

--- a/src/Magpie.Core/OnnxHelper.h
+++ b/src/Magpie.Core/OnnxHelper.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "pch.h"
+#include <onnxruntime_cxx_api.h>
+
+namespace Magpie {
+
+struct OnnxHelper {
+private:
+	static void _CloseCUDAProviderOptions(OrtCUDAProviderOptionsV2* options) {
+		Ort::GetApi().ReleaseCUDAProviderOptions(options);
+	}
+
+	static void _CloseTensorRTProviderOptions(OrtTensorRTProviderOptionsV2* options) {
+		Ort::GetApi().ReleaseTensorRTProviderOptions(options);
+	}
+
+public:
+	// 上游删除了 DirectXHelper::GetTextureSize / upstream removed
+	// DirectXHelper::GetTextureSize; it now reads the desc inline.
+	static SIZE GetTextureSize(ID3D11Texture2D* texture) noexcept {
+		D3D11_TEXTURE2D_DESC desc;
+		texture->GetDesc(&desc);
+		return SIZE{ (LONG)desc.Width, (LONG)desc.Height };
+	}
+
+	using unique_cuda_provider_options = wil::unique_any<OrtCUDAProviderOptionsV2*,
+		decltype(_CloseCUDAProviderOptions), _CloseCUDAProviderOptions>;
+
+	using unique_tensorrt_provider_options = wil::unique_any<OrtTensorRTProviderOptionsV2*,
+		decltype(_CloseTensorRTProviderOptions), _CloseTensorRTProviderOptions>;
+};
+
+}

--- a/src/Magpie.Core/Renderer.cpp
+++ b/src/Magpie.Core/Renderer.cpp
@@ -507,6 +507,16 @@ ID3D11Texture2D* Renderer::_BuildEffects() noexcept {
 	_effectDrawers.resize(effectCount);
 
 	ID3D11Texture2D* inOutTexture = _frameSource->GetOutput();
+
+	// ONNX 模型应用于第一个效果之前 / the ONNX model runs before the first effect
+	if (!_onnxEffectDrawer.Initialize(
+		_backendResources,
+		_backendDescriptorStore,
+		&inOutTexture
+	)) {
+		Logger::Get().Error("初始化 ONNX 效果失败 / ONNX effect failed to initialize");
+		return nullptr;
+	}
 	for (uint32_t i = 0; i < effectCount; ++i) {
 		if (!_effectDrawers[i].Initialize(
 			_effectDescs[i],
@@ -636,6 +646,16 @@ ID3D11Texture2D* Renderer::_ResizeEffects() noexcept {
 	const uint32_t effectCount = (uint32_t)effects.size();
 
 	ID3D11Texture2D* inOutTexture = _frameSource->GetOutput();
+
+	// ONNX 模型应用于第一个效果之前 / the ONNX model runs before the first effect
+	if (!_onnxEffectDrawer.Initialize(
+		_backendResources,
+		_backendDescriptorStore,
+		&inOutTexture
+	)) {
+		Logger::Get().Error("初始化 ONNX 效果失败 / ONNX effect failed to initialize");
+		return nullptr;
+	}
 	for (uint32_t i = 0; i < effectCount; ++i) {
 		if (!_effectDrawers[i].ResizeTextures(
 			_effectDescs[i],
@@ -971,6 +991,8 @@ void Renderer::_BackendRender(ID3D11Texture2D* effectsOutput) noexcept {
 	}
 
 	_effectsProfiler.OnBeginEffects(d3dDC);
+
+	_onnxEffectDrawer.Draw(_effectsProfiler);
 
 	for (const EffectDrawer& effectDrawer : _effectDrawers) {
 		effectDrawer.Draw(_effectsProfiler);

--- a/src/Magpie.Core/Renderer.h
+++ b/src/Magpie.Core/Renderer.h
@@ -3,6 +3,7 @@
 #include "CursorDrawer.h"
 #include "DeviceResources.h"
 #include "EffectDrawer.h"
+#include "OnnxEffectDrawer.h"
 #include "EffectsProfiler.h"
 #include "OverlayDrawer.h"
 #include "PresenterBase.h"
@@ -123,6 +124,8 @@ private:
 	Magpie::BackendDescriptorStore _backendDescriptorStore;
 	std::unique_ptr<FrameSourceBase> _frameSource;
 	std::vector<EffectDrawer> _effectDrawers;
+	// 在第一个效果之前运行 / runs before the first effect
+	OnnxEffectDrawer _onnxEffectDrawer;
 
 	StepTimer _stepTimer;
 	EffectsProfiler _effectsProfiler;

--- a/src/Magpie.Core/TensorRTInferenceBackend.cpp
+++ b/src/Magpie.Core/TensorRTInferenceBackend.cpp
@@ -1,0 +1,801 @@
+#include "pch.h"
+#include "TensorRTInferenceBackend.h"
+#include "DeviceResources.h"
+#include <cuda_d3d11_interop.h>
+#include "shaders/TextureToTensorCS.h"
+#include "shaders/TensorToTextureCS.h"
+#include "BackendDescriptorStore.h"
+#include "Logger.h"
+#include "OnnxStatus.h"
+#include "DirectXHelper.h"
+#include "OnnxHelper.h"
+#include "OnnxEffectDrawer.h"
+#include "HashHelper.h"
+#include "Win32Helper.h"
+#include "StrHelper.h"
+#include "ScalingWindow.h"
+#include "ScalingOptions.h"
+#include "CommonSharedConstants.h"
+
+#pragma warning(push)
+// C4100: “pluginFactory”: 未引用的形参
+// C4996: 'nvinfer1::IPluginV2' : 被声明为已否决
+#pragma warning(disable: 4100 4996)
+#include <NvInfer.h>
+#pragma warning(pop)
+
+namespace Magpie {
+
+static void LogCudaError(std::string_view msg, cudaError_t cudaResult) noexcept {
+	Logger::Get().Error(fmt::format("{}\n\tCUDA error code: {}", msg, (int)cudaResult));
+}
+
+static bool CheckComputeCapability(int deviceId) noexcept {
+	int major, minor;
+
+	cudaError_t cudaResult = cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, deviceId);
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		Logger::Get().Error("cudaDeviceGetAttribute 失败");
+		return false;
+	}
+
+	cudaResult = cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, deviceId);
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		Logger::Get().Error("cudaDeviceGetAttribute 失败");
+		return false;
+	}
+
+	Logger::Get().Info(fmt::format("当前设备 Compute Capability: {}.{}", major, minor));
+
+	// TensorRT 要求 Compute Capability 至少为 6.0
+	// https://docs.nvidia.com/deeplearning/tensorrt/support-matrix/index.html
+	if (major < 6) {
+		Logger::Get().Error("当前设备无法使用 TensorRT");
+		return false;
+	}
+
+	return true;
+}
+
+static std::wstring ModelStem(const wchar_t* modelPath) noexcept {
+	std::wstring stem(modelPath);
+	if (size_t slash = stem.find_last_of(L"\\\\/"); slash != std::wstring::npos) {
+		stem.erase(0, slash + 1);
+	}
+	if (size_t dot = stem.find_last_of(L'.'); dot != std::wstring::npos) {
+		stem.erase(dot);
+	}
+	return stem;
+}
+
+static std::wstring GetCacheDir(
+	const std::vector<uint8_t>& modelData,
+	const wchar_t* modelPath,
+	IDXGIAdapter4* adapter,
+	std::pair<uint16_t, uint16_t> minShapes,
+	std::pair<uint16_t, uint16_t> maxShapes,
+	std::pair<uint16_t, uint16_t> optShapes,
+	uint8_t optimizationLevel,
+	bool enableFP16
+) noexcept {
+	DXGI_ADAPTER_DESC desc;
+	adapter->GetDesc(&desc);
+
+	// TensorRT 缓存和多种因素绑定，这里考虑的因素有：
+	// * 模型哈希
+	// * ONNX Runtime 版本
+	// * TensorRT 版本
+	// * 显卡型号 (替代 Compute Capability)
+	// * 配置文件
+	// * 优化等级
+	// * 是否启用半精度
+	std::string str = fmt::format(
+		"modelHash:{}\nortVersion:{}\ntrtVersion:{}\nvendorId:{}\ndeviceId:{}\nminShapes:{},{}\nmaxShapes:{},{}\noptShapes:{},{}\noptLevel:{}\nfp16:{}",
+		HashHelper::Hash64(modelData), Ort::GetVersionString(), NV_TENSORRT_VERSION, desc.VendorId, desc.DeviceId,
+		minShapes.first, minShapes.second, maxShapes.first, maxShapes.second, optShapes.first,
+		optShapes.second, optimizationLevel, enableFP16);
+
+	std::wstring strHash = HashHelper::HexHash(std::span((const BYTE*)str.data(), str.size()));
+	// 目录名带上模型名和分辨率，便于识别 / name the folder after the model and the
+	// profile size so the cache is identifiable at a glance instead of a bare hash.
+	const std::wstring stem = ModelStem(modelPath);
+
+	std::wstring dirName(stem);
+	dirName += L'_';
+	dirName += std::to_wstring(maxShapes.first);
+	dirName += L'x';
+	dirName += std::to_wstring(maxShapes.second);
+	dirName += L'_';
+	dirName += strHash;
+
+	return StrHelper::Concat(CommonSharedConstants::CACHE_DIR, L"tensorrt\\", dirName);
+}
+
+static void* ShareBufferWithCuda(
+	const winrt::com_ptr<ID3D11Buffer>& buffer,
+	uint32_t bufferSize,
+	cudaExternalMemory_t* bufferCudaMem,
+	cudaExternalSemaphore_t* bufferCudaSem
+) noexcept {
+	winrt::com_ptr<IDXGIResource> dxgiRes = buffer.try_as<IDXGIResource>();
+	if (!dxgiRes) {
+		return nullptr;
+	}
+
+	HANDLE sharedHandle = NULL;
+	HRESULT hr = dxgiRes->GetSharedHandle(&sharedHandle);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("GetSharedHandle 失败", hr);
+		return nullptr;
+	}
+
+	cudaExternalMemoryHandleDesc externalMemoryHandleDesc{
+		.type = cudaExternalMemoryHandleTypeD3D11ResourceKmt,
+		.handle = {.win32 = {.handle = sharedHandle } },
+		.size = bufferSize,
+		.flags = cudaExternalMemoryDedicated
+	};
+	cudaError_t cudaResult = cudaImportExternalMemory(
+		bufferCudaMem, &externalMemoryHandleDesc);
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		LogCudaError("cudaImportExternalMemory 失败", cudaResult);
+		return nullptr;
+	}
+
+	cudaExternalSemaphoreHandleDesc extSemaDesc{
+		.type = cudaExternalSemaphoreHandleTypeKeyedMutexKmt,
+		.handle = {.win32 = {.handle = sharedHandle } },
+	};
+	cudaResult = cudaImportExternalSemaphore(bufferCudaSem, &extSemaDesc);
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		LogCudaError("cudaImportExternalSemaphore 失败", cudaResult);
+		return nullptr;
+	}
+
+	void* bufferCudaPtr = nullptr;
+	cudaExternalMemoryBufferDesc externalMemoryBufferDesc{ .size = bufferSize };
+	cudaResult = cudaExternalMemoryGetMappedBuffer(
+		&bufferCudaPtr, *bufferCudaMem, &externalMemoryBufferDesc);
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		LogCudaError("cudaExternalMemoryGetMappedBuffer 失败", cudaResult);
+		return nullptr;
+	}
+
+	return bufferCudaPtr;
+}
+
+TensorRTInferenceBackend::~TensorRTInferenceBackend() {
+	if (_inputBufferCudaSem) {
+		cudaDestroyExternalSemaphore((cudaExternalSemaphore_t)_inputBufferCudaSem);
+	}
+	if (_outputBufferCudaSem) {
+		cudaDestroyExternalSemaphore((cudaExternalSemaphore_t)_outputBufferCudaSem);
+	}
+	if (_inputBufferCudaPtr) {
+		cudaFree(_inputBufferCudaPtr);
+	}
+	if (_outputBufferCudaPtr) {
+		cudaFree(_outputBufferCudaPtr);
+	}
+	if (_inputBufferCudaMem) {
+		cudaDestroyExternalMemory((cudaExternalMemory_t)_inputBufferCudaMem);
+	}
+	if (_outputBufferCudaMem) {
+		cudaDestroyExternalMemory((cudaExternalMemory_t)_outputBufferCudaMem);
+	}
+}
+
+bool TensorRTInferenceBackend::Initialize(
+	const wchar_t* modelPath,
+	uint32_t scale,
+	DeviceResources& deviceResources,
+	BackendDescriptorStore& descriptorStore,
+	ID3D11Texture2D* input,
+	ID3D11Texture2D** output
+) noexcept {
+	if (!Win32Helper::FileExists(L"third_party\\onnxruntime_providers_tensorrt.dll")) {
+		Logger::Get().Error("未安装 TensorRT 拓展");
+		return false;
+	}
+
+	int deviceId = 0;
+	cudaError_t cudaResult = cudaD3D11GetDevice(&deviceId, deviceResources.GetGraphicsAdapter());
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		LogCudaError("cudaD3D11GetDevice 失败", cudaResult);
+		return false;
+	}
+
+	if (!CheckComputeCapability(deviceId)) {
+		Logger::Get().Error("CheckComputeCapability 失败");
+		return false;
+	}
+
+	cudaResult = cudaSetDevice(deviceId);
+	if (cudaResult != cudaError_t::cudaSuccess) {
+		LogCudaError("cudaSetDevice 失败", cudaResult);
+		return false;
+	}
+
+	// TensorRT bakes an optimization profile into the engine at build time and
+	// rejects any input outside it. Upstream hardcoded a 1920x1080 maximum, so a
+	// larger source failed every frame with "does not satisfy any optimization
+	// profiles" and the user just saw a black screen. Derive the profile from the
+	// actual input instead - GetCacheDir already hashes these shapes, so each
+	// resolution simply gets its own cached engine.
+	const SIZE inputSize = OnnxHelper::GetTextureSize(input);
+
+	bool isFP16Data = false;
+	try {
+		const OrtApi& ortApi = Ort::GetApi();
+
+		_env = Ort::Env(ORT_LOGGING_LEVEL_INFO, "", _OrtLog, nullptr);
+
+		Ort::SessionOptions sessionOptions;
+		sessionOptions.SetIntraOpNumThreads(1);
+
+		Ort::ThrowOnError(ortApi.AddFreeDimensionOverride(sessionOptions, "DATA_BATCH", 1));
+
+		if (!_CreateSession(deviceResources, deviceId, sessionOptions, modelPath,
+			uint32_t(inputSize.cx), uint32_t(inputSize.cy),
+			ScalingWindow::Get().Options().onnxStaticEngine != 0,
+			ScalingWindow::Get().Options().onnxDynamicMaxWidth,
+			ScalingWindow::Get().Options().onnxDynamicMaxHeight,
+			ScalingWindow::Get().Options().onnxDynamicMinWidth,
+			ScalingWindow::Get().Options().onnxDynamicMinHeight)) {
+			Logger::Get().Error("_CreateSession 失败");
+			return false;
+		}
+
+		if (!_IsModelValid(_session, isFP16Data)) {
+			Logger::Get().Error("不支持此模型");
+			return false;
+		}
+
+		_cudaMemInfo = Ort::MemoryInfo("Cuda", OrtAllocatorType::OrtDeviceAllocator, deviceId, OrtMemTypeDefault);
+	} catch (const Ort::Exception& e) {
+		Logger::Get().Error(e.what());
+		return false;
+	}
+
+	ID3D11Device5* d3dDevice = deviceResources.GetD3DDevice();
+	_d3dDC = deviceResources.GetD3DDC();
+
+	const SIZE outputSize = SIZE{ inputSize.cx * (LONG)scale, inputSize.cy * (LONG)scale };
+
+	// 创建输出纹理
+	winrt::com_ptr<ID3D11Texture2D> outputTex = DirectXHelper::CreateTexture2D(
+		d3dDevice,
+		DXGI_FORMAT_R8G8B8A8_UNORM,
+		outputSize.cx,
+		outputSize.cy,
+		D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS
+	);
+	if (!outputTex) {
+		Logger::Get().Error("创建输出纹理失败");
+		return false;
+	}
+	*output = outputTex.get();
+
+	const uint32_t inputElemCount = uint32_t(inputSize.cx * inputSize.cy * 3);
+	const uint32_t outputElemCount = uint32_t(outputSize.cx * outputSize.cy * 3);
+	const uint32_t inputBufferSize = isFP16Data ? ((inputElemCount + 1) / 2 * 4) : (inputElemCount * 4);
+	const uint32_t outputBufferSize = isFP16Data ? ((outputElemCount + 1) / 2 * 4) : (outputElemCount * 4);
+
+	winrt::com_ptr<ID3D11Buffer> inputBuffer;
+	winrt::com_ptr<ID3D11Buffer> outputBuffer;
+	{
+		D3D11_BUFFER_DESC desc{
+			.ByteWidth = inputBufferSize,
+			.BindFlags = D3D11_BIND_UNORDERED_ACCESS,
+			.MiscFlags = D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX
+		};
+		HRESULT hr = d3dDevice->CreateBuffer(&desc, nullptr, inputBuffer.put());
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateBuffer 失败", hr);
+			return false;
+		}
+
+		desc.ByteWidth = outputBufferSize;
+		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		hr = d3dDevice->CreateBuffer(&desc, nullptr, outputBuffer.put());
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateBuffer 失败", hr);
+			return false;
+		}
+	}
+
+	_inputBufferCudaPtr = ShareBufferWithCuda(
+		inputBuffer,
+		inputBufferSize,
+		(cudaExternalMemory_t*)&_inputBufferCudaMem,
+		(cudaExternalSemaphore_t*)&_inputBufferCudaSem
+	);
+	_outputBufferCudaPtr = ShareBufferWithCuda(
+		outputBuffer,
+		outputBufferSize,
+		(cudaExternalMemory_t*)&_outputBufferCudaMem,
+		(cudaExternalSemaphore_t*)&_outputBufferCudaSem
+	);
+	if (!_inputBufferCudaPtr || !_outputBufferCudaPtr) {
+		Logger::Get().Error("ShareBufferWithCuda 失败");
+		return false;
+	}
+
+	try {
+		_ioBinding = Ort::IoBinding(_session);
+
+		const int64_t inputShape[]{ 1,3,inputSize.cy,inputSize.cx };
+		_ioBinding.BindInput("input", Ort::Value::CreateTensor(
+			_cudaMemInfo,
+			_inputBufferCudaPtr,
+			inputBufferSize,
+			inputShape,
+			std::size(inputShape),
+			isFP16Data ? ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 : ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+		));
+
+		const int64_t outputShape[]{ 1,3,outputSize.cy,outputSize.cx };
+		_ioBinding.BindOutput("output", Ort::Value::CreateTensor(
+			_cudaMemInfo,
+			_outputBufferCudaPtr,
+			outputBufferSize,
+			outputShape,
+			std::size(outputShape),
+			isFP16Data ? ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 : ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+		));
+	} catch (const Ort::Exception& e) {
+		Logger::Get().Error(e.what());
+		return false;
+	}
+
+	_inputBufferKmt = inputBuffer.try_as<IDXGIKeyedMutex>();
+	if (!_inputBufferKmt) {
+		return false;
+	}
+
+	_outputBufferKmt = outputBuffer.try_as<IDXGIKeyedMutex>();
+	if (!_outputBufferKmt) {
+		return false;
+	}
+
+	_inputTexSrv = descriptorStore.GetShaderResourceView(input);
+	if (!_inputTexSrv) {
+		Logger::Get().Error("GetShaderResourceView 失败");
+		return false;
+	}
+
+	_sampler = deviceResources.GetSampler(
+		D3D11_FILTER_MIN_MAG_MIP_POINT, D3D11_TEXTURE_ADDRESS_CLAMP);
+	if (!_sampler) {
+		Logger::Get().Error("GetSampler 失败");
+		return false;
+	}
+
+	{
+		D3D11_UNORDERED_ACCESS_VIEW_DESC desc{
+			.Format = isFP16Data ? DXGI_FORMAT_R16_FLOAT : DXGI_FORMAT_R32_FLOAT,
+			.ViewDimension = D3D11_UAV_DIMENSION_BUFFER,
+			.Buffer{
+				.NumElements = inputElemCount
+			}
+		};
+
+		HRESULT hr = d3dDevice->CreateUnorderedAccessView(
+			inputBuffer.get(), &desc, _inputBufferUav.put());
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateUnorderedAccessView 失败", hr);
+			return false;
+		}
+	}
+
+	{
+		D3D11_SHADER_RESOURCE_VIEW_DESC desc{
+			.Format = isFP16Data ? DXGI_FORMAT_R16_FLOAT : DXGI_FORMAT_R32_FLOAT,
+			.ViewDimension = D3D11_SRV_DIMENSION_BUFFER,
+			.Buffer{
+				.NumElements = outputElemCount
+			}
+		};
+
+		HRESULT hr = d3dDevice->CreateShaderResourceView(
+			outputBuffer.get(), &desc, _outputBufferSrv.put());
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateShaderResourceView 失败", hr);
+			return false;
+		}
+	}
+
+	{
+		D3D11_UNORDERED_ACCESS_VIEW_DESC desc{
+			.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D
+		};
+		HRESULT hr = d3dDevice->CreateUnorderedAccessView(
+			outputTex.get(), &desc, _outputTexUav.put());
+		if (FAILED(hr)) {
+			Logger::Get().ComError("CreateUnorderedAccessView 失败", hr);
+			return false;
+		}
+	}
+
+	HRESULT hr = d3dDevice->CreateComputeShader(
+		TextureToTensorCS, sizeof(TextureToTensorCS), nullptr, _texToTensorShader.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateComputeShader 失败", hr);
+		return false;
+	}
+
+	hr = d3dDevice->CreateComputeShader(
+		TensorToTextureCS, sizeof(TensorToTextureCS), nullptr, _tensorToTexShader.put());
+	if (FAILED(hr)) {
+		Logger::Get().ComError("CreateComputeShader 失败", hr);
+		return false;
+	}
+
+	static constexpr std::pair<uint32_t, uint32_t> TEX_TO_TENSOR_BLOCK_SIZE{ 16, 16 };
+	static constexpr std::pair<uint32_t, uint32_t> TENSOR_TO_TEX_BLOCK_SIZE{ 8, 8 };
+	_texToTensorDispatchCount = {
+		(inputSize.cx + TEX_TO_TENSOR_BLOCK_SIZE.first - 1) / TEX_TO_TENSOR_BLOCK_SIZE.first,
+		(inputSize.cy + TEX_TO_TENSOR_BLOCK_SIZE.second - 1) / TEX_TO_TENSOR_BLOCK_SIZE.second
+	};
+	_tensorToTexDispatchCount = {
+		(outputSize.cx + TENSOR_TO_TEX_BLOCK_SIZE.first - 1) / TENSOR_TO_TEX_BLOCK_SIZE.first,
+		(outputSize.cy + TENSOR_TO_TEX_BLOCK_SIZE.second - 1) / TENSOR_TO_TEX_BLOCK_SIZE.second
+	};
+
+	return true;
+}
+
+void TensorRTInferenceBackend::Evaluate() noexcept {
+	if (_evaluateFailed) {
+		// 已失败：停止推理，避免刷屏。注意输出纹理仍在链上，需重新开始缩放
+		// Latched: stop inferring so a broken session does not spam the log every
+		// frame. The model's output texture is still wired into the chain, so the
+		// picture does not recover here - scaling must be restarted.
+		return;
+	}
+
+	// 输入纹理 -> 输入张量
+	HRESULT hr = _inputBufferKmt->AcquireSync(_inputBufferMutexKey, INFINITE);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("AcquireSync 失败", hr);
+		_OnEvaluateFailed();
+		return;
+	}
+
+	_d3dDC->CSSetShaderResources(0, 1, &_inputTexSrv);
+	_d3dDC->CSSetSamplers(0, 1, &_sampler);
+	{
+		ID3D11UnorderedAccessView* uav = _inputBufferUav.get();
+		_d3dDC->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+	}
+
+	_d3dDC->CSSetShader(_texToTensorShader.get(), nullptr, 0);
+	_d3dDC->Dispatch(_texToTensorDispatchCount.first, _texToTensorDispatchCount.second, 1);
+
+	_inputBufferKmt->ReleaseSync(++_inputBufferMutexKey);
+
+	{
+		cudaExternalSemaphore_t semArr[] = {
+			(cudaExternalSemaphore_t)_inputBufferCudaSem,
+			(cudaExternalSemaphore_t)_outputBufferCudaSem
+		};
+		cudaExternalSemaphoreWaitParams extSemWaitParamsArr[] = {
+			{.params{.keyedMutex{.key = _inputBufferMutexKey, .timeoutMs = INFINITE}}},
+			{.params{.keyedMutex{.key = _outputBufferMutexKey, .timeoutMs = INFINITE}}}
+		};
+		cudaError_t cudaResult = cudaWaitExternalSemaphoresAsync(semArr, extSemWaitParamsArr, 2);
+		if (cudaResult != cudaError_t::cudaSuccess) {
+			LogCudaError("cudaWaitExternalSemaphoresAsync 失败", cudaResult);
+			_OnEvaluateFailed();
+			return;
+		}
+	}
+	
+	try {
+		Ort::RunOptions runOptions;
+		runOptions.AddConfigEntry("disable_synchronize_execution_providers", "1");
+		_session.Run(runOptions, _ioBinding);
+	} catch (const Ort::Exception& e) {
+		Logger::Get().Error(e.what());
+		_OnEvaluateFailed();
+		return;
+	}
+
+	{
+		cudaExternalSemaphore_t semArr[] = {
+			(cudaExternalSemaphore_t)_inputBufferCudaSem,
+			(cudaExternalSemaphore_t)_outputBufferCudaSem
+		};
+
+		cudaExternalSemaphoreSignalParams extSemSigParams[] = {
+			{.params = {.keyedMutex = {.key = ++_inputBufferMutexKey}}},
+			{.params = {.keyedMutex = {.key = ++_outputBufferMutexKey}}}
+		};
+		cudaError_t cudaResult = cudaSignalExternalSemaphoresAsync(semArr, extSemSigParams, 2);
+		if (cudaResult != cudaError_t::cudaSuccess) {
+			LogCudaError("cudaSignalExternalSemaphoresAsync 失败", cudaResult);
+			_OnEvaluateFailed();
+			return;
+		}
+	}
+	
+	// 输出张量 -> 输出纹理
+
+	hr = _outputBufferKmt->AcquireSync(_outputBufferMutexKey, INFINITE);
+	if (FAILED(hr)) {
+		Logger::Get().ComError("AcquireSync 失败", hr);
+		_OnEvaluateFailed();
+		return;
+	}
+
+	{
+		ID3D11ShaderResourceView* srv = _outputBufferSrv.get();
+		_d3dDC->CSSetShaderResources(0, 1, &srv);
+	}
+	{
+		ID3D11UnorderedAccessView* uav = _outputTexUav.get();
+		_d3dDC->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+	}
+
+	_d3dDC->CSSetShader(_tensorToTexShader.get(), nullptr, 0);
+	_d3dDC->Dispatch(_tensorToTexDispatchCount.first, _tensorToTexDispatchCount.second, 1);
+
+	{
+		ID3D11ShaderResourceView* srv = nullptr;
+		_d3dDC->CSSetShaderResources(0, 1, &srv);
+	}
+	{
+		ID3D11UnorderedAccessView* uav = nullptr;
+		_d3dDC->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+	}
+
+	_outputBufferKmt->ReleaseSync(++_outputBufferMutexKey);
+
+}
+
+void TensorRTInferenceBackend::_OnEvaluateFailed() noexcept {
+	_evaluateFailed = true;
+
+	// 清掉非粘滞的 CUDA 错误，让下一次缩放从干净状态开始
+	// Clear non-sticky CUDA errors so the next scale starts clean. A sticky
+	// error (illegal address, launch failure) poisons the context for the
+	// lifetime of the process and genuinely does need a restart.
+	cudaGetLastError();
+
+	Logger::Get().Error(
+		"推理失败，本次缩放禁用 AI / inference failed - AI upscaling is disabled "
+		"for this scaling session. Stop and start scaling to retry; if it keeps "
+		"failing, restart Magpie to reset the CUDA context.");
+
+	OnnxStatus::Report(L"AI upscaling stopped",
+		L"Inference failed, so scaling continues without the model. Restart "
+		L"scaling to retry.");
+}
+
+bool TensorRTInferenceBackend::_CreateSession(
+	DeviceResources& deviceResources,
+	int deviceId,
+	Ort::SessionOptions& sessionOptions,
+	const wchar_t* modelPath,
+	uint32_t inputWidth,
+	uint32_t inputHeight,
+	bool staticEngine,
+	uint32_t dynamicMaxWidth,
+	uint32_t dynamicMaxHeight,
+	uint32_t dynamicMinWidth,
+	uint32_t dynamicMinHeight
+) {
+	// TensorRT profiles are a range (min..max): an engine built for 1440p serves
+	// any smaller window, but not a larger one. So round the input up to the next
+	// standard tier, and if a BIGGER engine for this model is already cached,
+	// reuse its dimensions so we get a cache hit instead of building again.
+	static constexpr uint32_t TIERS[][2] = {
+		{1280, 720}, {1920, 1080}, {2560, 1440}, {3200, 1800},
+		{3840, 2160}, {5120, 2880}, {7680, 4320}
+	};
+	uint32_t profileWidth = 0;
+	uint32_t profileHeight = 0;
+	for (const auto& tier : TIERS) {
+		if (tier[0] >= inputWidth && tier[1] >= inputHeight) {
+			profileWidth = tier[0];
+			profileHeight = tier[1];
+			break;
+		}
+	}
+	if (profileWidth == 0) {
+		profileWidth = std::min(inputWidth, 65535u);
+		profileHeight = std::min(inputHeight, 65535u);
+	}
+
+	{
+		// cache dir names are <stem>_<W>x<H>_<hash>
+		const std::wstring stem = ModelStem(modelPath);
+		const std::wstring pattern =
+			StrHelper::Concat(CommonSharedConstants::CACHE_DIR, L"tensorrt\\", stem, L"_*");
+		uint32_t bestW = 0;
+		uint32_t bestH = 0;
+		WIN32_FIND_DATAW fd{};
+		HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
+		if (hFind != INVALID_HANDLE_VALUE) {
+			do {
+				if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+					continue;
+				}
+				const std::wstring name(fd.cFileName);
+				const size_t lastU = name.rfind(L'_');
+				if (lastU == std::wstring::npos || lastU == 0) {
+					continue;
+				}
+				const size_t prevU = name.rfind(L'_', lastU - 1);
+				if (prevU == std::wstring::npos) {
+					continue;
+				}
+				const std::wstring res = name.substr(prevU + 1, lastU - prevU - 1);
+				const size_t xPos = res.find(L'x');
+				if (xPos == std::wstring::npos) {
+					continue;
+				}
+				const uint32_t w = (uint32_t)_wtoi(res.substr(0, xPos).c_str());
+				const uint32_t h = (uint32_t)_wtoi(res.substr(xPos + 1).c_str());
+				if (w < inputWidth || h < inputHeight) {
+					continue;
+				}
+				if (bestW == 0 || (uint64_t)w * h < (uint64_t)bestW * bestH) {
+					bestW = w;
+					bestH = h;
+				}
+			} while (FindNextFileW(hFind, &fd));
+			FindClose(hFind);
+		}
+		if (bestW != 0) {
+			profileWidth = bestW;
+			profileHeight = bestH;
+		}
+	}
+
+	// 用户指定了动态引擎的上限则优先使用 / an explicit max wins over the tier
+	// search: the user knows the largest window they will actually scale.
+	if (!staticEngine && dynamicMaxWidth != 0 && dynamicMaxHeight != 0) {
+		profileWidth = std::clamp(std::max(dynamicMaxWidth, inputWidth), 1u, 65535u);
+		profileHeight = std::clamp(std::max(dynamicMaxHeight, inputHeight), 1u, 65535u);
+	}
+
+	if (staticEngine) {
+		// 静态引擎：min=opt=max，最快但只适用于该分辨率
+		// Static: min=opt=max. Fastest, because TensorRT tunes kernels for this
+		// exact size - but the engine is only valid at it, so each new window
+		// size builds its own.
+		profileWidth = std::min(inputWidth, 65535u);
+		profileHeight = std::min(inputHeight, 65535u);
+	}
+
+	// 动态引擎的下限由用户指定，0 表示 1x1
+	// Lower bound of a dynamic profile. 0 means 1x1. Never let it exceed the
+	// current input or the max, or TensorRT rejects the profile outright.
+	uint32_t minWidth = dynamicMinWidth == 0 ? 1u : dynamicMinWidth;
+	uint32_t minHeight = dynamicMinHeight == 0 ? 1u : dynamicMinHeight;
+	minWidth = std::clamp(minWidth, 1u, std::min(inputWidth, profileWidth));
+	minHeight = std::clamp(minHeight, 1u, std::min(inputHeight, profileHeight));
+
+	const std::pair<uint16_t, uint16_t> minShapes = staticEngine
+		? std::pair<uint16_t, uint16_t>{ uint16_t(profileWidth), uint16_t(profileHeight) }
+		: std::pair<uint16_t, uint16_t>{ uint16_t(minWidth), uint16_t(minHeight) };
+	const std::pair<uint16_t, uint16_t> maxShapes{ uint16_t(profileWidth), uint16_t(profileHeight) };
+	const std::pair<uint16_t, uint16_t> optShapes{ uint16_t(profileWidth), uint16_t(profileHeight) };
+
+	const bool enableFP16 = true;
+	const uint8_t optimizationLevel = 5;
+
+	std::vector<uint8_t> modelData;
+	if (!Win32Helper::ReadFile(modelPath, modelData)) {
+		Logger::Get().Error("读取模型失败");
+		return false;
+	}
+
+	const std::wstring cacheDir = GetCacheDir(
+		modelData,
+		modelPath,
+		deviceResources.GetGraphicsAdapter(),
+		minShapes,
+		maxShapes,
+		optShapes,
+		optimizationLevel,
+		enableFP16
+	);
+	if (!Win32Helper::CreateDir(cacheDir, true)) {
+		Logger::Get().Win32Error("创建缓存文件夹失败");
+		return false;
+	}
+
+	const std::wstring cacheCtxPath = cacheDir + L"\\ctx.onnx";
+
+	const OrtApi& ortApi = Ort::GetApi();
+
+	OnnxHelper::unique_tensorrt_provider_options trtOptions;
+	Ort::ThrowOnError(ortApi.CreateTensorRTProviderOptions(trtOptions.put()));
+
+	const std::string deviceIdStr = std::to_string(deviceId);
+	{
+		const char* keys[]{
+			"device_id",
+			"has_user_compute_stream",
+			"trt_fp16_enable",
+			"trt_builder_optimization_level",
+			"trt_profile_min_shapes",
+			"trt_profile_max_shapes",
+			"trt_profile_opt_shapes",
+			"trt_engine_cache_enable",
+			"trt_engine_cache_prefix",
+			"trt_dump_ep_context_model",
+			"trt_ep_context_file_path"
+		};
+		std::string optLevelStr = std::to_string(optimizationLevel);
+		std::string minShapesStr = fmt::format("input:1x3x{}x{}", minShapes.second, minShapes.first);
+		std::string maxShapesStr = fmt::format("input:1x3x{}x{}", maxShapes.second, maxShapes.first);
+		std::string optShapesStr = fmt::format("input:1x3x{}x{}", optShapes.second, optShapes.first);
+
+		std::string cacheDirANSI = StrHelper::UTF16ToANSI(cacheDir);
+		std::string cacheCtxPathANSI = StrHelper::UTF16ToANSI(cacheCtxPath);
+
+		const char* values[]{
+			deviceIdStr.c_str(),
+			"1",
+			enableFP16 ? "1" : "0",
+			optLevelStr.c_str(),
+			minShapesStr.c_str(),
+			maxShapesStr.c_str(),
+			optShapesStr.c_str(),
+			"1",
+			"trt",
+			"1",
+			cacheCtxPathANSI.c_str()
+		};
+		Ort::ThrowOnError(ortApi.UpdateTensorRTProviderOptions(trtOptions.get(), keys, values, std::size(keys)));
+	}
+
+	OnnxHelper::unique_cuda_provider_options cudaOptions;
+	Ort::ThrowOnError(ortApi.CreateCUDAProviderOptions(cudaOptions.put()));
+
+	{
+		const char* keys[]{ "device_id", "has_user_compute_stream" };
+		const char* values[]{ deviceIdStr.c_str(), "1" };
+		Ort::ThrowOnError(ortApi.UpdateCUDAProviderOptions(cudaOptions.get(), keys, values, std::size(keys)));
+	}
+
+	sessionOptions.AppendExecutionProvider_TensorRT_V2(*trtOptions.get());
+	sessionOptions.AppendExecutionProvider_CUDA_V2(*cudaOptions.get());
+
+	// Building an engine blocks this thread for minutes with no other feedback,
+	// which is indistinguishable from a hang. Say so explicitly, and time both
+	// paths so a cache hit vs a rebuild is obvious after the fact.
+	const bool engineCached = Win32Helper::FileExists(cacheCtxPath.c_str());
+	Logger::Get().Info(fmt::format(
+		"TensorRT session: input {}x{}, profile {}x{}, fp16={}, optLevel={}, engine cache {}",
+		inputWidth, inputHeight, profileWidth, profileHeight,
+		enableFP16, uint32_t(optimizationLevel), engineCached ? "HIT" : "MISS"));
+
+	const uint64_t startTick = GetTickCount64();
+	if (engineCached) {
+		Logger::Get().Info("读取缓存 " + StrHelper::UTF16ToUTF8(cacheCtxPath));
+		_session = Ort::Session(_env, cacheCtxPath.c_str(), sessionOptions);
+	} else {
+		Logger::Get().Info(
+			"No cached TensorRT engine for this model at this resolution. Building one "
+			"now - this takes minutes and Magpie will appear frozen until it finishes. "
+			"Avoid GPU-heavy work meanwhile. It is cached afterwards and reused.");
+		OnnxStatus::Report(L"Building AI engine",
+			L"First run at this resolution. This takes a few minutes and Magpie "
+			L"will look frozen until it finishes.");
+		_session = Ort::Session(_env, modelData.data(), modelData.size(), sessionOptions);
+	}
+	if (!engineCached) {
+		OnnxStatus::Report(L"AI engine ready",
+			L"The engine is built and cached; later scales start instantly.");
+	}
+	Logger::Get().Info(fmt::format("TensorRT engine {} in {} ms",
+		engineCached ? "loaded from cache" : "BUILT", GetTickCount64() - startTick));
+
+	return true;
+}
+
+}

--- a/src/Magpie.Core/TensorRTInferenceBackend.h
+++ b/src/Magpie.Core/TensorRTInferenceBackend.h
@@ -1,0 +1,86 @@
+#pragma once
+#include "InferenceBackendBase.h"
+
+struct cudaGraphicsResource;
+
+namespace Magpie {
+
+class TensorRTInferenceBackend : public InferenceBackendBase {
+public:
+	TensorRTInferenceBackend() = default;
+	TensorRTInferenceBackend(const TensorRTInferenceBackend&) = delete;
+	TensorRTInferenceBackend(TensorRTInferenceBackend&&) = default;
+
+	virtual ~TensorRTInferenceBackend();
+
+	bool Initialize(
+		const wchar_t* modelPath,
+		uint32_t scale,
+		DeviceResources& deviceResources,
+		BackendDescriptorStore& descriptorStore,
+		ID3D11Texture2D* input,
+		ID3D11Texture2D** output
+	) noexcept override;
+
+	void Evaluate() noexcept override;
+
+private:
+	bool _CreateSession(
+		DeviceResources& deviceResources,
+		int deviceId,
+		Ort::SessionOptions& sessionOptions,
+		const wchar_t* modelPath,
+		uint32_t inputWidth,
+		uint32_t inputHeight,
+		bool staticEngine,
+		uint32_t dynamicMaxWidth,
+		uint32_t dynamicMaxHeight,
+		uint32_t dynamicMinWidth,
+		uint32_t dynamicMinHeight
+	);
+
+	Ort::Env _env{ nullptr };
+	Ort::Session _session{ nullptr };
+
+	ID3D11DeviceContext4* _d3dDC = nullptr;
+
+	ID3D11SamplerState* _sampler = nullptr;
+	ID3D11ShaderResourceView* _inputTexSrv = nullptr;
+	winrt::com_ptr<ID3D11UnorderedAccessView> _inputBufferUav;
+	winrt::com_ptr<ID3D11ShaderResourceView> _outputBufferSrv;
+	winrt::com_ptr<ID3D11UnorderedAccessView> _outputTexUav;
+
+	winrt::com_ptr<IDXGIKeyedMutex> _inputBufferKmt;
+	winrt::com_ptr<IDXGIKeyedMutex> _outputBufferKmt;
+
+	UINT64 _inputBufferMutexKey = 0;
+	UINT64 _outputBufferMutexKey = 0;
+
+	winrt::com_ptr<ID3D11ComputeShader> _texToTensorShader;
+	winrt::com_ptr<ID3D11ComputeShader> _tensorToTexShader;
+
+	std::pair<uint32_t, uint32_t> _texToTensorDispatchCount{};
+	std::pair<uint32_t, uint32_t> _tensorToTexDispatchCount{};
+
+	Ort::MemoryInfo _cudaMemInfo{ nullptr };
+
+	// cudaExternalMemory_t
+	void* _inputBufferCudaMem = nullptr;
+	void* _outputBufferCudaMem = nullptr;
+	void* _inputBufferCudaPtr = nullptr;
+	void* _outputBufferCudaPtr = nullptr;
+	// cudaExternalSemaphore_t
+	void* _inputBufferCudaSem = nullptr;
+	void* _outputBufferCudaSem = nullptr;
+
+	Ort::IoBinding _ioBinding{ nullptr };
+
+	// 一旦推理失败就停止，避免每帧刷屏并输出黑屏
+	// Latched on first failure: keeps a broken session from running every frame,
+	// spamming the log and drawing a black screen.
+	bool _evaluateFailed = false;
+
+	void _OnEvaluateFailed() noexcept;
+};
+
+}

--- a/src/Magpie.Core/include/OnnxStatus.h
+++ b/src/Magpie.Core/include/OnnxStatus.h
@@ -21,7 +21,11 @@ struct OnnxStatus {
 	// Must be called after third_party\onnxruntime.dll has been pinned, and
 	// before any Ort API use. ORT_API_MANUAL_INIT disables the header's own
 	// pre-main initialization, which would otherwise bind System32's copy.
+#ifdef MAGPIE_ONNX_ENABLED
 	static void InitOrtApi() noexcept;
+#else
+	static void InitOrtApi() noexcept {}
+#endif
 
 	// onnxruntime.dll 是否已加载并绑定；未加载时必须跳过所有 ONNX 代码
 	// Whether onnxruntime.dll loaded and the API table was bound. When false,

--- a/src/Magpie.Core/include/OnnxStatus.h
+++ b/src/Magpie.Core/include/OnnxStatus.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <functional>
+#include <string>
+
+namespace Magpie {
+
+// Magpie.Core 向应用层报告 ONNX 状态的钩子。
+//
+// The app layer installs Callback; Magpie.Core calls Report from the scaling
+// thread. Kept in include/ because OnnxEffectDrawer.h is internal to
+// Magpie.Core and not visible to src/Magpie.
+//
+// Magpie.Core is a static library linked into Magpie.exe, so a plain
+// std::function is enough - no cross-module event plumbing is needed.
+struct OnnxStatus {
+	// 在缩放线程上调用，实现必须自行处理线程同步
+	// Invoked on the scaling thread; the implementation must marshal.
+	static inline std::function<void(std::wstring, std::wstring)> Callback;
+
+	// 必须在 third_party\onnxruntime.dll 被固定之后调用
+	// Must be called after third_party\onnxruntime.dll has been pinned, and
+	// before any Ort API use. ORT_API_MANUAL_INIT disables the header's own
+	// pre-main initialization, which would otherwise bind System32's copy.
+	static void InitOrtApi() noexcept;
+
+	// onnxruntime.dll 是否已加载并绑定；未加载时必须跳过所有 ONNX 代码
+	// Whether onnxruntime.dll loaded and the API table was bound. When false,
+	// every ONNX path must be skipped - the DLL is delay-loaded, so touching
+	// the API would raise inside the loader.
+	static inline bool IsOrtAvailable = false;
+
+	static void Report(std::wstring title, std::wstring text) noexcept {
+		if (Callback) {
+			Callback(std::move(title), std::move(text));
+		}
+	}
+};
+
+}

--- a/src/Magpie.Core/include/ScalingOptions.h
+++ b/src/Magpie.Core/include/ScalingOptions.h
@@ -203,6 +203,28 @@ struct ScalingOptions {
 	CursorInterpolationMode cursorInterpolationMode = CursorInterpolationMode::NearestNeighbor;
 	std::optional<float> autoHideCursorDelay;
 	DuplicateFrameDetectionMode duplicateFrameDetectionMode = DuplicateFrameDetectionMode::Dynamic;
+
+	// ---- ONNX 上采样 / ONNX upscaling ----
+	// 模型路径（相对于工作目录），为空则不启用
+	// Model path relative to the working dir; empty disables ONNX.
+	std::wstring onnxModel;
+	// 必须和模型匹配 / must match the model's real factor
+	uint32_t onnxScale = 2;
+	// 0 = DirectML, 1 = TensorRT
+	uint32_t onnxBackend = 0;
+	// 1 = static engine (min=opt=max): fastest, one engine per window size
+	uint32_t onnxStaticEngine = 0;
+	// Bounds of a dynamic engine's profile. 0 = auto / 1x1.
+	uint32_t onnxDynamicMaxWidth = 0;
+	uint32_t onnxDynamicMaxHeight = 0;
+	// 推理前把画面降到这个分辨率，0 = 关闭
+	// Downscale to this size before inference. 0 = off. Makes a model useful
+	// on a native-res window and cuts inference cost.
+	uint32_t onnxRenderWidth = 0;
+	uint32_t onnxRenderHeight = 0;
+	uint32_t onnxDynamicMinWidth = 0;
+	uint32_t onnxDynamicMinHeight = 0;
+
 	ToolbarState fullscreenInitialToolbarState = ToolbarState::AutoHide;
 	ToolbarState windowedInitialToolbarState = ToolbarState::AutoHide;
 	float initialWindowedScaleFactor = 0.0f;

--- a/src/Magpie.Core/shaders/DownscaleCS.hlsl
+++ b/src/Magpie.Core/shaders/DownscaleCS.hlsl
@@ -1,0 +1,33 @@
+// 推理前的预降采样 / pre-inference downscale.
+//
+// 让模型在更低的分辨率上运行：例如 4K 窗口先降到 1440p 再由模型放大回去。
+// Lets the model run at a lower resolution - e.g. take a 4K window down to 1440p
+// and let the model bring it back up. This is what makes a model useful on a
+// native-resolution window, where there is otherwise nothing to upscale.
+//
+// 注意：这不会恢复细节 / Note: this cannot recover detail. The wins are inference
+// cost and hitting exact multiples (1080p + 2x = exactly 2160p).
+//
+// A linear sampler gives bilinear filtering, which is adequate for the modest
+// ratios this is used at (4K->1440p is 1.5x). TextureToTensorCS cannot do this
+// itself: it uses GatherRed/Green/Blue on a 2x2 grid, which is a 1:1 copy rather
+// than a filter, and would alias badly.
+
+Texture2D<float4> src : register(t0);
+RWTexture2D<unorm float4> dst : register(u0);
+
+SamplerState sam : register(s0);
+
+[numthreads(8, 8, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+	uint width, height;
+	dst.GetDimensions(width, height);
+
+	if (tid.x >= width || tid.y >= height) {
+		return;
+	}
+
+	// 采样目标像素中心 / sample at the centre of the destination texel
+	const float2 uv = (float2(tid.xy) + 0.5f) / float2(width, height);
+	dst[tid.xy] = src.SampleLevel(sam, uv, 0);
+}

--- a/src/Magpie.Core/shaders/TensorToTextureCS.hlsl
+++ b/src/Magpie.Core/shaders/TensorToTextureCS.hlsl
@@ -1,0 +1,15 @@
+Buffer<min16float> tensor : register(t0);
+RWTexture2D<min16float4> tex : register(u0);
+
+[numthreads(8, 8, 1)]
+void main(uint3 tid : SV_GroupThreadID, uint3 gid : SV_GroupID) {
+	const uint2 gxy = (gid.xy << 3) + tid.xy;
+
+	uint width, height;
+	tex.GetDimensions(width, height);
+
+	const uint planeStride = width * height;
+	const uint idx = gxy.y * width + gxy.x;
+	min16float3 color = { tensor[idx], tensor[planeStride + idx], tensor[planeStride * 2 + idx] };
+	tex[gxy] = min16float4(color, 1);
+}

--- a/src/Magpie.Core/shaders/TextureToTensorCS.hlsl
+++ b/src/Magpie.Core/shaders/TextureToTensorCS.hlsl
@@ -1,0 +1,54 @@
+Texture2D<min16float4> tex : register(t0);
+RWBuffer<min16float> result : register(u0);
+
+SamplerState sam : register(s0);
+
+[numthreads(8, 8, 1)]
+void main(uint3 tid : SV_GroupThreadID, uint3 gid : SV_GroupID) {
+	const uint2 gxy = (gid.xy << 4) + (tid.xy << 1);
+
+	uint width, height;
+	tex.GetDimensions(width, height);
+
+	if (gxy.x >= width || gxy.y >= height) {
+		return;
+	}
+
+	const float2 pos = (gxy + 1) / float2(width, height);
+
+	min16float4 red = tex.GatherRed(sam, pos);
+	min16float4 green = tex.GatherGreen(sam, pos);
+	min16float4 blue = tex.GatherBlue(sam, pos);
+
+	const uint planeStride = width * height;
+	const uint planeStride2 = width * height * 2;
+
+	// w z
+	// x y
+	uint idx = gxy.y * width + gxy.x;
+
+	result[idx] = red.w;
+	result[idx + planeStride] = green.w;
+	result[idx + planeStride2] = blue.w;
+
+	const bool zyValid = gxy.x + 1 < width;
+	if (zyValid) {
+		result[idx + 1] = red.z;
+		result[idx + planeStride + 1] = green.z;
+		result[idx + planeStride2 + 1] = blue.z;
+	}
+
+	idx += width;
+
+	if (gxy.y + 1 < height) {
+		result[idx] = red.x;
+		result[idx + planeStride] = green.x;
+		result[idx + planeStride2] = blue.x;
+
+		if (zyValid) {
+			result[idx + 1] = red.y;
+			result[idx + planeStride + 1] = green.y;
+			result[idx + planeStride2 + 1] = blue.y;
+		}
+	}
+}

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -82,6 +82,26 @@ static void WriteProfile(rapidjson::PrettyWriter<rapidjson::StringBuffer>& write
 
 	writer.Key("scalingMode");
 	writer.Int(profile.scalingMode);
+	writer.Key("onnxModel");
+	writer.String(StrHelper::UTF16ToUTF8(profile.onnxModel).c_str());
+	writer.Key("onnxScale");
+	writer.Uint(profile.onnxScale);
+	writer.Key("onnxBackend");
+	writer.Uint(profile.onnxBackend);
+	writer.Key("onnxStaticEngine");
+	writer.Uint(profile.onnxStaticEngine);
+	writer.Key("onnxDynamicMaxWidth");
+	writer.Uint(profile.onnxDynamicMaxWidth);
+	writer.Key("onnxDynamicMaxHeight");
+	writer.Uint(profile.onnxDynamicMaxHeight);
+	writer.Key("onnxRenderWidth");
+	writer.Uint(profile.onnxRenderWidth);
+	writer.Key("onnxRenderHeight");
+	writer.Uint(profile.onnxRenderHeight);
+	writer.Key("onnxDynamicMinWidth");
+	writer.Uint(profile.onnxDynamicMinWidth);
+	writer.Key("onnxDynamicMinHeight");
+	writer.Uint(profile.onnxDynamicMinHeight);
 	writer.Key("captureMethod");
 	writer.Uint((uint32_t)profile.captureMethod);
 	writer.Key("multiMonitorUsage");
@@ -990,6 +1010,32 @@ bool AppSettings::_LoadProfile(
 	JsonHelper::ReadInt(profileObj, "scalingMode", profile.scalingMode);
 	if (profile.scalingMode < -1 || profile.scalingMode >= (int)_scalingModes.size()) {
 		profile.scalingMode = -1;
+	}
+
+	JsonHelper::ReadString(profileObj, "onnxModel", profile.onnxModel);
+	JsonHelper::ReadUInt(profileObj, "onnxScale", profile.onnxScale);
+	JsonHelper::ReadUInt(profileObj, "onnxBackend", profile.onnxBackend);
+	JsonHelper::ReadUInt(profileObj, "onnxStaticEngine", profile.onnxStaticEngine);
+	JsonHelper::ReadUInt(profileObj, "onnxDynamicMaxWidth", profile.onnxDynamicMaxWidth);
+	JsonHelper::ReadUInt(profileObj, "onnxDynamicMaxHeight", profile.onnxDynamicMaxHeight);
+	JsonHelper::ReadUInt(profileObj, "onnxRenderWidth", profile.onnxRenderWidth);
+	JsonHelper::ReadUInt(profileObj, "onnxRenderHeight", profile.onnxRenderHeight);
+	if (profile.onnxRenderWidth > 16384) {
+		profile.onnxRenderWidth = 0;
+	}
+	if (profile.onnxRenderHeight > 16384) {
+		profile.onnxRenderHeight = 0;
+	}
+	JsonHelper::ReadUInt(profileObj, "onnxDynamicMinWidth", profile.onnxDynamicMinWidth);
+	JsonHelper::ReadUInt(profileObj, "onnxDynamicMinHeight", profile.onnxDynamicMinHeight);
+	if (profile.onnxScale < 1 || profile.onnxScale > 8) {
+		profile.onnxScale = 2;
+	}
+	if (profile.onnxBackend > 1) {
+		profile.onnxBackend = 0;
+	}
+	if (profile.onnxStaticEngine > 1) {
+		profile.onnxStaticEngine = 0;
 	}
 
 	{

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -94,8 +94,18 @@
     <Link>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>onnxruntime.lib;directml.lib;cudart.lib;Gdi32.lib;Dwmapi.lib;Shell32.lib;Ole32.lib;Imagehlp.lib;Comctl32.lib;Shlwapi.lib;Magnification.lib;bcp47mrm.lib;Shcore.lib;Uxtheme.lib;Taskschd.lib;Dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>onnxruntime.dll;cudart64_12.dll;DirectML.dll;d3dcompiler_47.dll;Magnification.dll;Imagehlp.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>Gdi32.lib;Dwmapi.lib;Shell32.lib;Ole32.lib;Imagehlp.lib;Comctl32.lib;Shlwapi.lib;Magnification.lib;bcp47mrm.lib;Shcore.lib;Uxtheme.lib;Taskschd.lib;Dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>d3dcompiler_47.dll;Magnification.dll;Imagehlp.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+  <!-- 延迟加载是必需的：见 main.cpp 中 PinThirdPartyRuntimes 的注释
+       Delay-loading is required, not an optimization - see PinThirdPartyRuntimes
+       in main.cpp. Without it the loader binds System32's onnxruntime.dll
+       before we get a chance to pin ours. -->
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Link>
+      <AdditionalDependencies>onnxruntime.lib;directml.lib;cudart.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>onnxruntime.dll;cudart64_12.dll;DirectML.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <!-- 删除 clang-cl 不支持的选项 -->

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -291,6 +291,7 @@
     </ClInclude>
     <ClInclude Include="ToastService.h" />
     <ClInclude Include="TouchHelper.h" />
+    <ClInclude Include="OnnxRuntimeService.h" />
     <ClInclude Include="UpdateService.h" />
     <ClInclude Include="WrapPanel.h">
       <DependentUpon>WrapPanel.idl</DependentUpon>
@@ -485,6 +486,7 @@
     </ClCompile>
     <ClCompile Include="ToastService.cpp" />
     <ClCompile Include="TouchHelper.cpp" />
+    <ClCompile Include="OnnxRuntimeService.cpp" />
     <ClCompile Include="UpdateService.cpp" />
     <ClCompile Include="WrapPanel.cpp">
       <DependentUpon>WrapPanel.idl</DependentUpon>

--- a/src/Magpie/Magpie.vcxproj
+++ b/src/Magpie/Magpie.vcxproj
@@ -94,8 +94,8 @@
     <Link>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>Gdi32.lib;Dwmapi.lib;Shell32.lib;Ole32.lib;Imagehlp.lib;Comctl32.lib;Shlwapi.lib;Magnification.lib;bcp47mrm.lib;Shcore.lib;Uxtheme.lib;Taskschd.lib;Dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>d3dcompiler_47.dll;Magnification.dll;Imagehlp.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>onnxruntime.lib;directml.lib;cudart.lib;Gdi32.lib;Dwmapi.lib;Shell32.lib;Ole32.lib;Imagehlp.lib;Comctl32.lib;Shlwapi.lib;Magnification.lib;bcp47mrm.lib;Shcore.lib;Uxtheme.lib;Taskschd.lib;Dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>onnxruntime.dll;cudart64_12.dll;DirectML.dll;d3dcompiler_47.dll;Magnification.dll;Imagehlp.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <!-- 删除 clang-cl 不支持的选项 -->

--- a/src/Magpie/NotifyIconService.cpp
+++ b/src/Magpie/NotifyIconService.cpp
@@ -98,6 +98,20 @@ void NotifyIconService::IsShow(bool value) noexcept {
 
 LRESULT NotifyIconService::_NotifyIconWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
 	switch (message) {
+	case _WM_SHOW_BALLOON:
+	{
+		std::unique_ptr<std::pair<std::wstring, std::wstring>> payload(
+			(std::pair<std::wstring, std::wstring>*)lParam);
+		if (_isShow) {
+			NOTIFYICONDATA nid = _nid;
+			nid.uFlags = NIF_INFO;
+			wcsncpy_s(nid.szInfoTitle, payload->first.c_str(), _TRUNCATE);
+			wcsncpy_s(nid.szInfo, payload->second.c_str(), _TRUNCATE);
+			nid.dwInfoFlags = NIIF_NONE;
+			Shell_NotifyIcon(NIM_MODIFY, &nid);
+		}
+		return 0;
+	}
 	case CommonSharedConstants::WM_NOTIFY_ICON:
 	{
 		switch (lParam) {
@@ -190,6 +204,21 @@ LRESULT NotifyIconService::_NotifyIconWndProc(HWND hWnd, UINT message, WPARAM wP
 	}
 
 	return DefWindowProc(hWnd, message, wParam, lParam);
+}
+
+void NotifyIconService::ShowBalloon(std::wstring title, std::wstring text) noexcept {
+	if (!_nid.hWnd) {
+		return;
+	}
+
+	// 跨线程：投递到图标窗口，由它调用 Shell_NotifyIcon
+	// Cross-thread: hand it to the icon window and let that thread call
+	// Shell_NotifyIcon. PostMessage takes ownership of the payload.
+	auto* payload = new std::pair<std::wstring, std::wstring>(
+		std::move(title), std::move(text));
+	if (!PostMessage(_nid.hWnd, _WM_SHOW_BALLOON, 0, (LPARAM)payload)) {
+		delete payload;
+	}
 }
 
 }

--- a/src/Magpie/NotifyIconService.h
+++ b/src/Magpie/NotifyIconService.h
@@ -13,6 +13,9 @@ public:
 	void Initialize() noexcept;
 	void Uninitialize() noexcept;
 
+	// 可从任意线程调用 / safe to call from any thread
+	void ShowBalloon(std::wstring title, std::wstring text) noexcept;
+
 	void IsShow(bool value) noexcept;
 	bool IsShow() const noexcept {
 		// 返回 _shouldShow 而不是 _isShow，对外接口假设总是创建成功
@@ -20,6 +23,10 @@ public:
 	}
 
 private:
+	// 气球提示可能来自缩放线程，投递到拥有图标的线程处理
+	// Balloons can originate on the scaling thread; posted to the icon's thread.
+	static constexpr UINT _WM_SHOW_BALLOON = WM_USER + 10;
+
 	static LRESULT _NotifyIconWndProcStatic(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 		return Get()._NotifyIconWndProc(hWnd, msg, wParam, lParam);
 	}

--- a/src/Magpie/OnnxRuntimeService.cpp
+++ b/src/Magpie/OnnxRuntimeService.cpp
@@ -1,0 +1,286 @@
+#include "pch.h"
+#include "OnnxRuntimeService.h"
+#include "App.h"
+#include "Logger.h"
+#include "StrHelper.h"
+#include "Win32Helper.h"
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Web.Http.h>
+
+using namespace winrt;
+// App 在 winrt::Magpie::implementation 里，而本文件位于 namespace Magpie
+// App lives in winrt::Magpie::implementation; this file is in namespace Magpie,
+// so without this the name resolves to Magpie::App and does not exist.
+using namespace winrt::Magpie::implementation;
+using namespace Windows::Storage::Streams;
+using namespace Windows::Web::Http;
+
+namespace Magpie {
+
+// 运行时已经作为 release 资源发布，直接取用，不再另行分发。
+// 注意运行时分散在两个资源里：onnxruntime.dll 和 DirectML.dll 在主包的
+// third_party\ 下，TensorRT/CUDA 那几个大文件在单独的 ext 包里。
+//
+// The runtime is already published as release assets, so it is fetched from
+// there rather than redistributed again. It is split across two of them:
+// onnxruntime.dll and DirectML.dll live under third_party\ inside the main
+// package, while the large TensorRT/CUDA libraries are in the ext package.
+struct RuntimePackage {
+	const wchar_t* url;
+	const wchar_t* fileName;
+	// 主包里带 third_party\ 前缀，需要剥掉一层
+	// The main package nests them under third_party\, so strip one level.
+	const wchar_t* subDir;
+	// 已存在则跳过，重试时不必重新下载近 1 GB
+	// Skipped when already present, so a retry does not refetch ~1 GB.
+	const wchar_t* probe;
+	uint64_t approxBytes;
+};
+
+static constexpr RuntimePackage PACKAGES[] = {
+	{
+		L"https://github.com/Blinue/Magpie/releases/download/onnx-preview2/Magpie-onnx-preview2-x64.zip",
+		L"onnx-core.zip",
+		L"third_party",
+		L"onnxruntime.dll",
+		26ull * 1024 * 1024
+	},
+	{
+		L"https://github.com/Blinue/Magpie/releases/download/onnx-preview2/ext-tensorrt-x64.7z",
+		L"onnx-ext.7z",
+		nullptr,
+		L"nvinfer_10.dll",
+		973ull * 1024 * 1024
+	}
+};
+
+std::wstring OnnxRuntimeService::_ThirdPartyDir() const noexcept {
+	return (Win32Helper::GetExePath().parent_path() / L"third_party").wstring();
+}
+
+bool OnnxRuntimeService::IsInstalled() const noexcept {
+	const std::wstring probe = _ThirdPartyDir() + L"\\onnxruntime.dll";
+	return Win32Helper::FileExists(probe.c_str());
+}
+
+void OnnxRuntimeService::_Status(OnnxRuntimeStatus value) {
+	if (_status == value) {
+		return;
+	}
+
+	_status = value;
+	StatusChanged.Invoke(value);
+}
+
+bool OnnxRuntimeService::_Extract(
+	const std::wstring& archivePath,
+	const std::wstring& destDir,
+	const wchar_t* subDir
+) noexcept {
+	// tar.exe 一定在 System32，用绝对路径避免 PATH 被劫持
+	// tar.exe always lives in System32; use the absolute path so a hijacked
+	// PATH cannot substitute something else.
+	wchar_t systemDir[MAX_PATH];
+	const UINT len = GetSystemDirectory(systemDir, MAX_PATH);
+	if (len == 0 || len >= MAX_PATH) {
+		Logger::Get().Win32Error("GetSystemDirectory 失败");
+		return false;
+	}
+
+	const std::wstring tarPath = StrHelper::Concat(systemDir, L"\\tar.exe");
+	if (!Win32Helper::FileExists(tarPath.c_str())) {
+		Logger::Get().Error("找不到 tar.exe / tar.exe is not present");
+		return false;
+	}
+
+	// bsdtar 能按路径挑选条目，--strip-components 去掉外层目录
+	// bsdtar can select entries by path; --strip-components drops the wrapper
+	// directory so the files land directly in destDir.
+	std::wstring cmdLine = StrHelper::Concat(
+		L"\"", tarPath, L"\" -xf \"", archivePath, L"\" -C \"", destDir, L"\"");
+	if (subDir) {
+		cmdLine += StrHelper::Concat(L" --strip-components=1 ", subDir);
+	}
+
+	STARTUPINFO si{ .cb = sizeof(si), .dwFlags = STARTF_USESHOWWINDOW, .wShowWindow = SW_HIDE };
+	wil::unique_process_information pi;
+	if (!CreateProcess(nullptr, cmdLine.data(), nullptr, nullptr, FALSE,
+		CREATE_NO_WINDOW, nullptr, nullptr, &si, pi.addressof())) {
+		Logger::Get().Win32Error("CreateProcess(tar.exe) 失败");
+		return false;
+	}
+
+	WaitForSingleObject(pi.hProcess, INFINITE);
+
+	DWORD exitCode = 1;
+	GetExitCodeProcess(pi.hProcess, &exitCode);
+	if (exitCode != 0) {
+		Logger::Get().Error(fmt::format("tar.exe 解压失败，退出码 {}", exitCode));
+		return false;
+	}
+
+	return true;
+}
+
+fire_and_forget OnnxRuntimeService::DownloadAndInstall() {
+	if (_status == OnnxRuntimeStatus::Downloading ||
+		_status == OnnxRuntimeStatus::Extracting) {
+		co_return;
+	}
+
+	_cancelled = false;
+	_downloadProgress = 0;
+
+	const std::wstring thirdPartyDir = _ThirdPartyDir();
+
+	if (!Win32Helper::DirExists(thirdPartyDir.c_str()) &&
+		!Win32Helper::CreateDir(thirdPartyDir, true)) {
+		Logger::Get().Win32Error("创建 third_party 失败");
+		_Status(OnnxRuntimeStatus::Error);
+		co_return;
+	}
+
+	// 已经就位的包不再下载，重试时只补缺的那个
+	// Skip packages already on disk so a retry only fetches what is missing.
+	uint64_t plannedBytes = 0;
+	bool needed[std::size(PACKAGES)]{};
+	for (size_t i = 0; i < std::size(PACKAGES); ++i) {
+		const std::wstring probe = thirdPartyDir + L"\\" + PACKAGES[i].probe;
+		needed[i] = !Win32Helper::FileExists(probe.c_str());
+		if (needed[i]) {
+			plannedBytes += PACKAGES[i].approxBytes;
+		}
+	}
+
+	_Status(OnnxRuntimeStatus::Downloading);
+
+	// 下载留在 UI 线程：WinRT 的异步等待会回到同一个上下文，而状态事件最终
+	// 会触碰 XAML，从线程池线程触发会抛 "marshalled for a different thread"。
+	// 只有阻塞的解压切到后台，并且在报告状态前切回来。
+	//
+	// The download stays on the UI thread: the awaits below resume on the same
+	// context, and the status events end up touching XAML, so firing them from
+	// a thread-pool thread throws. Only the blocking extract goes to the
+	// background, and every exit path returns here before reporting.
+	bool ok = false;
+	bool cancelled = false;
+	bool failed = false;
+	// 跨多个包累计，进度条按总量走
+	// Accumulated across packages so the bar tracks the whole job.
+	uint64_t doneBytes = 0;
+
+	try {
+		for (size_t i = 0; i < std::size(PACKAGES) && !cancelled && !failed; ++i) {
+			if (!needed[i]) {
+				continue;
+			}
+
+			const RuntimePackage& pkg = PACKAGES[i];
+			const std::wstring archivePath =
+				StrHelper::Concat(thirdPartyDir, L"\\", pkg.fileName);
+
+			HttpClient httpClient;
+			auto requestProgressOp = httpClient.GetInputStreamAsync(Uri(pkg.url));
+			IInputStream httpStream = co_await requestProgressOp;
+
+			{
+				wil::unique_hfile file(
+					CreateFile2(archivePath.c_str(), GENERIC_WRITE, 0, CREATE_ALWAYS, nullptr));
+				if (!file) {
+					Logger::Get().Win32Error("创建下载文件失败");
+					failed = true;
+				} else {
+					Buffer buffer(64 * 1024);
+					// 总量接近 1 GB，必须用 64 位计数
+					// Close to 1 GB in total, so the counter has to be 64-bit.
+					uint64_t pkgBytes = 0;
+
+					while (true) {
+						IBuffer resultBuffer = co_await httpStream.ReadAsync(
+							buffer, buffer.Capacity(), InputStreamOptions::Partial);
+
+						if (_cancelled) {
+							httpStream.Close();
+							cancelled = true;
+							break;
+						}
+
+						const uint32_t bufferSize = resultBuffer.Length();
+						if (bufferSize == 0) {
+							break;
+						}
+
+						if (!WriteFile(file.get(), resultBuffer.data(), bufferSize, nullptr, nullptr)) {
+							Logger::Get().Win32Error("WriteFile 失败");
+							failed = true;
+							break;
+						}
+
+						pkgBytes += bufferSize;
+						if (plannedBytes > 0) {
+							_downloadProgress = std::min(1.0,
+								(doneBytes + pkgBytes) / (double)plannedBytes);
+							DownloadProgressChanged.Invoke(_downloadProgress);
+						}
+					}
+
+					doneBytes += pkgBytes;
+				}
+			}
+
+			if (cancelled || failed) {
+				DeleteFile(archivePath.c_str());
+				break;
+			}
+
+			_Status(OnnxRuntimeStatus::Extracting);
+
+			// 解压会阻塞（WaitForSingleObject），必须切到后台
+			// Extraction blocks on WaitForSingleObject, so it leaves the UI
+			// thread here and returns below before anything is reported.
+			co_await resume_background();
+			const bool extracted = _Extract(archivePath, thirdPartyDir, pkg.subDir);
+			DeleteFile(archivePath.c_str());
+			co_await App::Get().Dispatcher();
+
+			if (!extracted) {
+				failed = true;
+				break;
+			}
+
+			_Status(OnnxRuntimeStatus::Downloading);
+		}
+
+		if (!cancelled && !failed) {
+			ok = IsInstalled();
+			if (!ok) {
+				Logger::Get().Error("解压后仍找不到 onnxruntime.dll");
+			}
+		}
+	} catch (const hresult_error& e) {
+		Logger::Get().Error(StrHelper::Concat(
+			"下载运行时失败 / failed to download the runtime: ",
+			StrHelper::UTF16ToUTF8(e.message())));
+	}
+
+	// 清掉可能残留的半个压缩包
+	// Drop any half-written archive left behind.
+	for (const RuntimePackage& pkg : PACKAGES) {
+		DeleteFile(StrHelper::Concat(thirdPartyDir, L"\\", pkg.fileName).c_str());
+	}
+
+	// 可能仍在后台线程上（解压途中失败或抛异常），报告状态前必须切回
+	// May still be on a background thread if the extract failed or threw, so
+	// come back before touching anything the UI is bound to. Harmless when we
+	// are already on the UI thread.
+	co_await App::Get().Dispatcher();
+
+	if (cancelled) {
+		_downloadProgress = 0;
+		_Status(OnnxRuntimeStatus::NotInstalled);
+	} else {
+		_Status(ok ? OnnxRuntimeStatus::Installed : OnnxRuntimeStatus::Error);
+	}
+}
+
+}

--- a/src/Magpie/OnnxRuntimeService.h
+++ b/src/Magpie/OnnxRuntimeService.h
@@ -1,0 +1,75 @@
+#pragma once
+#include "Event.h"
+
+namespace Magpie {
+
+enum class OnnxRuntimeStatus {
+	// third_party\ 里没有运行时
+	NotInstalled,
+	Downloading,
+	Extracting,
+	Installed,
+	Error
+};
+
+// AI 放大所需的运行时（onnxruntime / TensorRT / CUDA / DirectML）解压后约 2.4 GB，
+// 不随程序分发，因此按需下载到 third_party\。
+//
+// The runtime needed for AI upscaling is ~2.4 GB unpacked - far too large to
+// ship with Magpie - so it is fetched on demand into third_party\. Without it
+// the app runs normally and simply reports that AI upscaling is unavailable
+// (see PinThirdPartyRuntimes in main.cpp), so this is purely additive.
+class OnnxRuntimeService {
+public:
+	static OnnxRuntimeService& Get() noexcept {
+		static OnnxRuntimeService instance;
+		return instance;
+	}
+
+	OnnxRuntimeService(const OnnxRuntimeService&) = delete;
+	OnnxRuntimeService(OnnxRuntimeService&&) = delete;
+
+	// 以 third_party\onnxruntime.dll 是否存在为准
+	// Presence of third_party\onnxruntime.dll is the test; a partial extract
+	// would leave it missing, so a failed install does not read as complete.
+	bool IsInstalled() const noexcept;
+
+	OnnxRuntimeStatus Status() const noexcept {
+		return _status;
+	}
+
+	// 0 ~ 1，仅在 Downloading 时有意义
+	double DownloadProgress() const noexcept {
+		return _downloadProgress;
+	}
+
+	winrt::fire_and_forget DownloadAndInstall();
+
+	void Cancel() noexcept {
+		_cancelled = true;
+	}
+
+	Event<OnnxRuntimeStatus> StatusChanged;
+	Event<double> DownloadProgressChanged;
+
+private:
+	OnnxRuntimeService() = default;
+
+	void _Status(OnnxRuntimeStatus value);
+
+	// 用系统自带的 tar.exe 解压。它是 bsdtar/libarchive，原生支持 7z，
+	// 这样就不必为了一个下载功能引入 LZMA 依赖。
+	// Extraction goes through the in-box tar.exe: it is bsdtar/libarchive with
+	// liblzma and reads 7z natively, which avoids taking an LZMA dependency
+	// just to unpack one download.
+	bool _Extract(const std::wstring& archivePath, const std::wstring& destDir,
+		const wchar_t* subDir) noexcept;
+
+	std::wstring _ThirdPartyDir() const noexcept;
+
+	OnnxRuntimeStatus _status = OnnxRuntimeStatus::NotInstalled;
+	double _downloadProgress = 0;
+	bool _cancelled = false;
+};
+
+}

--- a/src/Magpie/Profile.h
+++ b/src/Magpie/Profile.h
@@ -51,6 +51,16 @@ struct Profile {
 		launchParameters = other.launchParameters;
 		destAlignment = other.destAlignment;
 		scalingFlags = other.scalingFlags;
+		onnxModel = other.onnxModel;
+		onnxScale = other.onnxScale;
+		onnxBackend = other.onnxBackend;
+		onnxStaticEngine = other.onnxStaticEngine;
+		onnxDynamicMaxWidth = other.onnxDynamicMaxWidth;
+		onnxDynamicMaxHeight = other.onnxDynamicMaxHeight;
+		onnxRenderWidth = other.onnxRenderWidth;
+		onnxRenderHeight = other.onnxRenderHeight;
+		onnxDynamicMinWidth = other.onnxDynamicMinWidth;
+		onnxDynamicMinHeight = other.onnxDynamicMinHeight;
 		
 		isCroppingEnabled = other.isCroppingEnabled;
 		isFrameRateLimiterEnabled = other.isFrameRateLimiterEnabled;
@@ -98,6 +108,22 @@ struct Profile {
 	DestAlignment destAlignment = DestAlignment::Center;
 
 	uint32_t scalingFlags = ScalingFlags::AdjustCursorSpeed;
+
+	// ---- ONNX 上采样 / ONNX upscaling ----
+	// 默认配置文件即全局设置，具名配置文件覆盖它
+	// The default profile is the global setting; named profiles override it.
+	std::wstring onnxModel;
+	uint32_t onnxScale = 2;
+	// 0 = DirectML, 1 = TensorRT
+	uint32_t onnxBackend = 0;
+	uint32_t onnxStaticEngine = 0;
+	uint32_t onnxDynamicMaxWidth = 0;
+	uint32_t onnxDynamicMaxHeight = 0;
+	// 推理前预降采样的目标分辨率，0 = 关闭 / pre-downscale target, 0 = off
+	uint32_t onnxRenderWidth = 0;
+	uint32_t onnxRenderHeight = 0;
+	uint32_t onnxDynamicMinWidth = 0;
+	uint32_t onnxDynamicMinHeight = 0;
 
 	bool isPackaged = false;
 	bool isCroppingEnabled = false;

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -184,85 +184,6 @@
 					          ItemsSource="{x:Bind ViewModel.CaptureMethods, Mode=OneTime}"
 					          SelectedIndex="{x:Bind ViewModel.CaptureMethod, Mode=TwoWay}" />
 				</local:SettingsCard>
-				<local:SettingsCard Header="AI upscaling model"
-				                    Description="ONNX model from the models folder. Runs before the scaling mode's effects.">
-					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
-					          ItemsSource="{x:Bind ViewModel.OnnxModels, Mode=OneTime}"
-					          SelectedIndex="{x:Bind ViewModel.OnnxModel, Mode=TwoWay}" />
-				</local:SettingsCard>
-				<local:SettingsCard Header="Render at lower resolution first"
-				                    Description="Downscale to this size before the model runs, then let it scale back up (width, height). 0 = off. Use it on native-resolution windows, where there is otherwise nothing to upscale.">
-					<local:SimpleStackPanel Orientation="Horizontal"
-					                        Spacing="8">
-						<muxc:NumberBox Width="104"
-						                Value="{x:Bind ViewModel.OnnxRenderWidth, Mode=TwoWay}"
-						                Minimum="0"
-						                Maximum="16384"
-						                SmallChange="64"
-						                SpinButtonPlacementMode="Compact" />
-						<muxc:NumberBox Width="104"
-						                Value="{x:Bind ViewModel.OnnxRenderHeight, Mode=TwoWay}"
-						                Minimum="0"
-						                Maximum="16384"
-						                SmallChange="64"
-						                SpinButtonPlacementMode="Compact" />
-					</local:SimpleStackPanel>
-				</local:SettingsCard>
-				<local:SettingsCard Header="AI inference backend"
-				                    Description="TensorRT is faster on NVIDIA; the first scale builds an engine, which takes minutes.">
-					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
-					          ItemsSource="{x:Bind ViewModel.OnnxBackends, Mode=OneTime}"
-					          SelectedIndex="{x:Bind ViewModel.OnnxBackend, Mode=TwoWay}" />
-				</local:SettingsCard>
-				<local:SettingsCard Header="AI model scale"
-				                    Description="Must match the model's real factor. Set automatically when you pick a model.">
-					<muxc:NumberBox Width="104"
-					                Value="{x:Bind ViewModel.OnnxScale, Mode=TwoWay}"
-					                Minimum="1"
-					                Maximum="8"
-					                SmallChange="1"
-					                SpinButtonPlacementMode="Compact" />
-				</local:SettingsCard>
-				<local:SettingsCard Header="Static AI engine (TensorRT)"
-				                    Description="Fastest, but rebuilds per window size. Off reuses one engine for that size and smaller.">
-					<ToggleSwitch IsOn="{x:Bind ViewModel.OnnxStaticEngine, Mode=TwoWay}" />
-				</local:SettingsCard>
-				<local:SettingsCard Header="Dynamic engine max size"
-				                    Description="Largest window the engine must cover (width, height). 0 = auto.">
-					<local:SimpleStackPanel Orientation="Horizontal"
-					                        Spacing="8">
-						<muxc:NumberBox Width="104"
-						                Value="{x:Bind ViewModel.OnnxDynamicMaxWidth, Mode=TwoWay}"
-						                Minimum="0"
-						                Maximum="16384"
-						                SmallChange="64"
-						                SpinButtonPlacementMode="Compact" />
-						<muxc:NumberBox Width="104"
-						                Value="{x:Bind ViewModel.OnnxDynamicMaxHeight, Mode=TwoWay}"
-						                Minimum="0"
-						                Maximum="16384"
-						                SmallChange="64"
-						                SpinButtonPlacementMode="Compact" />
-					</local:SimpleStackPanel>
-				</local:SettingsCard>
-				<local:SettingsCard Header="Dynamic engine min size"
-				                    Description="Smallest window the engine must cover (width, height). 0 = 1x1.">
-					<local:SimpleStackPanel Orientation="Horizontal"
-					                        Spacing="8">
-						<muxc:NumberBox Width="104"
-						                Value="{x:Bind ViewModel.OnnxDynamicMinWidth, Mode=TwoWay}"
-						                Minimum="0"
-						                Maximum="16384"
-						                SmallChange="64"
-						                SpinButtonPlacementMode="Compact" />
-						<muxc:NumberBox Width="104"
-						                Value="{x:Bind ViewModel.OnnxDynamicMinHeight, Mode=TwoWay}"
-						                Minimum="0"
-						                Maximum="16384"
-						                SmallChange="64"
-						                SpinButtonPlacementMode="Compact" />
-					</local:SimpleStackPanel>
-				</local:SettingsCard>
 				<muxc:InfoBar x:Uid="Profile_General_DesktopDuplicationWarning"
 				              IsClosable="False"
 				              IsOpen="{x:Bind ViewModel.IsCaptureMethodDesktopDuplication, Mode=OneWay}"
@@ -301,6 +222,80 @@
 						<ComboBoxItem x:Uid="Profile_General_Multimonitor_Intersected" />
 						<ComboBoxItem x:Uid="Profile_General_Multimonitor_All" />
 					</ComboBox>
+				</local:SettingsCard>
+			</local:SettingsGroup>
+			<local:SettingsGroup x:Uid="Profile_AI">
+				<local:SettingsCard x:Uid="Profile_AI_Model">
+					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
+					          ItemsSource="{x:Bind ViewModel.OnnxModels, Mode=OneTime}"
+					          SelectedIndex="{x:Bind ViewModel.OnnxModel, Mode=TwoWay}" />
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Profile_AI_RenderSize">
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        Spacing="8">
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxRenderWidth, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxRenderHeight, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Profile_AI_Backend">
+					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
+					          ItemsSource="{x:Bind ViewModel.OnnxBackends, Mode=OneTime}"
+					          SelectedIndex="{x:Bind ViewModel.OnnxBackend, Mode=TwoWay}" />
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Profile_AI_Scale">
+					<muxc:NumberBox Width="104"
+					                Value="{x:Bind ViewModel.OnnxScale, Mode=TwoWay}"
+					                Minimum="1"
+					                Maximum="8"
+					                SmallChange="1"
+					                SpinButtonPlacementMode="Compact" />
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Profile_AI_StaticEngine">
+					<ToggleSwitch IsOn="{x:Bind ViewModel.OnnxStaticEngine, Mode=TwoWay}" />
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Profile_AI_MaxSize">
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        Spacing="8">
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMaxWidth, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMaxHeight, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
+				<local:SettingsCard x:Uid="Profile_AI_MinSize">
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        Spacing="8">
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMinWidth, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMinHeight, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+					</local:SimpleStackPanel>
 				</local:SettingsCard>
 			</local:SettingsGroup>
 			<local:SettingsGroup x:Uid="Profile_WindowedScaling">

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -225,12 +225,18 @@
 				</local:SettingsCard>
 			</local:SettingsGroup>
 			<local:SettingsGroup x:Uid="Profile_AI">
-				<local:SettingsCard x:Uid="Profile_AI_Model">
+				<muxc:InfoBar x:Uid="Profile_AI_RuntimeMissing"
+				              IsClosable="False"
+				              IsOpen="{x:Bind ViewModel.IsOnnxRuntimeMissing, Mode=OneTime}"
+				              Severity="Informational" />
+				<local:SettingsCard x:Uid="Profile_AI_Model"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
 					          ItemsSource="{x:Bind ViewModel.OnnxModels, Mode=OneTime}"
 					          SelectedIndex="{x:Bind ViewModel.OnnxModel, Mode=TwoWay}" />
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Profile_AI_RenderSize">
+				<local:SettingsCard x:Uid="Profile_AI_RenderSize"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<local:SimpleStackPanel Orientation="Horizontal"
 					                        Spacing="8">
 						<muxc:NumberBox Width="104"
@@ -247,12 +253,14 @@
 						                SpinButtonPlacementMode="Compact" />
 					</local:SimpleStackPanel>
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Profile_AI_Backend">
+				<local:SettingsCard x:Uid="Profile_AI_Backend"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
 					          ItemsSource="{x:Bind ViewModel.OnnxBackends, Mode=OneTime}"
 					          SelectedIndex="{x:Bind ViewModel.OnnxBackend, Mode=TwoWay}" />
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Profile_AI_Scale">
+				<local:SettingsCard x:Uid="Profile_AI_Scale"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<muxc:NumberBox Width="104"
 					                Value="{x:Bind ViewModel.OnnxScale, Mode=TwoWay}"
 					                Minimum="1"
@@ -260,10 +268,12 @@
 					                SmallChange="1"
 					                SpinButtonPlacementMode="Compact" />
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Profile_AI_StaticEngine">
+				<local:SettingsCard x:Uid="Profile_AI_StaticEngine"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<ToggleSwitch IsOn="{x:Bind ViewModel.OnnxStaticEngine, Mode=TwoWay}" />
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Profile_AI_MaxSize">
+				<local:SettingsCard x:Uid="Profile_AI_MaxSize"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<local:SimpleStackPanel Orientation="Horizontal"
 					                        Spacing="8">
 						<muxc:NumberBox Width="104"
@@ -280,7 +290,8 @@
 						                SpinButtonPlacementMode="Compact" />
 					</local:SimpleStackPanel>
 				</local:SettingsCard>
-				<local:SettingsCard x:Uid="Profile_AI_MinSize">
+				<local:SettingsCard x:Uid="Profile_AI_MinSize"
+				                    IsEnabled="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneTime}">
 					<local:SimpleStackPanel Orientation="Horizontal"
 					                        Spacing="8">
 						<muxc:NumberBox Width="104"

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -184,6 +184,85 @@
 					          ItemsSource="{x:Bind ViewModel.CaptureMethods, Mode=OneTime}"
 					          SelectedIndex="{x:Bind ViewModel.CaptureMethod, Mode=TwoWay}" />
 				</local:SettingsCard>
+				<local:SettingsCard Header="AI upscaling model"
+				                    Description="ONNX model from the models folder. Runs before the scaling mode's effects.">
+					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
+					          ItemsSource="{x:Bind ViewModel.OnnxModels, Mode=OneTime}"
+					          SelectedIndex="{x:Bind ViewModel.OnnxModel, Mode=TwoWay}" />
+				</local:SettingsCard>
+				<local:SettingsCard Header="Render at lower resolution first"
+				                    Description="Downscale to this size before the model runs, then let it scale back up (width, height). 0 = off. Use it on native-resolution windows, where there is otherwise nothing to upscale.">
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        Spacing="8">
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxRenderWidth, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxRenderHeight, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
+				<local:SettingsCard Header="AI inference backend"
+				                    Description="TensorRT is faster on NVIDIA; the first scale builds an engine, which takes minutes.">
+					<ComboBox DropDownOpened="ComboBox_DropDownOpened"
+					          ItemsSource="{x:Bind ViewModel.OnnxBackends, Mode=OneTime}"
+					          SelectedIndex="{x:Bind ViewModel.OnnxBackend, Mode=TwoWay}" />
+				</local:SettingsCard>
+				<local:SettingsCard Header="AI model scale"
+				                    Description="Must match the model's real factor. Set automatically when you pick a model.">
+					<muxc:NumberBox Width="104"
+					                Value="{x:Bind ViewModel.OnnxScale, Mode=TwoWay}"
+					                Minimum="1"
+					                Maximum="8"
+					                SmallChange="1"
+					                SpinButtonPlacementMode="Compact" />
+				</local:SettingsCard>
+				<local:SettingsCard Header="Static AI engine (TensorRT)"
+				                    Description="Fastest, but rebuilds per window size. Off reuses one engine for that size and smaller.">
+					<ToggleSwitch IsOn="{x:Bind ViewModel.OnnxStaticEngine, Mode=TwoWay}" />
+				</local:SettingsCard>
+				<local:SettingsCard Header="Dynamic engine max size"
+				                    Description="Largest window the engine must cover (width, height). 0 = auto.">
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        Spacing="8">
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMaxWidth, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMaxHeight, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
+				<local:SettingsCard Header="Dynamic engine min size"
+				                    Description="Smallest window the engine must cover (width, height). 0 = 1x1.">
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        Spacing="8">
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMinWidth, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+						<muxc:NumberBox Width="104"
+						                Value="{x:Bind ViewModel.OnnxDynamicMinHeight, Mode=TwoWay}"
+						                Minimum="0"
+						                Maximum="16384"
+						                SmallChange="64"
+						                SpinButtonPlacementMode="Compact" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
 				<muxc:InfoBar x:Uid="Profile_General_DesktopDuplicationWarning"
 				              IsClosable="False"
 				              IsOpen="{x:Bind ViewModel.IsCaptureMethodDesktopDuplication, Mode=OneWay}"

--- a/src/Magpie/ProfileViewModel.cpp
+++ b/src/Magpie/ProfileViewModel.cpp
@@ -11,6 +11,7 @@
 #include "Win32Helper.h"
 #include "AppSettings.h"
 #include "Logger.h"
+#include "OnnxRuntimeService.h"
 #include "ScalingMode.h"
 #include "ScalingService.h"
 #include "FileDialogHelper.h"
@@ -993,6 +994,14 @@ void ProfileViewModel::AutoHideCursorDelay(double value) {
 
 hstring ProfileViewModel::AutoHideCursorDelayText() const noexcept {
 	return App::Get().DoubleFormatter().FormatDouble(AutoHideCursorDelay());
+}
+
+bool ProfileViewModel::IsOnnxRuntimeInstalled() const noexcept {
+	return OnnxRuntimeService::Get().IsInstalled();
+}
+
+bool ProfileViewModel::IsOnnxRuntimeMissing() const noexcept {
+	return !OnnxRuntimeService::Get().IsInstalled();
 }
 
 hstring ProfileViewModel::LaunchParameters() const noexcept {

--- a/src/Magpie/ProfileViewModel.cpp
+++ b/src/Magpie/ProfileViewModel.cpp
@@ -326,6 +326,220 @@ void ProfileViewModel::ScalingMode(int value) {
 	RaisePropertyChanged(L"ScalingMode");
 }
 
+// 扫描 models\*.onnx。相对路径，和 Magpie 读取模型时一致
+// Enumerate models\*.onnx. Relative path, matching how the backend opens it.
+// Index 0 is the empty "None" entry so it lines up with the ComboBox.
+static std::vector<std::wstring> EnumOnnxModelPaths() noexcept {
+	std::vector<std::wstring> paths;
+	paths.push_back(std::wstring());
+
+	WIN32_FIND_DATAW findData{};
+	HANDLE hFind = FindFirstFileW(L"models\\*.onnx", &findData);
+	if (hFind != INVALID_HANDLE_VALUE) {
+		do {
+			if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+				continue;
+			}
+			paths.push_back(std::wstring(L"models\\") + findData.cFileName);
+		} while (FindNextFileW(hFind, &findData));
+		FindClose(hFind);
+	}
+	return paths;
+}
+
+IVector<IInspectable> ProfileViewModel::OnnxModels() const noexcept {
+	std::vector<IInspectable> models;
+	models.push_back(box_value(L"None"));
+
+	for (const std::wstring& path : EnumOnnxModelPaths()) {
+		if (path.empty()) {
+			continue;
+		}
+		const size_t slash = path.find_last_of(L'\\');
+		models.push_back(box_value(slash == std::wstring::npos
+			? path : path.substr(slash + 1)));
+	}
+	return single_threaded_vector(std::move(models));
+}
+
+IVector<IInspectable> ProfileViewModel::OnnxBackends() const noexcept {
+	std::vector<IInspectable> backends;
+	backends.push_back(box_value(L"DirectML"));
+	backends.push_back(box_value(L"TensorRT"));
+	return single_threaded_vector(std::move(backends));
+}
+
+int ProfileViewModel::OnnxModel() const noexcept {
+	const std::vector<std::wstring> paths = EnumOnnxModelPaths();
+	for (size_t i = 0; i < paths.size(); ++i) {
+		if (paths[i] == _data->onnxModel) {
+			return (int)i;
+		}
+	}
+	// 配置中的模型已不存在 / the configured model is gone
+	return 0;
+}
+
+void ProfileViewModel::OnnxModel(int value) {
+	const std::vector<std::wstring> paths = EnumOnnxModelPaths();
+	if (value < 0 || (size_t)value >= paths.size() || _data->onnxModel == paths[value]) {
+		return;
+	}
+
+	_data->onnxModel = paths[value];
+
+	// 从文件名推断倍率 / infer the factor from the filename. A stale scale makes
+	// inference fail every frame with a shape mismatch, i.e. a black screen.
+	if (!_data->onnxModel.empty()) {
+		std::wstring lower = _data->onnxModel;
+		for (wchar_t& ch : lower) {
+			ch = (wchar_t)towlower(ch);
+		}
+		uint32_t detected = 0;
+		for (uint32_t f = 1; f <= 8; ++f) {
+			const std::wstring a = L"x" + std::to_wstring(f);
+			const std::wstring b = std::to_wstring(f) + L"x";
+			if (lower.find(a) != std::wstring::npos || lower.find(b) != std::wstring::npos) {
+				detected = f;
+				break;
+			}
+		}
+		_data->onnxScale = detected ? detected : 2;
+		RaisePropertyChanged(L"OnnxScale");
+	}
+
+	RaisePropertyChanged(L"OnnxModel");
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxBackend() const noexcept {
+	return (int)_data->onnxBackend;
+}
+
+void ProfileViewModel::OnnxBackend(int value) {
+	if (value < 0 || value > 1 || (int)_data->onnxBackend == value) {
+		return;
+	}
+
+	_data->onnxBackend = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxBackend");
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxScale() const noexcept {
+	return (int)_data->onnxScale;
+}
+
+void ProfileViewModel::OnnxScale(int value) {
+	if (value < 1 || value > 8 || (int)_data->onnxScale == value) {
+		return;
+	}
+
+	_data->onnxScale = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxScale");
+	AppSettings::Get().Save();
+}
+
+bool ProfileViewModel::OnnxStaticEngine() const noexcept {
+	return _data->onnxStaticEngine != 0;
+}
+
+void ProfileViewModel::OnnxStaticEngine(bool value) {
+	if ((_data->onnxStaticEngine != 0) == value) {
+		return;
+	}
+
+	_data->onnxStaticEngine = value ? 1u : 0u;
+	RaisePropertyChanged(L"OnnxStaticEngine");
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxDynamicMaxWidth() const noexcept {
+	return (int)_data->onnxDynamicMaxWidth;
+}
+
+void ProfileViewModel::OnnxDynamicMaxWidth(int value) {
+	if (value < 0 || value > 16384 || (int)_data->onnxDynamicMaxWidth == value) {
+		return;
+	}
+
+	_data->onnxDynamicMaxWidth = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxDynamicMaxWidth");
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxDynamicMaxHeight() const noexcept {
+	return (int)_data->onnxDynamicMaxHeight;
+}
+
+void ProfileViewModel::OnnxDynamicMaxHeight(int value) {
+	if (value < 0 || value > 16384 || (int)_data->onnxDynamicMaxHeight == value) {
+		return;
+	}
+
+	_data->onnxDynamicMaxHeight = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxDynamicMaxHeight");
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxRenderWidth() const noexcept {
+	return (int)_data->onnxRenderWidth;
+}
+
+void ProfileViewModel::OnnxRenderWidth(int value) {
+	if (value < 0 || value > 16384 || (int)_data->onnxRenderWidth == value) {
+		return;
+	}
+
+	_data->onnxRenderWidth = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxRenderWidth");
+
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxRenderHeight() const noexcept {
+	return (int)_data->onnxRenderHeight;
+}
+
+void ProfileViewModel::OnnxRenderHeight(int value) {
+	if (value < 0 || value > 16384 || (int)_data->onnxRenderHeight == value) {
+		return;
+	}
+
+	_data->onnxRenderHeight = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxRenderHeight");
+
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxDynamicMinWidth() const noexcept {
+	return (int)_data->onnxDynamicMinWidth;
+}
+
+void ProfileViewModel::OnnxDynamicMinWidth(int value) {
+	if (value < 0 || value > 16384 || (int)_data->onnxDynamicMinWidth == value) {
+		return;
+	}
+
+	_data->onnxDynamicMinWidth = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxDynamicMinWidth");
+	AppSettings::Get().Save();
+}
+
+int ProfileViewModel::OnnxDynamicMinHeight() const noexcept {
+	return (int)_data->onnxDynamicMinHeight;
+}
+
+void ProfileViewModel::OnnxDynamicMinHeight(int value) {
+	if (value < 0 || value > 16384 || (int)_data->onnxDynamicMinHeight == value) {
+		return;
+	}
+
+	_data->onnxDynamicMinHeight = (uint32_t)value;
+	RaisePropertyChanged(L"OnnxDynamicMinHeight");
+	AppSettings::Get().Save();
+}
+
 IVector<IInspectable> ProfileViewModel::CaptureMethods() const noexcept {
 	ResourceLoader resourceLoader =
 		ResourceLoader::GetForCurrentView(CommonSharedConstants::APP_RESOURCE_MAP_ID);

--- a/src/Magpie/ProfileViewModel.h
+++ b/src/Magpie/ProfileViewModel.h
@@ -175,6 +175,9 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel>,
 
 	hstring AutoHideCursorDelayText() const noexcept;
 
+	bool IsOnnxRuntimeInstalled() const noexcept;
+	bool IsOnnxRuntimeMissing() const noexcept;
+
 	hstring LaunchParameters() const noexcept;
 	void LaunchParameters(const hstring& value);
 

--- a/src/Magpie/ProfileViewModel.h
+++ b/src/Magpie/ProfileViewModel.h
@@ -62,6 +62,42 @@ struct ProfileViewModel : ProfileViewModelT<ProfileViewModel>,
 
 	IVector<IInspectable> CaptureMethods() const noexcept;
 
+	// 按需构建，和 dev 中 ScalingModes()/CaptureMethods() 的做法一致
+	// Built on demand, matching how dev does ScalingModes()/CaptureMethods().
+	IVector<IInspectable> OnnxModels() const noexcept;
+
+	int OnnxModel() const noexcept;
+	void OnnxModel(int value);
+
+	IVector<IInspectable> OnnxBackends() const noexcept;
+
+	int OnnxBackend() const noexcept;
+	void OnnxBackend(int value);
+
+	int OnnxScale() const noexcept;
+	void OnnxScale(int value);
+
+	bool OnnxStaticEngine() const noexcept;
+	void OnnxStaticEngine(bool value);
+
+	int OnnxDynamicMaxWidth() const noexcept;
+	void OnnxDynamicMaxWidth(int value);
+
+	int OnnxDynamicMaxHeight() const noexcept;
+	void OnnxDynamicMaxHeight(int value);
+
+	int OnnxDynamicMinWidth() const noexcept;
+	void OnnxDynamicMinWidth(int value);
+
+	int OnnxDynamicMinHeight() const noexcept;
+	void OnnxDynamicMinHeight(int value);
+
+	int OnnxRenderWidth() const noexcept;
+	void OnnxRenderWidth(int value);
+
+	int OnnxRenderHeight() const noexcept;
+	void OnnxRenderHeight(int value);
+
 	int CaptureMethod() const noexcept;
 	void CaptureMethod(int value);
 

--- a/src/Magpie/ProfileViewModel.idl
+++ b/src/Magpie/ProfileViewModel.idl
@@ -28,6 +28,19 @@ namespace Magpie {
 
 		IVector<IInspectable> CaptureMethods { get; };
 		Int32 CaptureMethod;
+
+		IVector<IInspectable> OnnxModels { get; };
+		Int32 OnnxModel;
+		IVector<IInspectable> OnnxBackends { get; };
+		Int32 OnnxBackend;
+		Int32 OnnxScale;
+		Boolean OnnxStaticEngine;
+		Int32 OnnxDynamicMaxWidth;
+		Int32 OnnxDynamicMaxHeight;
+		Int32 OnnxDynamicMinWidth;
+		Int32 OnnxDynamicMinHeight;
+		Int32 OnnxRenderWidth;
+		Int32 OnnxRenderHeight;
 		Boolean IsCaptureMethodDesktopDuplication { get; };
 
 		Int32 AutoScale;

--- a/src/Magpie/ProfileViewModel.idl
+++ b/src/Magpie/ProfileViewModel.idl
@@ -77,6 +77,9 @@ namespace Magpie {
 		Double AutoHideCursorDelay;
 		String AutoHideCursorDelayText { get; };
 
+		Boolean IsOnnxRuntimeInstalled { get; };
+		Boolean IsOnnxRuntimeMissing { get; };
+
 		String LaunchParameters;
 		Int32 DestAlignment;
 		Boolean IsDirectFlipDisabled;

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -135,6 +135,51 @@
   <data name="Home_Activation_Timer_Delay.Header" xml:space="preserve">
     <value>Delay in seconds</value>
   </data>
+  <data name="Profile_AI.Header" xml:space="preserve">
+    <value>AI upscaling</value>
+  </data>
+  <data name="Profile_AI_Backend.Description" xml:space="preserve">
+    <value>TensorRT is faster on NVIDIA; the first scale builds an engine, which takes minutes.</value>
+  </data>
+  <data name="Profile_AI_Backend.Header" xml:space="preserve">
+    <value>AI inference backend</value>
+  </data>
+  <data name="Profile_AI_MaxSize.Description" xml:space="preserve">
+    <value>Largest window the engine must cover (width, height). 0 = auto.</value>
+  </data>
+  <data name="Profile_AI_MaxSize.Header" xml:space="preserve">
+    <value>Dynamic engine max size</value>
+  </data>
+  <data name="Profile_AI_MinSize.Description" xml:space="preserve">
+    <value>Smallest window the engine must cover (width, height). 0 = 1x1.</value>
+  </data>
+  <data name="Profile_AI_MinSize.Header" xml:space="preserve">
+    <value>Dynamic engine min size</value>
+  </data>
+  <data name="Profile_AI_Model.Description" xml:space="preserve">
+    <value>ONNX model from the models folder. Runs before the scaling mode's effects.</value>
+  </data>
+  <data name="Profile_AI_Model.Header" xml:space="preserve">
+    <value>AI upscaling model</value>
+  </data>
+  <data name="Profile_AI_RenderSize.Description" xml:space="preserve">
+    <value>Downscale to this size before the model runs, then let it scale back up (width, height). 0 = off. Use it on native-resolution windows, where there is otherwise nothing to upscale.</value>
+  </data>
+  <data name="Profile_AI_RenderSize.Header" xml:space="preserve">
+    <value>Render at lower resolution first</value>
+  </data>
+  <data name="Profile_AI_Scale.Description" xml:space="preserve">
+    <value>Must match the model's real factor. Set automatically when you pick a model.</value>
+  </data>
+  <data name="Profile_AI_Scale.Header" xml:space="preserve">
+    <value>AI model scale</value>
+  </data>
+  <data name="Profile_AI_StaticEngine.Description" xml:space="preserve">
+    <value>Fastest, but rebuilds per window size. Off reuses one engine for that size and smaller.</value>
+  </data>
+  <data name="Profile_AI_StaticEngine.Header" xml:space="preserve">
+    <value>Static AI engine (TensorRT)</value>
+  </data>
   <data name="ShortcutDialog_Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>

--- a/src/Magpie/Resources.language-en-US.resw
+++ b/src/Magpie/Resources.language-en-US.resw
@@ -168,6 +168,12 @@
   <data name="Profile_AI_RenderSize.Header" xml:space="preserve">
     <value>Render at lower resolution first</value>
   </data>
+  <data name="Profile_AI_RuntimeMissing.Message" xml:space="preserve">
+    <value>Download it in Settings, then restart Magpie. These options stay unavailable until then.</value>
+  </data>
+  <data name="Profile_AI_RuntimeMissing.Title" xml:space="preserve">
+    <value>AI upscaling needs its runtime.</value>
+  </data>
   <data name="Profile_AI_Scale.Description" xml:space="preserve">
     <value>Must match the model's real factor. Set automatically when you pick a model.</value>
   </data>
@@ -179,6 +185,45 @@
   </data>
   <data name="Profile_AI_StaticEngine.Header" xml:space="preserve">
     <value>Static AI engine (TensorRT)</value>
+  </data>
+  <data name="Settings_AI.Header" xml:space="preserve">
+    <value>AI upscaling</value>
+  </data>
+  <data name="Settings_AI_Models.Description" xml:space="preserve">
+    <value>ONNX models are not bundled - put your own in the models folder and they appear in every profile's model list. OpenModelDB is a good place to find them. Check each model's own licence before using it.</value>
+  </data>
+  <data name="Settings_AI_Models.Header" xml:space="preserve">
+    <value>AI upscaling models</value>
+  </data>
+  <data name="Settings_AI_Models_BrowseLink.Content" xml:space="preserve">
+    <value>Browse OpenModelDB</value>
+  </data>
+  <data name="Settings_AI_Models_OpenFolderButton.Content" xml:space="preserve">
+    <value>Open models folder</value>
+  </data>
+  <data name="Settings_AI_Runtime.Description" xml:space="preserve">
+    <value>The ONNX Runtime, TensorRT, CUDA and DirectML libraries that AI upscaling needs. They are about 1 GB to download and 2.4 GB on disk, so they are not bundled with Magpie. Everything else works without them.</value>
+  </data>
+  <data name="Settings_AI_Runtime.Header" xml:space="preserve">
+    <value>AI upscaling runtime</value>
+  </data>
+  <data name="Settings_AI_Runtime_CancelButton.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Settings_AI_Runtime_DownloadButton.Content" xml:space="preserve">
+    <value>Download (about 1 GB)</value>
+  </data>
+  <data name="Settings_AI_Runtime_Error.Message" xml:space="preserve">
+    <value>Check your connection and try again. See the log for details.</value>
+  </data>
+  <data name="Settings_AI_Runtime_Error.Title" xml:space="preserve">
+    <value>The runtime could not be installed.</value>
+  </data>
+  <data name="Settings_AI_Runtime_Installed.Text" xml:space="preserve">
+    <value>Installed</value>
+  </data>
+  <data name="Settings_AI_Runtime_RestartRequired.Title" xml:space="preserve">
+    <value>The runtime is installed. Restart Magpie to enable AI upscaling.</value>
   </data>
   <data name="ShortcutDialog_Cancel" xml:space="preserve">
     <value>Cancel</value>

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -8,6 +8,8 @@
 #include "ScalingMode.h"
 #include "ScalingModesService.h"
 #include "ScalingService.h"
+#include "NotifyIconService.h"
+#include "OnnxStatus.h"
 #include "ShortcutService.h"
 #include "ToastService.h"
 #include "TouchHelper.h"
@@ -29,6 +31,13 @@ ScalingService& ScalingService::Get() noexcept {
 ScalingService::~ScalingService() {}
 
 void ScalingService::Initialize() {
+	// 把 Magpie.Core 的状态接到托盘气球上
+	// Wire Magpie.Core's status reports to tray balloons, so a multi-minute
+	// engine build or a broken model says so instead of looking like a hang.
+	OnnxStatus::Callback = [](std::wstring title, std::wstring text) {
+		NotifyIconService::Get().ShowBalloon(std::move(title), std::move(text));
+	};
+
 	_scalingRuntime.emplace();
 	_scalingRuntime->StateChanged(
 		std::bind_front(&ScalingService::_ScalingRuntime_StateChanged, this));
@@ -358,6 +367,16 @@ ScalingError ScalingService::_StartScaleImpl(HWND hWnd, const Profile& profile, 
 
 	options.graphicsCardId = profile.graphicsCardId;
 	options.captureMethod = profile.captureMethod;
+	options.onnxModel = profile.onnxModel;
+	options.onnxScale = profile.onnxScale;
+	options.onnxBackend = profile.onnxBackend;
+	options.onnxStaticEngine = profile.onnxStaticEngine;
+	options.onnxDynamicMaxWidth = profile.onnxDynamicMaxWidth;
+	options.onnxDynamicMaxHeight = profile.onnxDynamicMaxHeight;
+	options.onnxRenderWidth = profile.onnxRenderWidth;
+	options.onnxRenderHeight = profile.onnxRenderHeight;
+	options.onnxDynamicMinWidth = profile.onnxDynamicMinWidth;
+	options.onnxDynamicMinHeight = profile.onnxDynamicMinHeight;
 	if (profile.isFrameRateLimiterEnabled) {
 		options.maxFrameRate = profile.maxFrameRate;
 	}

--- a/src/Magpie/SettingsPage.xaml
+++ b/src/Magpie/SettingsPage.xaml
@@ -79,6 +79,63 @@
 					              IsOn="{x:Bind ViewModel.IsAlwaysRunAsAdmin, Mode=TwoWay}" />
 				</local:SettingsCard>
 			</local:SettingsGroup>
+			<local:SettingsGroup x:Uid="Settings_AI"
+			                     Visibility="{x:Bind ViewModel.IsOnnxRuntimeSupported, Mode=OneTime}">
+				<local:SettingsCard x:Uid="Settings_AI_Runtime"
+				                    IsWrapEnabled="True">
+					<local:SettingsCard.HeaderIcon>
+						<FontIcon Glyph="&#xE896;" />
+					</local:SettingsCard.HeaderIcon>
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        VerticalAlignment="Center"
+					                        Spacing="8">
+						<muxc:ProgressRing IsActive="{x:Bind ViewModel.IsOnnxRuntimeBusy, Mode=OneWay}"
+						                   IsIndeterminate="{x:Bind ViewModel.IsOnnxRuntimeProgressIndeterminate, Mode=OneWay}"
+						                   Value="{x:Bind ViewModel.OnnxRuntimeDownloadProgress, Mode=OneWay}"
+						                   Visibility="{x:Bind ViewModel.IsOnnxRuntimeBusy, Mode=OneWay}"
+						                   Width="24"
+						                   Height="24" />
+						<Button x:Uid="Settings_AI_Runtime_CancelButton"
+						        Click="{x:Bind ViewModel.CancelOnnxRuntimeDownload}"
+						        Visibility="{x:Bind ViewModel.IsOnnxRuntimeBusy, Mode=OneWay}" />
+						<TextBlock x:Uid="Settings_AI_Runtime_Installed"
+						           VerticalAlignment="Center"
+						           Visibility="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneWay}" />
+						<Button x:Uid="Settings_AI_Runtime_DownloadButton"
+						        Style="{StaticResource AccentButtonStyle}"
+						        Click="{x:Bind ViewModel.DownloadOnnxRuntime}"
+						        Visibility="{x:Bind ViewModel.IsOnnxRuntimeInstalled, Mode=OneWay, Converter={StaticResource NegativeVisibilityConverter}}" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
+				<muxc:InfoBar x:Uid="Settings_AI_Runtime_RestartRequired"
+				              IsClosable="False"
+				              IsOpen="{x:Bind ViewModel.IsOnnxRuntimeRestartRequired, Mode=OneWay}"
+				              Severity="Success">
+					<muxc:InfoBar.ActionButton>
+						<Button x:Uid="Settings_General_RequireRestart_ActionButton"
+						        HorizontalAlignment="Right"
+						        Click="{x:Bind ViewModel.Restart}" />
+					</muxc:InfoBar.ActionButton>
+				</muxc:InfoBar>
+				<muxc:InfoBar x:Uid="Settings_AI_Runtime_Error"
+				              IsClosable="False"
+				              IsOpen="{x:Bind ViewModel.IsOnnxRuntimeError, Mode=OneWay}"
+				              Severity="Error" />
+				<local:SettingsCard x:Uid="Settings_AI_Models"
+				                    IsWrapEnabled="True">
+					<local:SettingsCard.HeaderIcon>
+						<FontIcon Glyph="&#xE8B7;" />
+					</local:SettingsCard.HeaderIcon>
+					<local:SimpleStackPanel Orientation="Horizontal"
+					                        VerticalAlignment="Center"
+					                        Spacing="8">
+						<HyperlinkButton x:Uid="Settings_AI_Models_BrowseLink"
+						                 NavigateUri="https://openmodeldb.info/" />
+						<Button x:Uid="Settings_AI_Models_OpenFolderButton"
+						        Click="{x:Bind ViewModel.OpenModelsLocation}" />
+					</local:SimpleStackPanel>
+				</local:SettingsCard>
+			</local:SettingsGroup>
 		</local:SimpleStackPanel>
 	</local:PageFrame>
 </Page>

--- a/src/Magpie/SettingsViewModel.cpp
+++ b/src/Magpie/SettingsViewModel.cpp
@@ -8,11 +8,99 @@
 #include "AutoStartHelper.h"
 #include "CommonSharedConstants.h"
 #include "LocalizationService.h"
+#include "OnnxRuntimeService.h"
 #include "Win32Helper.h"
+// WIN32_LEAN_AND_MEAN 排除了 shellapi.h / excluded by WIN32_LEAN_AND_MEAN
+#include <shellapi.h>
 
 using namespace Magpie;
 
 namespace winrt::Magpie::implementation {
+
+SettingsViewModel::SettingsViewModel() {
+	OnnxRuntimeService& service = OnnxRuntimeService::Get();
+
+	_onnxStatusChangedRevoker = service.StatusChanged(
+		auto_revoke,
+		std::bind_front(&SettingsViewModel::_OnnxRuntimeService_StatusChanged, this)
+	);
+	_onnxDownloadProgressChangedRevoker = service.DownloadProgressChanged(
+		auto_revoke,
+		std::bind_front(&SettingsViewModel::_OnnxRuntimeService_DownloadProgressChanged, this)
+	);
+}
+
+void SettingsViewModel::_OnnxRuntimeService_StatusChanged(OnnxRuntimeStatus status) {
+	if (status == OnnxRuntimeStatus::Installed) {
+		_onnxRestartRequired = true;
+		RaisePropertyChanged(L"IsOnnxRuntimeRestartRequired");
+	}
+
+	RaisePropertyChanged(L"IsOnnxRuntimeInstalled");
+	RaisePropertyChanged(L"IsOnnxRuntimeBusy");
+	RaisePropertyChanged(L"IsOnnxRuntimeError");
+	RaisePropertyChanged(L"IsOnnxRuntimeProgressIndeterminate");
+}
+
+void SettingsViewModel::_OnnxRuntimeService_DownloadProgressChanged(double /*progress*/) {
+	RaisePropertyChanged(L"OnnxRuntimeDownloadProgress");
+}
+
+bool SettingsViewModel::IsOnnxRuntimeSupported() const noexcept {
+#ifdef MAGPIE_ONNX_ENABLED
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool SettingsViewModel::IsOnnxRuntimeInstalled() const noexcept {
+	return OnnxRuntimeService::Get().IsInstalled();
+}
+
+bool SettingsViewModel::IsOnnxRuntimeBusy() const noexcept {
+	const OnnxRuntimeStatus status = OnnxRuntimeService::Get().Status();
+	return status == OnnxRuntimeStatus::Downloading ||
+		status == OnnxRuntimeStatus::Extracting;
+}
+
+bool SettingsViewModel::IsOnnxRuntimeError() const noexcept {
+	return OnnxRuntimeService::Get().Status() == OnnxRuntimeStatus::Error;
+}
+
+bool SettingsViewModel::IsOnnxRuntimeRestartRequired() const noexcept {
+	return _onnxRestartRequired;
+}
+
+double SettingsViewModel::OnnxRuntimeDownloadProgress() const noexcept {
+	return OnnxRuntimeService::Get().DownloadProgress() * 100;
+}
+
+bool SettingsViewModel::IsOnnxRuntimeProgressIndeterminate() const noexcept {
+	// 解压阶段没有进度可报
+	// Extraction reports no progress, so the bar spins instead of lying.
+	return OnnxRuntimeService::Get().Status() == OnnxRuntimeStatus::Extracting;
+}
+
+void SettingsViewModel::DownloadOnnxRuntime() {
+	OnnxRuntimeService::Get().DownloadAndInstall();
+	RaisePropertyChanged(L"IsOnnxRuntimeBusy");
+}
+
+void SettingsViewModel::CancelOnnxRuntimeDownload() {
+	OnnxRuntimeService::Get().Cancel();
+}
+
+fire_and_forget SettingsViewModel::OpenModelsLocation() const noexcept {
+	// 目录可能还不存在，先建出来，否则资源管理器会报错
+	// The folder may not exist yet; create it first or Explorer just errors.
+	const std::wstring modelsDir =
+		(Win32Helper::GetExePath().parent_path() / L"models").wstring();
+	Win32Helper::CreateDir(modelsDir, true);
+
+	co_await resume_background();
+	ShellExecute(nullptr, L"open", modelsDir.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+}
 
 IVector<IInspectable> SettingsViewModel::Languages() const {
 	std::span<const wchar_t*> tags = LocalizationService::Get().SupportedLanguages();

--- a/src/Magpie/SettingsViewModel.h
+++ b/src/Magpie/SettingsViewModel.h
@@ -1,10 +1,13 @@
 #pragma once
 #include "SettingsViewModel.g.h"
+#include "OnnxRuntimeService.h"
 
 namespace winrt::Magpie::implementation {
 
 struct SettingsViewModel : SettingsViewModelT<SettingsViewModel>,
                            wil::notify_property_changed_base<SettingsViewModel> {
+	SettingsViewModel();
+
 	IVector<IInspectable> Languages() const;
 
 	int Language() const noexcept;
@@ -31,6 +34,29 @@ struct SettingsViewModel : SettingsViewModelT<SettingsViewModel>,
 
 	bool IsAlwaysRunAsAdmin() const noexcept;
 	void IsAlwaysRunAsAdmin(bool value);
+
+	bool IsOnnxRuntimeSupported() const noexcept;
+	bool IsOnnxRuntimeInstalled() const noexcept;
+	bool IsOnnxRuntimeBusy() const noexcept;
+	bool IsOnnxRuntimeError() const noexcept;
+	bool IsOnnxRuntimeRestartRequired() const noexcept;
+	double OnnxRuntimeDownloadProgress() const noexcept;
+	bool IsOnnxRuntimeProgressIndeterminate() const noexcept;
+	void DownloadOnnxRuntime();
+	void CancelOnnxRuntimeDownload();
+	fire_and_forget OpenModelsLocation() const noexcept;
+
+private:
+	void _OnnxRuntimeService_StatusChanged(::Magpie::OnnxRuntimeStatus status);
+	void _OnnxRuntimeService_DownloadProgressChanged(double progress);
+
+	::Magpie::Event<::Magpie::OnnxRuntimeStatus>::EventRevoker _onnxStatusChangedRevoker;
+	::Magpie::Event<double>::EventRevoker _onnxDownloadProgressChangedRevoker;
+
+	// 安装完成后必须重启：运行时是在 main 里固定的
+	// Set once an install completes - the runtime is pinned in main(), so it
+	// cannot be picked up until the next launch.
+	bool _onnxRestartRequired = false;
 };
 
 }

--- a/src/Magpie/SettingsViewModel.idl
+++ b/src/Magpie/SettingsViewModel.idl
@@ -13,5 +13,16 @@ namespace Magpie {
 
 		Boolean IsProcessElevated { get; };
 		Boolean IsAlwaysRunAsAdmin;
+
+		Boolean IsOnnxRuntimeSupported { get; };
+		Boolean IsOnnxRuntimeInstalled { get; };
+		Boolean IsOnnxRuntimeBusy { get; };
+		Boolean IsOnnxRuntimeError { get; };
+		Boolean IsOnnxRuntimeRestartRequired { get; };
+		Double OnnxRuntimeDownloadProgress { get; };
+		Boolean IsOnnxRuntimeProgressIndeterminate { get; };
+		void DownloadOnnxRuntime();
+		void CancelOnnxRuntimeDownload();
+		void OpenModelsLocation();
 	}
 }

--- a/src/Magpie/main.cpp
+++ b/src/Magpie/main.cpp
@@ -15,6 +15,8 @@
 
 
 #include "pch.h"
+#include "OnnxStatus.h"
+#include "StrHelper.h"
 #include "App.h"
 #include "Win32Helper.h"
 #include "TouchHelper.h"
@@ -28,6 +30,57 @@ using namespace winrt::Magpie::implementation;
 static void SetWorkingDir() noexcept {
 	FAIL_FAST_IF_WIN32_BOOL_FALSE(SetCurrentDirectory(
 		Win32Helper::GetExePath().parent_path().c_str()));
+}
+
+// 固定 third_party 中的运行库，必须在使用 ORT 之前、日志初始化之后调用
+// Pin the runtimes shipped in third_party\. Must run before anything touches
+// ONNX Runtime, and after the logger exists so failures can be reported.
+//
+// Windows ships its own ONNX Runtime in System32, and
+// SetDefaultDllDirectories searches System32 before any AddDllDirectory
+// path - so an unqualified load binds the OS copy. Built against newer
+// headers, GetApi(ORT_API_VERSION) then returns nullptr and the first Ort
+// call dereferences it. Loading by absolute path pins ours; later
+// resolutions of the same name reuse the loaded module.
+//
+// This matters only since v0.12: onnxruntime.lib used to link into
+// Magpie.App.dll, which loaded after the search path was extended.
+static void PinThirdPartyRuntimes() noexcept {
+	const std::filesystem::path exeDir = Win32Helper::GetExePath().parent_path();
+	const std::wstring thirdPartyDir = (exeDir / L"third_party").wstring();
+
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	AddDllDirectory(thirdPartyDir.c_str());
+
+	bool ortLoaded = false;
+	for (const wchar_t* dllName : { L"onnxruntime.dll", L"DirectML.dll" }) {
+		const std::wstring dllPath = thirdPartyDir + L"\\" + dllName;
+		if (LoadLibraryEx(dllPath.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+			LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR)) {
+			if (dllName == L"onnxruntime.dll"sv) {
+				ortLoaded = true;
+			}
+		} else {
+			// 不致命：没有 ONNX 时缩放仍可工作
+			// Not fatal - scaling still works without ONNX.
+			Logger::Get().Win32Error(StrHelper::Concat(
+				"加载失败 / failed to preload ", StrHelper::UTF16ToUTF8(dllPath)));
+		}
+	}
+
+	// ORT_API_MANUAL_INIT 关掉了头文件里 main 之前的静态初始化，
+	// 现在才绑定 API 表，确保来自我们刚固定的 DLL
+	// ORT_API_MANUAL_INIT disabled the header's pre-main static init; bind the
+	// API table now so it comes from the DLL just pinned.
+	if (ortLoaded) {
+		OnnxStatus::InitOrtApi();
+	} else {
+		// 绝不能在这里碰 Ort：延迟加载会在加载器内部抛出
+		// Never touch Ort here - the delay-load would raise inside the loader.
+		Logger::Get().Error(
+			"third_party\\onnxruntime.dll 缺失，已禁用 AI 放大 / missing, AI "
+			"upscaling disabled for this session");
+	}
 }
 
 static void InitializeLogger(const wchar_t* logFilePath) noexcept {
@@ -72,6 +125,8 @@ int APIENTRY wWinMain(
 	InitializeLogger(mode == Normal ?
 		CommonSharedConstants::LOG_PATH :
 		CommonSharedConstants::REGISTER_TOUCH_HELPER_LOG_PATH);
+
+	PinThirdPartyRuntimes();
 
 	Logger::Get().Info(fmt::format("程序启动\n\t版本: {}\n\tOS 版本: {}\n\t管理员: {}",
 #ifdef MP_VERSION_STRING

--- a/src/Magpie/main.cpp
+++ b/src/Magpie/main.cpp
@@ -46,6 +46,10 @@ static void SetWorkingDir() noexcept {
 // This matters only since v0.12: onnxruntime.lib used to link into
 // Magpie.App.dll, which loaded after the search path was extended.
 static void PinThirdPartyRuntimes() noexcept {
+#ifndef MAGPIE_ONNX_ENABLED
+	// ONNX 只在 x64 上编译 / the feature is compiled out on other platforms
+	return;
+#else
 	const std::filesystem::path exeDir = Win32Helper::GetExePath().parent_path();
 	const std::wstring thirdPartyDir = (exeDir / L"third_party").wstring();
 
@@ -81,6 +85,7 @@ static void PinThirdPartyRuntimes() noexcept {
 			"third_party\\onnxruntime.dll 缺失，已禁用 AI 放大 / missing, AI "
 			"upscaling disabled for this session");
 	}
+#endif
 }
 
 static void InitializeLogger(const wchar_t* logFilePath) noexcept {


### PR DESCRIPTION

<img width="1775" height="1432" alt="image" src="https://github.com/user-attachments/assets/f0e2319b-860e-476c-834d-6bac16e0d1e1" />

<img width="2146" height="1509" alt="image" src="https://github.com/user-attachments/assets/df4bc961-7f07-44bd-8b60-952769412383" />

<img width="2146" height="1509" alt="image" src="https://github.com/user-attachments/assets/a3ee7850-224e-4945-b399-e45cb214f8a5" />

<img width="1691" height="1194" alt="image" src="https://github.com/user-attachments/assets/4c250128-f3f7-4141-b9e2-a7ee09391fd0" />


This brings the [`onnx-preview2`](https://github.com/Blinue/Magpie/releases/tag/onnx-preview2) work forward onto the current `dev` tree, and adds the pieces that turned out to be necessary to actually use it day to day on a desktop.

I ran this for a while on an RTX 5080 across a range of ONNX models (Real-ESRGAN, Real-CUGAN, AnimeJaNai, various compact/span models). Everything below came out of that, in roughly the order the problems showed up. Happy to split this into smaller PRs, drop any part of it, or rework anything that cuts against how you want this to land — the preview is your design and I've tried not to fight it.

---

## 1. Port to `dev`

The preview branch is based on v0.11.2 and doesn't apply to `dev` as-is:

| Upstream change | What it needed |
| --- | --- |
| `StrUtils` → `StrHelper`, `Win32Utils` → `Win32Helper` | mechanical renames across the ONNX sources |
| `namespace Magpie::Core` flattened to `Magpie` | namespace fixes |
| `Utils::HashData` removed | new self-contained `HashHelper` (FNV-1a) — the engine cache key needs a stable hash |
| `OnnxHelper::GetTextureSize` dropped | restored |
| `Magpie.sln` → `Magpie.slnx`, new publish script | project/CI updates |

The model runs before the first effect. It's initialised from **both** `_BuildEffects` and `_ResizeEffects`, so it survives a resize — which meant `OnnxEffectDrawer::Initialize` had to become idempotent (it now releases everything it owns at the top).

## 2. In-app configuration

Previously the model was picked up from config with no UI. Everything is now on `ProfilePage` in its own `Profile_AI` group, which means it comes with per-game profiles **and** a global default for free, since both are rendered by the same page:


Strings go through `x:Uid` against `Resources.language-en-US.resw` like the rest of the page. Only en-US is added here — the other 19 languages come through Weblate. `DirectML` and `TensorRT` stay hardcoded as product names.

New `ScalingOptions` / `Profile` fields, plumbed through `AppSettings` (read + write), `ScalingService`, and `ProfileViewModel`:

```cpp
std::wstring onnxModel;              // relative to the working dir; empty disables ONNX
uint32_t onnxScale = 2;              // must match the model's real factor
uint32_t onnxBackend = 0;            // 0 = DirectML, 1 = TensorRT
uint32_t onnxStaticEngine = 0;       // 1 = min == opt == max
uint32_t onnxDynamicMinWidth = 0;    // dynamic profile bounds, 0 = auto
uint32_t onnxDynamicMinHeight = 0;
uint32_t onnxDynamicMaxWidth = 0;
uint32_t onnxDynamicMaxHeight = 0;
uint32_t onnxRenderWidth = 0;        // pre-downscale target, 0 = off
uint32_t onnxRenderHeight = 0;
```

`CONFIG_VERSION` is deliberately not bumped: every field has a default and `JsonHelper::Read*` leaves the target untouched when the key is absent, so old config files load unchanged and downgrade cleanly.

## 3. TensorRT engine profiles

**Anything above 1080p rendered black.** The optimisation profile's maximum was hardcoded:

```cpp
maxShapes(1920, 1080)
```

TensorRT silently produces nothing for input outside the profile, so a 1440p window was a black screen with no error.

My first fix built an engine per exact window size, which is much worse — a cold TensorRT build is minutes, and you'd pay it again for every pixel of window resize. What's here now uses the fact that a profile is a *range*: an engine built for 1440p already serves every smaller window.

```cpp
static constexpr uint32_t TIERS[][2] = {
    {1280, 720}, {1920, 1080}, {2560, 1440}, {3200, 1800},
    {3840, 2160}, {5120, 2880}, {7680, 4320}
};
```

Round the input up to the next tier; then scan the cache for an *already-built* engine for this model that's bigger still, and reuse its dimensions so it's a cache hit instead of a rebuild. A user-supplied max overrides the ladder.

**Cache naming.** Engine directories are now `<model-stem>_<W>x<H>_<hash>` instead of a bare hash, so:

- switching models no longer discards the other model's engines
- you can see what's on disk and delete one model's engines specifically
- the hash still covers model bytes, shapes, ORT/TRT versions and GPU, so it invalidates correctly

**Static engines** (`min == opt == max`) are available for a fixed window size, which builds faster and runs slightly faster at the cost of being size-specific.

## 4. Pre-downscale, and why fullscreen needed it

Magpie captures a fullscreen window at native resolution. Feeding 4K into a 2× model to display at 4K does a lot of work for no visible gain, and is far too slow to be usable.

`DownscaleCS.hlsl` is an optional bilinear pass that resamples *before* inference — set the model to run at 1440p or 1080p and let the existing effect chain scale the result back to the display. That's what makes fullscreen and maximised windows worth upscaling at all.

## 5. Real-CUGAN

CUGAN is documented as unsupported, and its shape signature passes `IsTensorShapeValid`, so the failure wasn't obvious. Probing it with shape inference across input sizes showed the actual constraint: **it only produces an exact integer scale when the input dimensions are aligned.** Arbitrary window sizes silently come out as a non-integer multiple.

Since the pre-downscale pass already resamples into an intermediate texture at a size we choose, aligning is free:

```cpp
constexpr uint32_t ONNX_INPUT_ALIGN = 4;
dstWidth  = std::max(ONNX_INPUT_ALIGN, dstWidth  / ONNX_INPUT_ALIGN * ONNX_INPUT_ALIGN);
dstHeight = std::max(ONNX_INPUT_ALIGN, dstHeight / ONNX_INPUT_ALIGN * ONNX_INPUT_ALIGN);
```

At most 3px is trimmed and the chain rescales to the display anyway, so it's invisible. CUGAN models work with this.

## 6. The crash — ONNX Runtime in System32

This one took the longest, so the detail may be worth having.

Scaling crashed with an access violation. The cause: **`C:\Windows\System32\onnxruntime.dll` was present (1.17, from Windows ML), and `System32` precedes anything added via `AddDllDirectory` in the search order.** The process bound to 1.17 rather than the bundled runtime and jumped into the wrong ABI.

It needed all three of these — any two alone still crashed:

1. **Delay-load** `onnxruntime.dll` (plus `cudart64_12.dll`, `DirectML.dll`), so the loader doesn't resolve it before we get control.
2. **`LoadLibraryEx` the bundled copy by absolute path** from `third_party\`, before anything touches ORT.
3. **`ORT_API_MANUAL_INIT`** + an explicit `Ort::InitApi()`. Without it the ORT headers' static initialiser runs *before* `main`, i.e. before step 2 can possibly have happened.

```cpp
static void PinThirdPartyRuntimes() noexcept {
    const std::filesystem::path exeDir = Win32Helper::GetExePath().parent_path();
    const std::wstring thirdPartyDir = (exeDir / L"third_party").wstring();
    SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
    AddDllDirectory(thirdPartyDir.c_str());
    // ... LoadLibraryEx each DLL by absolute path ...
    if (ortLoaded) { OnnxStatus::InitOrtApi(); }
}
```

Ordering in `wWinMain` matters and is easy to get wrong: `SetWorkingDir()` → `InitializeLogger()` → `PinThirdPartyRuntimes()`. Pinning has to come after the logger or its diagnostics go nowhere.

Delay-loading has a side effect worth flagging: a *missing* `onnxruntime.dll` becomes a hard failure at first use. `OnnxStatus::IsOrtAvailable` guards every entry point so a build without the ONNX runtime present just skips the model.

> While debugging this I asserted at one point that the crash reproduced with ONNX disabled. That was wrong — a second Magpie instance was stealing the scale via single-instance handoff, and separately `spdlog`'s `flush_on(warn)` meant my `Info`-level traces never reached disk. Both conclusions had to be redone at error level.

## 7. Not dying on failure

Every ONNX failure path previously took down the scaling session, and several left the app needing a restart:

- **DirectML EP null-deref** — `GetExecutionProviderApi("DML", ...)`'s status was discarded and the returned pointer used unconditionally. If the EP isn't present that's an immediate crash.
- **Session/engine build failure** now releases everything and returns success, so scaling continues without the model rather than aborting.
- **Inference failure** latches (`_OnEvaluateFailed`), drains `cudaGetLastError()` and reports once, instead of repeating the same GPU error every frame.

## 8. Status reporting

A cold TensorRT engine build takes minutes with no visible sign of progress — indistinguishable from a hang unless you open the log. `OnnxStatus` is a small hook in `Magpie.Core` that `src/Magpie` wires to tray balloons:

```cpp
OnnxStatus::Callback = [](std::wstring title, std::wstring text) {
    NotifyIconService::Get().ShowBalloon(std::move(title), std::move(text));
};
```

Reports engine builds starting/finishing, missing or invalid models, unavailable backends, and inference failures. It's deliberately a `std::function` in a public header so `Magpie.Core` keeps no dependency on the UI layer.

---

## 9. Getting the runtime, from inside the app

The runtime is ~1 GB compressed and 2.4 GB unpacked, so it cannot ship with Magpie. Left there, the feature is effectively invisible: it only works if you already know to assemble `third_party\` by hand out of two separate release assets.

So Settings gains an **AI upscaling** group:

| | |
| --- | --- |
| **AI upscaling runtime** | Download button with progress and cancel, then a restart prompt — the runtime is pinned in `main()`, so a fresh install cannot take effect until the next launch |
| **AI upscaling models** | Links to OpenModelDB and opens the `models\` folder |

The files come from the `onnx-preview2` release assets, so **nothing is redistributed a second time**. They turn out to be split across two of them: `onnxruntime.dll` and `DirectML.dll` sit under `third_party\` in the main package, while the large TensorRT/CUDA libraries are in `ext-tensorrt-x64.7z`. Fetching only the latter yields 2.3 GB of DLLs with the two the loader actually pins still missing — which is exactly what happened the first time I tested it.

**No new dependency for extraction.** The in-box `tar.exe` is bsdtar/libarchive with liblzma: it reads 7z natively, and `--strip-components=1` selects the nested directory straight out of the zip, so one code path handles both archives.

A package already on disk is skipped, keyed on a probe file, so retrying after a partial install fetches only what is missing rather than the full gigabyte again.

**No models are bundled.** Licences differ per model and several popular community ones (CC-BY-NC / CC-BY-NC-SA) prohibit redistribution outright, so the card points at OpenModelDB where each model's terms are stated. If you'd want a permissively-licensed default set bundled — the Real-ESRGAN family is BSD-3-Clause — that's your call to make, not one I wanted to make for you.

On the profile page the AI settings are disabled while the runtime is absent, with an InfoBar pointing at Settings, so they read as unavailable rather than broken.

## Build and CI

`src/Common.Post.props` takes the SDK locations from overridable properties instead of hardcoded paths, so a local checkout and CI can each point at their own layout:

```
OrtDir / OrtIncludeDir / OrtLibDir   TrtDir   CudaDir   DmlDir
```

The workflow keeps the existing matrix and the signing step untouched; the SDK steps are gated on `matrix.platform == 'x64'`. **All four jobs pass** — MSVC and ClangCL, x64 and ARM64.

Provisioning needs **no NVIDIA login**: nothing links `nvinfer`, so TensorRT's open-source headers are enough. Two details there are easy to get wrong — the DirectML NuGet ships x86/ARM64 alongside x64, and picking the first `onnxruntime.lib` match leaves every ORT symbol (`OrtGetApiBase`) unresolved; and the GPU prebuilt has neither the DirectML EP header nor its export, so the header comes from the ORT source tree and the import lib from the NuGet package.

## Known limitations

- **x64 only, by construction.** TensorRT and the CUDA runtime have no Windows ARM64 build. `MAGPIE_ONNX_ENABLED` is defined for x64 only; elsewhere the ONNX translation units and shaders drop out and `OnnxEffectDrawer` is an inert inline stub, so `Renderer` and `ScalingService` need no conditional compilation and ARM64 builds exactly as it does today. If ARM64 should get DirectML-only support later, that's the seam to widen.
- **Scale is set by hand and must match the model.** A wrong value gives a broken image with no diagnostic. It should be read from the ONNX graph via shape inference when the model is selected — I skipped it because it needs a model parser on the UI thread, but it's the next thing I'd fix. (Filename heuristics don't work: `realesr-animevideov3` is x4 with nothing in the name to say so.)
- **Interop is not the bottleneck.** I instrumented the D3D11↔CUDA path expecting to find cost there; it's ~0.11 ms against ~35.7 ms of inference (~0.3%). Worth recording so nobody else optimises it — the model is the cost, so pre-downscale is the lever that matters.
- **The model isn't reported to `EffectsProfiler`.** `OnnxEffectDrawer::Draw` takes the profiler and ignores it, so the in-app timings omit the single most expensive pass — inference dwarfs every effect in the chain. It should get its own entry; I left it out rather than guess at how you'd want a non-`EffectDrawer` pass represented there.
- Model discovery is a flat scan of `models\`; no metadata, no grouping.

## Testing

Windows 11 26200, RTX 5080, ONNX Runtime 1.21, TensorRT 10.8, CUDA 12.8.

- 26 models checked against `IsTensorShapeValid`; Real-ESRGAN, Real-CUGAN, AnimeJaNai and several compact/span models run end to end on both backends
- static and dynamic engines, including cache reuse across restarts and across switching models
- windowed, maximised and fullscreen; resize during scaling
- switching models and profiles at runtime, confirmed from the log that the new engine is the one loaded
- recovery paths: missing `onnxruntime.dll`, a scale that doesn't match the model, engine build failure, inference failure mid-scale


