### PR TITLE
提高保存配置文件的可靠性

### DIFF
--- a/src/Magpie.Core/Win32Helper.cpp
+++ b/src/Magpie.Core/Win32Helper.cpp
@@ -307,7 +307,7 @@ bool Win32Helper::ReadFile(const wchar_t* fileName, std::vector<uint8_t>& result
 
 	wil::unique_hfile hFile(CreateFile2(fileName, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, &extendedParams));
 	if (!hFile) {
-		Logger::Get().Error("打开文件失败");
+		Logger::Get().Win32Error("CreateFile2 失败");
 		return false;
 	}
 
@@ -316,7 +316,7 @@ bool Win32Helper::ReadFile(const wchar_t* fileName, std::vector<uint8_t>& result
 
 	DWORD readed;
 	if (!::ReadFile(hFile.get(), result.data(), size, &readed, nullptr)) {
-		Logger::Get().Error("读取文件失败");
+		Logger::Get().Win32Error("ReadFile 失败");
 		return false;
 	}
 
@@ -333,14 +333,14 @@ bool Win32Helper::WriteFile(const wchar_t* fileName, std::span<uint8_t> buffer) 
 
 	wil::unique_hfile hFile(CreateFile2(fileName, GENERIC_WRITE, 0, CREATE_ALWAYS, &extendedParams));
 	if (!hFile) {
-		Logger::Get().Error("打开文件失败");
+		Logger::Get().Win32Error("CreateFile2 失败");
 		return false;
 	}
 
 	DWORD written;
 	if (!::WriteFile(hFile.get(), buffer.data(), (DWORD)buffer.size(), &written, nullptr)
-		|| buffer.size() != written) {
-		Logger::Get().Error("写入文件失败");
+		|| written < buffer.size()) {
+		Logger::Get().Win32Error("WriteFile 失败");
 		return false;
 	}
 
@@ -378,7 +378,11 @@ bool Win32Helper::WriteTextFile(const wchar_t* fileName, std::string_view text) 
 		return false;
 	}
 
-	fwrite(text.data(), 1, text.size(), hFile.get());
+	if (fwrite(text.data(), 1, text.size(), hFile.get()) < text.size()) {
+		Logger::Get().Error("fwrite 失败");
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/Magpie/App.cpp
+++ b/src/Magpie/App.cpp
@@ -280,7 +280,7 @@ INumberFormatter2 App::DoubleFormatter() {
 	return numberFormatter;
 }
 
-void App::_Uninitialize() {
+void App::_Uninitialize() noexcept {
 	NotifyIconService::Get().Uninitialize();
 	UpdateService::Get().Uninitialize();
 	ScalingService::Get().Uninitialize();
@@ -289,6 +289,7 @@ void App::_Uninitialize() {
 	AdaptersService::Get().Uninitialize();
 	ToastService::Get().Uninitialize();
 	EffectsService::Get().Uninitialize();
+	AppSettings::Get().Uninitialize();
 
 	_colorValuesChangedRevoker.revoke();
 	_isShowNotifyIconChangedRevoker.Revoke();

--- a/src/Magpie/App.h
+++ b/src/Magpie/App.h
@@ -54,7 +54,7 @@ public:
 	::Magpie::MultithreadEvent<bool> ThemeChanged;
 
 private:
-	void _Uninitialize();
+	void _Uninitialize() noexcept;
 
 	bool _CheckSingleInstance() noexcept;
 

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -285,6 +285,27 @@ void AppSettings::Uninitialize() noexcept {
 	_isSaving.wait(true, std::memory_order_relaxed);
 }
 
+// 确保写入失败时不会丢失旧配置
+static bool SafeSaveConfig(const std::wstring& configPath, std::string_view json) noexcept {
+	std::wstring newConfigPath = configPath + L".new";
+	if (!Win32Helper::WriteTextFile(newConfigPath.c_str(), json)) {
+		Logger::Get().Error("写入新配置文件失败");
+		return false;
+	}
+
+	if (!DeleteFile(configPath.c_str())) {
+		Logger::Get().Win32Error("DeleteFile 失败");
+		return false;
+	}
+
+	if (!MoveFile(newConfigPath.c_str(), configPath.c_str())) {
+		Logger::Get().Win32Error("MoveFile 失败");
+		return false;
+	}
+
+	return true;
+}
+
 fire_and_forget AppSettings::SaveAsync() noexcept {
 	_UpdateWindowPlacement();
 
@@ -293,127 +314,7 @@ fire_and_forget AppSettings::SaveAsync() noexcept {
 		co_return;
 	}
 
-	rapidjson::StringBuffer json;
-	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json);
-	writer.StartObject();
-
-	writer.Key("language");
-	if (_language < 0) {
-		writer.String("");
-	} else {
-		const wchar_t* language = LocalizationService::SupportedLanguages()[_language];
-		writer.String(StrHelper::UTF16ToUTF8(language).c_str());
-	}
-
-	writer.Key("theme");
-	writer.Uint((uint32_t)_theme);
-
-	writer.Key("windowPos");
-	writer.StartObject();
-	writer.Key("centerX");
-	writer.Double(_mainWindowCenter.X);
-	writer.Key("centerY");
-	writer.Double(_mainWindowCenter.Y);
-	writer.Key("width");
-	writer.Double(_mainWindowSizeInDips.Width);
-	writer.Key("height");
-	writer.Double(_mainWindowSizeInDips.Height);
-	writer.Key("maximized");
-	writer.Bool(_isMainWindowMaximized);
-	writer.EndObject();
-
-	writer.Key("shortcuts");
-	writer.StartObject();
-	writer.Key("scale");
-	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::Scale]));
-	writer.Key("windowedModeScale");
-	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::WindowedModeScale]));
-	writer.Key("toolbar");
-	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::Toolbar]));
-	writer.Key("takeScreenshot");
-	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::TakeScreenshot]));
-	writer.EndObject();
-
-	writer.Key("countdownSeconds");
-	writer.Uint(_countdownSeconds);
-	writer.Key("developerMode");
-	writer.Bool(_isDeveloperMode);
-	writer.Key("debugMode");
-	writer.Bool(_isDebugMode);
-	writer.Key("benchmarkMode");
-	writer.Bool(_isBenchmarkMode);
-	writer.Key("disableTopmost");
-	writer.Bool(_isTopmostDisabled);
-	writer.Key("disableEffectCache");
-	writer.Bool(_isEffectCacheDisabled);
-	writer.Key("disableFontCache");
-	writer.Bool(_isFontCacheDisabled);
-	writer.Key("saveEffectSources");
-	writer.Bool(_isSaveEffectSources);
-	writer.Key("warningsAreErrors");
-	writer.Bool(_isWarningsAreErrors);
-	writer.Key("allowScalingMaximized");
-	writer.Bool(_isAllowScalingMaximized);
-	writer.Key("simulateExclusiveFullscreen");
-	writer.Bool(_isSimulateExclusiveFullscreen);
-	writer.Key("alwaysRunAsAdmin");
-	writer.Bool(_isAlwaysRunAsAdmin);
-	writer.Key("showNotifyIcon");
-	writer.Bool(_isShowNotifyIcon);
-	writer.Key("inlineParams");
-	writer.Bool(_isInlineParams);
-	writer.Key("autoCheckForUpdates");
-	writer.Bool(_isAutoCheckForUpdates);
-	writer.Key("checkForPreviewUpdates");
-	writer.Bool(_isCheckForPreviewUpdates);
-	writer.Key("updateCheckDate");
-	writer.Int64(_updateCheckDate.time_since_epoch().count());
-	writer.Key("duplicateFrameDetectionMode");
-	writer.Uint((uint32_t)_duplicateFrameDetectionMode);
-	writer.Key("enableStatisticsForDynamicDetection");
-	writer.Bool(_isStatisticsForDynamicDetectionEnabled);
-	writer.Key("minFrameRate");
-	writer.Double(_minFrameRate);
-	writer.Key("disableFP16");
-	writer.Bool(_isFP16Disabled);
-
-	ScalingModesService::Get().Export(writer);
-
-	writer.Key("profiles");
-	writer.StartArray();
-	WriteProfile(writer, _defaultProfile);
-	for (const Profile& rule : _profiles) {
-		WriteProfile(writer, rule);
-	}
-	writer.EndArray();
-
-	writer.Key("overlay");
-	writer.StartObject();
-	writer.Key("fullscreenInitialToolbarState");
-	writer.Uint((uint32_t)_fullscreenInitialToolbarState);
-	writer.Key("windowedInitialToolbarState");
-	writer.Uint((uint32_t)_windowedInitialToolbarState);
-	writer.Key("screenshotsDir");
-	writer.String(StrHelper::UTF16ToUTF8(_screenshotsDir.native()).c_str());
-	writer.Key("windows");
-	writer.StartObject();
-	for (const auto& [name, windowOption] : _overlayWindowOptions) {
-		writer.Key(name.c_str());
-		writer.StartObject();
-		writer.Key("hArea");
-		writer.Uint(windowOption.hArea);
-		writer.Key("vArea");
-		writer.Uint(windowOption.vArea);
-		writer.Key("hPos");
-		writer.Double(windowOption.hPos);
-		writer.Key("vPos");
-		writer.Double(windowOption.vPos);
-		writer.EndObject();
-	}
-	writer.EndObject();
-	writer.EndObject();
-
-	writer.EndObject();
+	rapidjson::StringBuffer json = _WriteConfigJson();
 
 	// 等待前一次保存完成以确保配置文件始终是最新的。保存过于频繁时会阻塞主线程，
 	// 但不会发生这种情况。
