### PR TITLE
fix: 窗口模式缩放支持 1.0x（不缩放）

### DIFF
--- a/src/Magpie.Core/ScalingWindow.cpp
+++ b/src/Magpie.Core/ScalingWindow.cpp
@@ -918,12 +918,14 @@ bool ScalingWindow::_CalcWindowedScalingWindowSize(int& width, int& height, bool
 	const RECT& srcRect = _srcTracker.SrcRect();
 	const float srcAspectRatio = float(srcRect.bottom - srcRect.top) / (srcRect.right - srcRect.left);
 
-	// 计算最小尺寸时使用源窗口包含窗口框架的矩形而不是被缩放区域
-	const RECT& srcFrameRect = _srcTracker.WindowFrameRect();
-	const int spaceAround = (int)lroundf(WINDOWED_MODE_MIN_SPACE_AROUND *
+	// 计算最小尺寸时使用源窗口包含窗口框架的矩形而不是被缩放区域。用户显式指定 1.0x 时
+	// 不应放大画面，此时只要求渲染窗口不小于被缩放区域，从而做到逐像素对应。
+	const bool noUpscaling = _options.initialWindowedScaleFactor == 1.0f;
+	const RECT& minSrcRect = noUpscaling ? srcRect : _srcTracker.WindowFrameRect();
+	const int spaceAround = noUpscaling ? 0 : (int)lroundf(WINDOWED_MODE_MIN_SPACE_AROUND *
 		dpi / float(USER_DEFAULT_SCREEN_DPI));
-	const int minRendererWidth = srcFrameRect.right - srcFrameRect.left + spaceAround;
-	const int minRendererHeight = srcFrameRect.bottom - srcFrameRect.top + spaceAround;
+	const int minRendererWidth = minSrcRect.right - minSrcRect.left + spaceAround;
+	const int minRendererHeight = minSrcRect.bottom - minSrcRect.top + spaceAround;
 
 	int xExtraSpace;
 	int yExtraSpace;

--- a/src/Magpie/ProfilePage.xaml
+++ b/src/Magpie/ProfilePage.xaml
@@ -259,7 +259,7 @@
 						                VerticalAlignment="Stretch"
 						                Loaded="NumberBox_Loaded"
 						                Maximum="10"
-						                Minimum="1.1"
+						                Minimum="1"
 						                NumberFormatter="{x:Bind local:App.DoubleFormatter, Mode=OneTime}"
 						                SmallChange="0.1"
 						                Value="{x:Bind ViewModel.CustomInitialWindowedScaleFactor, Mode=TwoWay}" />


### PR DESCRIPTION
## 问题

窗口模式缩放目前无法真正设为 1.0x（不缩放）。这个用法对同分辨率的效果链是有意义的：只想叠加滤镜（锐化、降噪一类不放大的效果），希望画面和源窗口逐像素对应、不引入任何重采样。

现在有两道限制，而且和配置层的下限不一致：

1. `ProfilePage.xaml` 中「初始缩放倍数 → 自定义」的 `NumberBox` `Minimum="1.1"`，UI 层就填不进 1。
2. 即使绕过 UI 直接改配置文件，`_CalcWindowedScalingWindowSize` 里的最小渲染尺寸是「源窗口包含窗口框架的矩形 + `WINDOWED_MODE_MIN_SPACE_AROUND`」，会把实际倍率顶到 1.05x 以上（源窗口带标题栏时更高），配置里的值被静默覆盖。
3. 但 `AppSettings::_LoadProfile` 读取配置时是把 `customInitialWindowedScaleFactor` clamp 到 **1.0** 的，也就是配置层本来就认为 1.0 合法。

三处的下限分别是 1.1 / 约 1.05+ / 1.0。

## 改动

- `ProfilePage.xaml`：`NumberBox` 的 `Minimum` 由 1.1 改为 1，和配置层的下限对齐。
- `ScalingWindow.cpp` / `_CalcWindowedScalingWindowSize`：仅当用户**显式**指定 1.0x 时，最小渲染尺寸改为以被缩放区域（`SrcRect`）为准，且不再额外留出 `WINDOWED_MODE_MIN_SPACE_AROUND`，从而使渲染窗口和源内容逐像素对应。

其他倍率（含「自动」）的行为完全不变，仍然按原有方式遮挡源窗口和它的阴影；`WINDOWED_MODE_MIN_SPACE_AROUND` 常量本身没有改动。`noUpscaling` 为 `false` 时这段代码与改动前等价。

`initialWindowedScaleFactor` 用小于 1.0 表示「自动」，`1.0f` 是一个未被占用的合法值，因此不会和现有语义冲突。

## 已知取舍

1.0x 下渲染窗口只和被缩放区域一样大，缩放窗口靠自身的标题栏和边框去遮挡源窗口。对使用标准窗口框架的源窗口这基本刚好覆盖；如果源窗口自绘非客户区且和标准框架尺寸差异较大，理论上可能露出边缘。这是选择「不缩放」时可以预期的结果，如果你觉得需要，也可以改成只放宽 `spaceAround` 而仍以窗口框架矩形为下限（代价是拿不到精确的 1:1）。

## 测试

- `Release` / `x64` / MSVC v145（VS 2026）编译通过，无警告。
- 在 1920x1080 窗口化游戏 + 同分辨率滤镜效果链上实际使用过 1.0x：渲染窗口与被缩放区域尺寸一致，画面没有重采样。
- 其他倍率和「自动」的表现与改动前一致。