@@ -423,8 +324,8 @@ fire_and_forget AppSettings::SaveAsync() noexcept {
 
 	co_await resume_background();
 
-	if (!Win32Helper::WriteTextFile(_configPath.c_str(), { json.GetString(), json.GetLength() })) {
-		Logger::Get().Error("保存配置失败");
+	if (!SafeSaveConfig(_configPath.native(), { json.GetString(), json.GetLength() })) {
+		Logger::Get().Error("保存配置文件失败");
 	}
 	
 	_isSaving.store(false, std::memory_order_relaxed);
@@ -676,6 +577,132 @@ void AppSettings::_UpdateWindowPlacement() noexcept {
 	};
 
 	_isMainWindowMaximized = wp.showCmd == SW_MAXIMIZE;
+}
+
+rapidjson::StringBuffer AppSettings::_WriteConfigJson() const noexcept {
+	rapidjson::StringBuffer json;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json);
+	writer.StartObject();
+
+	writer.Key("language");
+	if (_language < 0) {
+		writer.String("");
+	} else {
+		const wchar_t* language = LocalizationService::SupportedLanguages()[_language];
+		writer.String(StrHelper::UTF16ToUTF8(language).c_str());
+	}
+
+	writer.Key("theme");
+	writer.Uint((uint32_t)_theme);
+
+	writer.Key("windowPos");
+	writer.StartObject();
+	writer.Key("centerX");
+	writer.Double(_mainWindowCenter.X);
+	writer.Key("centerY");
+	writer.Double(_mainWindowCenter.Y);
+	writer.Key("width");
+	writer.Double(_mainWindowSizeInDips.Width);
+	writer.Key("height");
+	writer.Double(_mainWindowSizeInDips.Height);
+	writer.Key("maximized");
+	writer.Bool(_isMainWindowMaximized);
+	writer.EndObject();
+
+	writer.Key("shortcuts");
+	writer.StartObject();
+	writer.Key("scale");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::Scale]));
+	writer.Key("windowedModeScale");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::WindowedModeScale]));
+	writer.Key("toolbar");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::Toolbar]));
+	writer.Key("takeScreenshot");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::TakeScreenshot]));
+	writer.EndObject();
+
+	writer.Key("countdownSeconds");
+	writer.Uint(_countdownSeconds);
+	writer.Key("developerMode");
+	writer.Bool(_isDeveloperMode);
+	writer.Key("debugMode");
+	writer.Bool(_isDebugMode);
+	writer.Key("benchmarkMode");
+	writer.Bool(_isBenchmarkMode);
+	writer.Key("disableTopmost");
+	writer.Bool(_isTopmostDisabled);
+	writer.Key("disableEffectCache");
+	writer.Bool(_isEffectCacheDisabled);
+	writer.Key("disableFontCache");
+	writer.Bool(_isFontCacheDisabled);
+	writer.Key("saveEffectSources");
+	writer.Bool(_isSaveEffectSources);
+	writer.Key("warningsAreErrors");
+	writer.Bool(_isWarningsAreErrors);
+	writer.Key("allowScalingMaximized");
+	writer.Bool(_isAllowScalingMaximized);
+	writer.Key("simulateExclusiveFullscreen");
+	writer.Bool(_isSimulateExclusiveFullscreen);
+	writer.Key("alwaysRunAsAdmin");
+	writer.Bool(_isAlwaysRunAsAdmin);
+	writer.Key("showNotifyIcon");
+	writer.Bool(_isShowNotifyIcon);
+	writer.Key("inlineParams");
+	writer.Bool(_isInlineParams);
+	writer.Key("autoCheckForUpdates");
+	writer.Bool(_isAutoCheckForUpdates);
+	writer.Key("checkForPreviewUpdates");
+	writer.Bool(_isCheckForPreviewUpdates);
+	writer.Key("updateCheckDate");
+	writer.Int64(_updateCheckDate.time_since_epoch().count());
+	writer.Key("duplicateFrameDetectionMode");
+	writer.Uint((uint32_t)_duplicateFrameDetectionMode);
+	writer.Key("enableStatisticsForDynamicDetection");
+	writer.Bool(_isStatisticsForDynamicDetectionEnabled);
+	writer.Key("minFrameRate");
+	writer.Double(_minFrameRate);
+	writer.Key("disableFP16");
+	writer.Bool(_isFP16Disabled);
+
+	ScalingModesService::Get().Export(writer);
+
+	writer.Key("profiles");
+	writer.StartArray();
+	WriteProfile(writer, _defaultProfile);
+	for (const Profile& rule : _profiles) {
+		WriteProfile(writer, rule);
+	}
+	writer.EndArray();
+
+	writer.Key("overlay");
+	writer.StartObject();
+	writer.Key("fullscreenInitialToolbarState");
+	writer.Uint((uint32_t)_fullscreenInitialToolbarState);
+	writer.Key("windowedInitialToolbarState");
+	writer.Uint((uint32_t)_windowedInitialToolbarState);
+	writer.Key("screenshotsDir");
+	writer.String(StrHelper::UTF16ToUTF8(_screenshotsDir.native()).c_str());
+	writer.Key("windows");
+	writer.StartObject();
+	for (const auto& [name, windowOption] : _overlayWindowOptions) {
+		writer.Key(name.c_str());
+		writer.StartObject();
+		writer.Key("hArea");
+		writer.Uint(windowOption.hArea);
+		writer.Key("vArea");
+		writer.Uint(windowOption.vArea);
+		writer.Key("hPos");
+		writer.Double(windowOption.hPos);
+		writer.Key("vPos");
+		writer.Double(windowOption.vPos);
+		writer.EndObject();
+	}
+	writer.EndObject();
+	writer.EndObject();
+
+	writer.EndObject();
+
+	return json;
 }
 
 // 永远不会失败，遇到不合法的配置项时静默忽略

--- a/src/Magpie/AppSettings.cpp
+++ b/src/Magpie/AppSettings.cpp
@@ -26,10 +26,6 @@ namespace Magpie {
 // 如果配置文件和已发布的正式版本不再兼容，应提高此版本号
 static constexpr uint32_t CONFIG_VERSION = 4;
 
-_AppSettingsData::_AppSettingsData() {}
-
-_AppSettingsData::~_AppSettingsData() {}
-
 // 将热键存储为 uint32_t
 // 不能存储为字符串，因为某些键的字符相同，如句号和小键盘的点
 static uint32_t EncodeShortcut(const Shortcut& shortcut) noexcept {
@@ -198,6 +194,11 @@ static void ShowErrorMessage(const wchar_t* mainInstruction, const wchar_t* cont
 	TaskDialogIndirect(&tdc, nullptr, nullptr, nullptr);
 }
 
+AppSettings& AppSettings::Get() noexcept {
+	static AppSettings instance;
+	return instance;
+}
+
 AppSettings::~AppSettings() {}
 
 bool AppSettings::Initialize() noexcept {
@@ -279,19 +280,156 @@ bool AppSettings::Initialize() noexcept {
 	return true;
 }
 
-bool AppSettings::Save() noexcept {
-	_UpdateWindowPlacement();
-	return _Save(*this);
+void AppSettings::Uninitialize() noexcept {
+	// 等待后台保存完成
+	_isSaving.wait(true, std::memory_order_relaxed);
 }
 
 fire_and_forget AppSettings::SaveAsync() noexcept {
 	_UpdateWindowPlacement();
 
-	// 拷贝当前配置
-	_AppSettingsData data = *this;
+	if (!Win32Helper::CreateDir(_configDir.native(), true)) {
+		Logger::Get().Win32Error("创建配置文件夹失败");
+		co_return;
+	}
+
+	rapidjson::StringBuffer json;
+	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json);
+	writer.StartObject();
+
+	writer.Key("language");
+	if (_language < 0) {
+		writer.String("");
+	} else {
+		const wchar_t* language = LocalizationService::SupportedLanguages()[_language];
+		writer.String(StrHelper::UTF16ToUTF8(language).c_str());
+	}
+
+	writer.Key("theme");
+	writer.Uint((uint32_t)_theme);
+
+	writer.Key("windowPos");
+	writer.StartObject();
+	writer.Key("centerX");
+	writer.Double(_mainWindowCenter.X);
+	writer.Key("centerY");
+	writer.Double(_mainWindowCenter.Y);
+	writer.Key("width");
+	writer.Double(_mainWindowSizeInDips.Width);
+	writer.Key("height");
+	writer.Double(_mainWindowSizeInDips.Height);
+	writer.Key("maximized");
+	writer.Bool(_isMainWindowMaximized);
+	writer.EndObject();
+
+	writer.Key("shortcuts");
+	writer.StartObject();
+	writer.Key("scale");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::Scale]));
+	writer.Key("windowedModeScale");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::WindowedModeScale]));
+	writer.Key("toolbar");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::Toolbar]));
+	writer.Key("takeScreenshot");
+	writer.Uint(EncodeShortcut(_shortcuts[(size_t)ShortcutAction::TakeScreenshot]));
+	writer.EndObject();
+
+	writer.Key("countdownSeconds");
+	writer.Uint(_countdownSeconds);
+	writer.Key("developerMode");
+	writer.Bool(_isDeveloperMode);
+	writer.Key("debugMode");
+	writer.Bool(_isDebugMode);
+	writer.Key("benchmarkMode");
+	writer.Bool(_isBenchmarkMode);
+	writer.Key("disableTopmost");
+	writer.Bool(_isTopmostDisabled);
+	writer.Key("disableEffectCache");
+	writer.Bool(_isEffectCacheDisabled);
+	writer.Key("disableFontCache");
+	writer.Bool(_isFontCacheDisabled);
+	writer.Key("saveEffectSources");
+	writer.Bool(_isSaveEffectSources);
+	writer.Key("warningsAreErrors");
+	writer.Bool(_isWarningsAreErrors);
+	writer.Key("allowScalingMaximized");
+	writer.Bool(_isAllowScalingMaximized);
+	writer.Key("simulateExclusiveFullscreen");
+	writer.Bool(_isSimulateExclusiveFullscreen);
+	writer.Key("alwaysRunAsAdmin");
+	writer.Bool(_isAlwaysRunAsAdmin);
+	writer.Key("showNotifyIcon");
+	writer.Bool(_isShowNotifyIcon);
+	writer.Key("inlineParams");
+	writer.Bool(_isInlineParams);
+	writer.Key("autoCheckForUpdates");
+	writer.Bool(_isAutoCheckForUpdates);
+	writer.Key("checkForPreviewUpdates");
+	writer.Bool(_isCheckForPreviewUpdates);
+	writer.Key("updateCheckDate");
+	writer.Int64(_updateCheckDate.time_since_epoch().count());
+	writer.Key("duplicateFrameDetectionMode");
+	writer.Uint((uint32_t)_duplicateFrameDetectionMode);
+	writer.Key("enableStatisticsForDynamicDetection");
+	writer.Bool(_isStatisticsForDynamicDetectionEnabled);
+	writer.Key("minFrameRate");
+	writer.Double(_minFrameRate);
+	writer.Key("disableFP16");
+	writer.Bool(_isFP16Disabled);
+
+	ScalingModesService::Get().Export(writer);
+
+	writer.Key("profiles");
+	writer.StartArray();
+	WriteProfile(writer, _defaultProfile);
+	for (const Profile& rule : _profiles) {
+		WriteProfile(writer, rule);
+	}
+	writer.EndArray();
+
+	writer.Key("overlay");
+	writer.StartObject();
+	writer.Key("fullscreenInitialToolbarState");
+	writer.Uint((uint32_t)_fullscreenInitialToolbarState);
+	writer.Key("windowedInitialToolbarState");
+	writer.Uint((uint32_t)_windowedInitialToolbarState);
+	writer.Key("screenshotsDir");
+	writer.String(StrHelper::UTF16ToUTF8(_screenshotsDir.native()).c_str());
+	writer.Key("windows");
+	writer.StartObject();
+	for (const auto& [name, windowOption] : _overlayWindowOptions) {
+		writer.Key(name.c_str());
+		writer.StartObject();
+		writer.Key("hArea");
+		writer.Uint(windowOption.hArea);
+		writer.Key("vArea");
+		writer.Uint(windowOption.vArea);
+		writer.Key("hPos");
+		writer.Double(windowOption.hPos);
+		writer.Key("vPos");
+		writer.Double(windowOption.vPos);
+		writer.EndObject();
+	}
+	writer.EndObject();
+	writer.EndObject();
+
+	writer.EndObject();
+
+	// 等待前一次保存完成以确保配置文件始终是最新的。保存过于频繁时会阻塞主线程，
+	// 但不会发生这种情况。
+	_isSaving.wait(true, std::memory_order_relaxed);
+	// 此时不存在竞争，无需 CAS 循环
+	_isSaving.store(true, std::memory_order_relaxed);
+
 	co_await resume_background();
 
-	_Save(data);
+	if (!Win32Helper::WriteTextFile(_configPath.c_str(), { json.GetString(), json.GetLength() })) {
+		Logger::Get().Error("保存配置失败");
+	}
+	
+	_isSaving.store(false, std::memory_order_relaxed);
+	// 只有主线程会等待
+	_isSaving.notify_one();
 }
 
 void AppSettings::IsPortableMode(bool value) noexcept {
@@ -538,144 +676,6 @@ void AppSettings::_UpdateWindowPlacement() noexcept {
 	};
 
 	_isMainWindowMaximized = wp.showCmd == SW_MAXIMIZE;
-}
-
-bool AppSettings::_Save(const _AppSettingsData& data) noexcept {
-	if (!Win32Helper::CreateDir(data._configDir.native(), true)) {
-		Logger::Get().Win32Error("创建配置文件夹失败");
-		return false;
-	}
-
-	rapidjson::StringBuffer json;
-	rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json);
-	writer.StartObject();
-
-	writer.Key("language");
-	if (_language < 0) {
-		writer.String("");
-	} else {
-		const wchar_t* language = LocalizationService::SupportedLanguages()[_language];
-		writer.String(StrHelper::UTF16ToUTF8(language).c_str());
-	}
-
-	writer.Key("theme");
-	writer.Uint((uint32_t)data._theme);
-
-	writer.Key("windowPos");
-	writer.StartObject();
-	writer.Key("centerX");
-	writer.Double(data._mainWindowCenter.X);
-	writer.Key("centerY");
-	writer.Double(data._mainWindowCenter.Y);
-	writer.Key("width");
-	writer.Double(data._mainWindowSizeInDips.Width);
-	writer.Key("height");
-	writer.Double(data._mainWindowSizeInDips.Height);
-	writer.Key("maximized");
-	writer.Bool(data._isMainWindowMaximized);
-	writer.EndObject();
-
-	writer.Key("shortcuts");
-	writer.StartObject();
-	writer.Key("scale");
-	writer.Uint(EncodeShortcut(data._shortcuts[(size_t)ShortcutAction::Scale]));
-	writer.Key("windowedModeScale");
-	writer.Uint(EncodeShortcut(data._shortcuts[(size_t)ShortcutAction::WindowedModeScale]));
-	writer.Key("toolbar");
-	writer.Uint(EncodeShortcut(data._shortcuts[(size_t)ShortcutAction::Toolbar]));
-	writer.Key("takeScreenshot");
-	writer.Uint(EncodeShortcut(data._shortcuts[(size_t)ShortcutAction::TakeScreenshot]));
-	writer.EndObject();
-
-	writer.Key("countdownSeconds");
-	writer.Uint(data._countdownSeconds);
-	writer.Key("developerMode");
-	writer.Bool(data._isDeveloperMode);
-	writer.Key("debugMode");
-	writer.Bool(data._isDebugMode);
-	writer.Key("benchmarkMode");
-	writer.Bool(data._isBenchmarkMode);
-	writer.Key("disableTopmost");
-	writer.Bool(data._isTopmostDisabled);
-	writer.Key("disableEffectCache");
-	writer.Bool(data._isEffectCacheDisabled);
-	writer.Key("disableFontCache");
-	writer.Bool(data._isFontCacheDisabled);
-	writer.Key("saveEffectSources");
-	writer.Bool(data._isSaveEffectSources);
-	writer.Key("warningsAreErrors");
-	writer.Bool(data._isWarningsAreErrors);
-	writer.Key("allowScalingMaximized");
-	writer.Bool(data._isAllowScalingMaximized);
-	writer.Key("simulateExclusiveFullscreen");
-	writer.Bool(data._isSimulateExclusiveFullscreen);
-	writer.Key("alwaysRunAsAdmin");
-	writer.Bool(data._isAlwaysRunAsAdmin);
-	writer.Key("showNotifyIcon");
-	writer.Bool(data._isShowNotifyIcon);
-	writer.Key("inlineParams");
-	writer.Bool(data._isInlineParams);
-	writer.Key("autoCheckForUpdates");
-	writer.Bool(data._isAutoCheckForUpdates);
-	writer.Key("checkForPreviewUpdates");
-	writer.Bool(data._isCheckForPreviewUpdates);
-	writer.Key("updateCheckDate");
-	writer.Int64(data._updateCheckDate.time_since_epoch().count());
-	writer.Key("duplicateFrameDetectionMode");
-	writer.Uint((uint32_t)data._duplicateFrameDetectionMode);
-	writer.Key("enableStatisticsForDynamicDetection");
-	writer.Bool(data._isStatisticsForDynamicDetectionEnabled);
-	writer.Key("minFrameRate");
-	writer.Double(data._minFrameRate);
-	writer.Key("disableFP16");
-	writer.Bool(data._isFP16Disabled);
-
-	ScalingModesService::Get().Export(writer);
-
-	writer.Key("profiles");
-	writer.StartArray();
-	WriteProfile(writer, data._defaultProfile);
-	for (const Profile& rule : data._profiles) {
-		WriteProfile(writer, rule);
-	}
-	writer.EndArray();
-
-	writer.Key("overlay");
-	writer.StartObject();
-	writer.Key("fullscreenInitialToolbarState");
-	writer.Uint((uint32_t)_fullscreenInitialToolbarState);
-	writer.Key("windowedInitialToolbarState");
-	writer.Uint((uint32_t)_windowedInitialToolbarState);
-	writer.Key("screenshotsDir");
-	writer.String(StrHelper::UTF16ToUTF8(_screenshotsDir.native()).c_str());
-	writer.Key("windows");
-	writer.StartObject();
-	for (const auto& [name, windowOption] : _overlayWindowOptions) {
-		writer.Key(name.c_str());
-		writer.StartObject();
-		writer.Key("hArea");
-		writer.Uint(windowOption.hArea);
-		writer.Key("vArea");
-		writer.Uint(windowOption.vArea);
-		writer.Key("hPos");
-		writer.Double(windowOption.hPos);
-		writer.Key("vPos");
-		writer.Double(windowOption.vPos);
-		writer.EndObject();
-	}
-	writer.EndObject();
-	writer.EndObject();
-
-	writer.EndObject();
-
-	// 防止并行写入
-	auto lock = _saveLock.lock_exclusive();
-	if (!Win32Helper::WriteTextFile(data._configPath.c_str(), { json.GetString(), json.GetLength() })) {
-		Logger::Get().Error("保存配置失败");
-		return false;
-	}
-
-	return true;
 }
 
 // 永远不会失败，遇到不合法的配置项时静默忽略

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -15,81 +15,14 @@ enum class AppTheme {
 	System
 };
 
-struct _AppSettingsData {
-	_AppSettingsData();
-	virtual ~_AppSettingsData();
-
-	std::array<Shortcut, (size_t)winrt::Magpie::ShortcutAction::COUNT_OR_NONE> _shortcuts;
-
-	std::vector<ScalingMode> _scalingModes;
-
-	Profile _defaultProfile;
-	std::vector<Profile> _profiles;
-
-	std::filesystem::path _configDir;
-	std::filesystem::path _configPath;
-
-	// LocalizationService::SupportedLanguages 索引
-	// -1 表示使用系统设置
-	int _language = -1;
-
-	// 保存窗口中心点和 DPI 无关的窗口尺寸
-	winrt::Point _mainWindowCenter{};
-	// 小于零表示默认位置和尺寸
-	winrt::Size _mainWindowSizeInDips{ -1.0f,-1.0f };
-	
-	AppTheme _theme = AppTheme::System;
-	// 必须在 1~5 之间
-	uint32_t _countdownSeconds = 3;
-
-	// 上一次自动检查更新的日期
-	std::chrono::system_clock::time_point _updateCheckDate;
-
-	DuplicateFrameDetectionMode _duplicateFrameDetectionMode =
-		DuplicateFrameDetectionMode::Dynamic;
-
-	float _minFrameRate = 10.0f;
-
-	ToolbarState _fullscreenInitialToolbarState = ToolbarState::AutoHide;
-	ToolbarState _windowedInitialToolbarState = ToolbarState::AutoHide;
-	// 为空表示 FOLDERID_Screenshots，支持绝对路径和相对路径
-	std::filesystem::path _screenshotsDir;
-
-	phmap::flat_hash_map<std::string, OverlayWindowOption> _overlayWindowOptions;
-	
-	bool _isPortableMode = false;
-	bool _isAlwaysRunAsAdmin = false;
-	bool _isDeveloperMode = false;
-	bool _isDebugMode = false;
-	bool _isBenchmarkMode = false;
-	bool _isTopmostDisabled = false;
-	bool _isEffectCacheDisabled = false;
-	bool _isFontCacheDisabled = false;
-	bool _isSaveEffectSources = false;
-	bool _isWarningsAreErrors = false;
-	bool _isAllowScalingMaximized = false;
-	bool _isSimulateExclusiveFullscreen = false;
-	bool _isInlineParams = false;
-	bool _isShowNotifyIcon = true;
-	bool _isMainWindowMaximized = false;
-	bool _isAutoCheckForUpdates = true;
-	bool _isCheckForPreviewUpdates = false;
-	bool _isStatisticsForDynamicDetectionEnabled = false;
-	bool _isFP16Disabled = false;
-};
-
-class AppSettings : private _AppSettingsData {
+class AppSettings {
 public:
-	static AppSettings& Get() noexcept {
-		static AppSettings instance;
-		return instance;
-	}
+	static AppSettings& Get() noexcept;
 
-	virtual ~AppSettings();
+	~AppSettings();
 
 	bool Initialize() noexcept;
-
-	bool Save() noexcept;
+	void Uninitialize() noexcept;
 
 	winrt::fire_and_forget SaveAsync() noexcept;
 
@@ -360,7 +293,6 @@ private:
 	AppSettings(AppSettings&&) = delete;
 
 	void _UpdateWindowPlacement() noexcept;
-	bool _Save(const _AppSettingsData& data) noexcept;
 
 	void _LoadSettings(const rapidjson::GenericObject<true, rapidjson::Value>& root) noexcept;
 	bool _LoadProfile(
@@ -373,8 +305,64 @@ private:
 
 	bool _UpdateConfigPath(std::filesystem::path* existingConfigPath = nullptr) noexcept;
 
-	// 用于同步保存
-	wil::srwlock _saveLock;
+	std::array<Shortcut, (size_t)winrt::Magpie::ShortcutAction::COUNT_OR_NONE> _shortcuts;
+
+	std::vector<ScalingMode> _scalingModes;
+
+	Profile _defaultProfile;
+	std::vector<Profile> _profiles;
+
+	std::filesystem::path _configDir;
+	std::filesystem::path _configPath;
+
+	// LocalizationService::SupportedLanguages 索引
+	// -1 表示使用系统设置
+	int _language = -1;
+
+	// 保存窗口中心点和 DPI 无关的窗口尺寸
+	winrt::Point _mainWindowCenter{};
+	// 小于零表示默认位置和尺寸
+	winrt::Size _mainWindowSizeInDips{ -1.0f,-1.0f };
+
+	AppTheme _theme = AppTheme::System;
+	// 必须在 1~5 之间
+	uint32_t _countdownSeconds = 3;
+
+	// 上一次自动检查更新的日期
+	std::chrono::system_clock::time_point _updateCheckDate;
+
+	::Magpie::DuplicateFrameDetectionMode _duplicateFrameDetectionMode =
+		DuplicateFrameDetectionMode::Dynamic;
+
+	float _minFrameRate = 10.0f;
+
+	ToolbarState _fullscreenInitialToolbarState = ToolbarState::AutoHide;
+	ToolbarState _windowedInitialToolbarState = ToolbarState::AutoHide;
+	// 为空表示 FOLDERID_Screenshots，支持绝对路径和相对路径
+	std::filesystem::path _screenshotsDir;
+
+	phmap::flat_hash_map<std::string, OverlayWindowOption> _overlayWindowOptions;
+
+	std::atomic<bool> _isSaving = false;
+	bool _isPortableMode = false;
+	bool _isAlwaysRunAsAdmin = false;
+	bool _isDeveloperMode = false;
+	bool _isDebugMode = false;
+	bool _isBenchmarkMode = false;
+	bool _isTopmostDisabled = false;
+	bool _isEffectCacheDisabled = false;
+	bool _isFontCacheDisabled = false;
+	bool _isSaveEffectSources = false;
+	bool _isWarningsAreErrors = false;
+	bool _isAllowScalingMaximized = false;
+	bool _isSimulateExclusiveFullscreen = false;
+	bool _isInlineParams = false;
+	bool _isShowNotifyIcon = true;
+	bool _isMainWindowMaximized = false;
+	bool _isAutoCheckForUpdates = true;
+	bool _isCheckForPreviewUpdates = false;
+	bool _isStatisticsForDynamicDetectionEnabled = false;
+	bool _isFP16Disabled = false;
 };
 
 }

--- a/src/Magpie/AppSettings.h
+++ b/src/Magpie/AppSettings.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <winrt/Magpie.h>
 #include "Event.h"
-#include "Shortcut.h"
 #include "Profile.h"
+#include "Shortcut.h"
 #include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <winrt/Magpie.h>
 
 namespace Magpie {
 
@@ -18,6 +19,9 @@ enum class AppTheme {
 class AppSettings {
 public:
 	static AppSettings& Get() noexcept;
+
+	AppSettings(const AppSettings&) = delete;
+	AppSettings(AppSettings&&) = delete;
 
 	~AppSettings();
 
@@ -289,10 +293,9 @@ public:
 private:
 	AppSettings() = default;
 
-	AppSettings(const AppSettings&) = delete;
-	AppSettings(AppSettings&&) = delete;
-
 	void _UpdateWindowPlacement() noexcept;
+
+	rapidjson::StringBuffer _WriteConfigJson() const noexcept;
 
 	void _LoadSettings(const rapidjson::GenericObject<true, rapidjson::Value>& root) noexcept;
 	bool _LoadProfile(

--- a/src/Magpie/EffectsService.cpp
+++ b/src/Magpie/EffectsService.cpp
@@ -100,7 +100,7 @@ fire_and_forget EffectsService::Initialize() {
 	_initialized.notify_one();
 }
 
-void EffectsService::Uninitialize() {
+void EffectsService::Uninitialize() noexcept {
 	// 等待解析完成，防止退出时崩溃
 	_WaitForInitialize();
 }

--- a/src/Magpie/EffectsService.h
+++ b/src/Magpie/EffectsService.h
@@ -35,7 +35,7 @@ public:
 
 	winrt::fire_and_forget Initialize();
 
-	void Uninitialize();
+	void Uninitialize() noexcept;
 
 	const std::vector<EffectInfo>& Effects() noexcept;
 

--- a/src/Magpie/MainWindow.cpp
+++ b/src/Magpie/MainWindow.cpp
@@ -317,7 +317,7 @@ LRESULT MainWindow::_MessageHandler(UINT msg, WPARAM wParam, LPARAM lParam) noex
 	}
 	case WM_DESTROY:
 	{
-		AppSettings::Get().Save();
+		AppSettings::Get().SaveAsync();
 		_appThemeChangedRevoker.Revoke();
 		// 标题栏窗口经常使用 Content()，确保在关闭 DWXS 前销毁
 		_hwndTitleBar.reset();

--- a/src/Magpie/ScalingService.cpp
+++ b/src/Magpie/ScalingService.cpp
@@ -51,7 +51,7 @@ void ScalingService::Initialize() {
 	_CheckForegroundTimer_Tick(nullptr, nullptr);
 }
 
-void ScalingService::Uninitialize() {
+void ScalingService::Uninitialize() noexcept {
 	if (!_scalingRuntime) {
 		return;
 	}

--- a/src/Magpie/ScalingService.h
+++ b/src/Magpie/ScalingService.h
@@ -21,7 +21,7 @@ public:
 
 	void Initialize();
 
-	void Uninitialize();
+	void Uninitialize() noexcept;
 
 	void StartTimer(bool windowedMode);
 

--- a/src/Magpie/ShortcutService.cpp
+++ b/src/Magpie/ShortcutService.cpp
@@ -54,7 +54,7 @@ void ShortcutService::Initialize() {
 	}
 }
 
-void ShortcutService::Uninitialize() {
+void ShortcutService::Uninitialize() noexcept {
 	if (!_hwndHotkey) {
 		return;
 	}

--- a/src/Magpie/ShortcutService.h
+++ b/src/Magpie/ShortcutService.h
@@ -16,7 +16,7 @@ public:
 
 	void Initialize();
 
-	void Uninitialize();
+	void Uninitialize() noexcept;
 
 	bool IsError(winrt::Magpie::ShortcutAction action) const noexcept {
 		return _shortcutInfos[(size_t)action].isError;


### PR DESCRIPTION
Close #1435

1. 避免写入失败导致配置丢失：现在会先写入中间文件 config.json.new，成功后再重命名
2. 退出前确保写入配置文件已经完成